### PR TITLE
Fixing C++ crash exception: PFWORKBIN-261

### DIFF
--- a/targets/cpp-shared/cpp-shared.js
+++ b/targets/cpp-shared/cpp-shared.js
@@ -529,7 +529,7 @@ var getPropertyDeserializer = exports.getPropertyDeserializer = function(propert
 	}
 	
 	var val = "const Value::Member* "+property.name+"_member = obj.FindMember(\""+property.name+"\");\n";
-	val += "\tif ("+property.name+"_member != NULL) "+property.name+" = "+getter+";"
+	val += "\tif (" + property.name + "_member != NULL && !" + property.name + "_member->value.IsNull()) " + property.name + " = " + getter + ";"
 	
 	return val;
 }

--- a/targets/cpp-windows/UnittestRunner/BugfixTest.cpp
+++ b/targets/cpp-windows/UnittestRunner/BugfixTest.cpp
@@ -1,0 +1,74 @@
+#include <fstream>
+#include "CppUnitTest.h"
+#include "playfab/PlayFabAdminDataModels.h"
+
+using namespace Microsoft::VisualStudio::CppUnitTestFramework;
+using namespace std;
+using namespace rapidjson;
+using namespace PlayFab;
+using namespace PlayFab::AdminModels;
+
+#pragma comment(lib, "wldap32.lib")
+#pragma comment(lib, "ws2_32.lib")
+
+#if(_DEBUG)
+#pragma comment(lib, "libcurld.lib")
+#pragma comment(lib, "libeay32d.lib")
+#pragma comment(lib, "ssleay32d.lib")
+#pragma comment(lib, "zlibd.lib")
+#pragma comment(lib, "PlayFabAllAPId.lib")
+#else
+#pragma comment(lib, "libcurl.lib")
+#pragma comment(lib, "libeay32.lib")
+#pragma comment(lib, "ssleay32.lib")
+#pragma comment(lib, "zlib.lib")
+#pragma comment(lib, "PlayFabAllAPI.lib")
+#endif
+
+namespace UnittestRunner
+{
+	// These tests are not useful for SDK-Users
+	// Feel free to ignore or delete this file
+	// Specifically, they test specific internal workings in the SDK which have need of testing,
+	//   or are related to bugs that have been found and fixed.
+	TEST_CLASS(PlayFabInternalTests)
+	{
+	public:
+		TEST_CLASS_INITIALIZE(ClassInitialize)
+		{
+		}
+		TEST_CLASS_CLEANUP(ClassCleanup)
+		{
+		}
+
+		// BUGFIX: PFWORKBIN-293
+		TEST_METHOD(ReadUserDataObj)
+		{
+			UserDataRecord record;
+
+			{
+				// Test that the member fields exist, but are null, instead of the expected datatype
+				char* testinput = "{\"test\": {\"Value\": null, \"LastUpdated\": null, \"Permission\": null}}";
+				Document testDoc;
+				testDoc.Parse<0>(testinput);
+				Assert::IsTrue(testDoc.GetParseError() == NULL);
+				auto testvalue = testDoc.FindMember("test");
+				record.readFromValue(testvalue->value);
+				// Assert::IsFalse(record.readFromValue(testvalue->value)); // TODO: At some point I'd like this output to be useful
+			}
+
+			{
+				// Test that normal expected data parses correctly
+				char* testinput = "{\"test\": {\"Value\": \"asdf\", \"LastUpdated\": \"2015-08-11 12:00.00.00\", \"Permission\": \"Public\"}}";
+				Document testDoc;
+				testDoc.Parse<0>(testinput);
+				Assert::IsTrue(testDoc.GetParseError() == NULL);
+				auto testvalue = testDoc.FindMember("test");
+				record.readFromValue(testvalue->value);
+				// Assert::IsTrue(record.readFromValue(testvalue->value)); // TODO: At some point I'd like this output to be useful
+			}
+		}
+
+	private:
+	};
+}

--- a/targets/cpp-windows/UnittestRunner/PlayFabApiTest.cpp
+++ b/targets/cpp-windows/UnittestRunner/PlayFabApiTest.cpp
@@ -176,7 +176,7 @@ namespace UnittestRunner
 			clientApi.LoginWithEmailAddress(request, &LoginCallback, &LoginFailedCallback, NULL);
 			ClientApiWait();
 
-			Assert::IsTrue(testMessageReturn.compare("Login_Failed") == 0); // This call is supposed to return as an error
+			Assert::IsTrue(testMessageReturn.compare("Login_Failed - Password") == 0); // This call is supposed to return as an error
 		}
 		static void LoginCallback(LoginResult& result, void* userData)
 		{
@@ -185,8 +185,10 @@ namespace UnittestRunner
 		}
 		static void LoginFailedCallback(PlayFabError& error, void* userData)
 		{
-			testMessageReturn = "Login_Failed";
-			// TODO: error.ErrorMessage contains "password"
+			if (error.ErrorMessage.find("password") != std::string::npos)
+				testMessageReturn = "Login_Failed - Password";
+			else
+				testMessageReturn = "Login_Failed - " + error.ErrorMessage;
 		}
 
 		TEST_METHOD(LoginOrRegister)

--- a/targets/cpp-windows/UnittestRunner/UnittestRunner.vcxproj
+++ b/targets/cpp-windows/UnittestRunner/UnittestRunner.vcxproj
@@ -96,6 +96,7 @@
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="PlayFabApiTest.cpp" />
+    <ClCompile Include="BugfixTest.cpp" />
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">

--- a/targets/cpp-windows/UnittestRunner/UnittestRunner.vcxproj.filters
+++ b/targets/cpp-windows/UnittestRunner/UnittestRunner.vcxproj.filters
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup>
     <Filter Include="Source Files">
@@ -20,6 +20,9 @@
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="PlayFabApiTest.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="BugfixTest.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
   </ItemGroup>

--- a/targets/cpp-windows/source/source/core/PlayFabResultHandler.cpp
+++ b/targets/cpp-windows/source/source/core/PlayFabResultHandler.cpp
@@ -11,73 +11,84 @@ using namespace rapidjson;
 
 bool PlayFabRequestHandler::DecodeRequest(int httpStatus, HttpRequest* request, void* userData, PlayFabBaseModel& outResult, PlayFabError& outError)
 {
-    if (request->GetReponse().length() == 0)
-    {
-        // Got a null body
-        return false;
-    }
+	std::string response = request->GetReponse();
+	Document rawResult;
+	rawResult.Parse<0>(response.c_str());
 
-    Document rawResult;
-    rawResult.Parse<0>(request->GetReponse().c_str());
-    const Document& resultEnvelope = rawResult;
+	// Check for bad responses
+	if (response.length() == 0 // Null response
+		|| rawResult.GetParseError() != NULL) // Non-Json response
+	{
+		// If we get here, we failed to connect meaningfully to the server - Assume a timeout
+		outError.HttpCode = 408;
+		outError.ErrorCode = PlayFabErrorConnectionTimeout;
+		// For text returns, use the non-json response if possible, else default to no response
+		outError.ErrorName = outError.ErrorMessage = outError.HttpStatus = response.length() == 0 ? "Request Timeout or null response" : response;
+		return false;
+	}
 
-    const Value::Member* errorCodeJson = resultEnvelope.FindMember("errorCode");
-    if (errorCodeJson != NULL)
-    {
-        // THere was an error, BUMMER
-        if (!errorCodeJson->value.IsNumber())
-        {
-            // unexpected json formatting
-            return false;
-        }
-        // TODO: what happens when the error is not in the enum?
-        outError.ErrorCode = static_cast<PlayFabErrorCode>(errorCodeJson->value.GetInt());
+	// Check if the returned json indicates an error
+	const Value::Member* errorCodeJson = rawResult.FindMember("errorCode");
+	if (errorCodeJson != NULL)
+	{
+		// There was an error, BUMMER
+		if (!errorCodeJson->value.IsNumber())
+		{
+			// unexpected json formatting - If we get here, we failed to connect meaningfully to the server - Assume a timeout
+			outError.HttpCode = 408;
+			outError.ErrorCode = PlayFabErrorConnectionTimeout;
+			// For text returns, use the non-json response if possible, else default to no response
+			outError.ErrorName = outError.ErrorMessage = outError.HttpStatus = response.length() == 0 ? "Request Timeout or null response" : response;
+			return false;
+		}
+		// TODO: what happens when the error is not in the enum?
+		outError.ErrorCode = static_cast<PlayFabErrorCode>(errorCodeJson->value.GetInt());
 
-        const Value::Member* codeJson = resultEnvelope.FindMember("code");
-        if (codeJson != NULL && codeJson->value.IsNumber())
-            outError.HttpCode = codeJson->value.GetInt();
+		const Value::Member* codeJson = rawResult.FindMember("code");
+		if (codeJson != NULL && codeJson->value.IsNumber())
+			outError.HttpCode = codeJson->value.GetInt();
 
-        const Value::Member* statusJson = resultEnvelope.FindMember("status");
-        if (statusJson != NULL && statusJson->value.IsString())
-            outError.HttpStatus = statusJson->value.GetString();
+		const Value::Member* statusJson = rawResult.FindMember("status");
+		if (statusJson != NULL && statusJson->value.IsString())
+			outError.HttpStatus = statusJson->value.GetString();
 
-		const Value::Member* errorNameJson = resultEnvelope.FindMember("error");
-        if (errorNameJson != NULL && errorNameJson->value.IsString())
-            outError.ErrorName = errorNameJson->value.GetString();
-			
-        const Value::Member* errorMessageJson = resultEnvelope.FindMember("errorMessage");
-        if (errorMessageJson != NULL && errorMessageJson->value.IsString())
-            outError.ErrorMessage = errorMessageJson->value.GetString();
+		const Value::Member* errorNameJson = rawResult.FindMember("error");
+		if (errorNameJson != NULL && errorNameJson->value.IsString())
+			outError.ErrorName = errorNameJson->value.GetString();
 
-        const Value::Member* errorDetailsJson = resultEnvelope.FindMember("errorDetails");
-        if (errorDetailsJson != NULL && errorDetailsJson->value.IsObject())
-        {
-            const Value& errorDetailsObj = errorDetailsJson->value;
+		const Value::Member* errorMessageJson = rawResult.FindMember("errorMessage");
+		if (errorMessageJson != NULL && errorMessageJson->value.IsString())
+			outError.ErrorMessage = errorMessageJson->value.GetString();
 
-            for (Value::ConstMemberIterator itr = errorDetailsObj.MemberBegin(); itr != errorDetailsObj.MemberEnd(); ++itr)
-            {
-                if (itr->name.IsString() && itr->value.IsArray())
-                {
-                    const Value& errorList = itr->value;
-                    for (Value::ConstValueIterator erroListIter = errorList.Begin(); erroListIter != errorList.End(); ++erroListIter)
-                        outError.ErrorDetails.insert(std::pair<std::string, std::string>(itr->name.GetString(), erroListIter->GetString()));
-                }
-            }
-        }
-        // We encountered no errors parsing the error
-        return false;
-    }
+		const Value::Member* errorDetailsJson = rawResult.FindMember("errorDetails");
+		if (errorDetailsJson != NULL && errorDetailsJson->value.IsObject())
+		{
+			const Value& errorDetailsObj = errorDetailsJson->value;
 
-    const Value::Member* data = resultEnvelope.FindMember("data");
-    if (data == NULL || !data->value.IsObject())
-        return false;
+			for (Value::ConstMemberIterator itr = errorDetailsObj.MemberBegin(); itr != errorDetailsObj.MemberEnd(); ++itr)
+			{
+				if (itr->name.IsString() && itr->value.IsArray())
+				{
+					const Value& errorList = itr->value;
+					for (Value::ConstValueIterator erroListIter = errorList.Begin(); erroListIter != errorList.End(); ++erroListIter)
+						outError.ErrorDetails.insert(std::pair<std::string, std::string>(itr->name.GetString(), erroListIter->GetString()));
+				}
+			}
+		}
+		// We encountered no errors parsing the error
+		return false;
+	}
 
-    bool success = outResult.readFromValue(data->value);
-    if (!success)
-    {
-        // json decoding error
-        return false;
-    }
+	const Value::Member* data = rawResult.FindMember("data");
+	if (data == NULL || !data->value.IsObject())
+		return false;
 
-    return true;
+	bool success = outResult.readFromValue(data->value);
+	if (!success)
+	{
+		// json decoding error
+		return false;
+	}
+
+	return true;
 }


### PR DESCRIPTION
The C++ project was not safely checking all error possibilities, and one of those possibilities caused a crash.  This is now fixed.  As well, some error conditions didn't always set the error outputs, and so specific errors would be hidden.  All of this is fixed.