### PR TITLE
Fixing GMFB-327

### DIFF
--- a/targets/csharp-unity/PlayFabApiTest.cs
+++ b/targets/csharp-unity/PlayFabApiTest.cs
@@ -125,7 +125,7 @@ namespace PlayFab.UUnit
             UUnitAssert.NotNull(lastReceivedMessage);
         }
 
-        public void SharedErrorCallback(PlayFabError error)
+        private void SharedErrorCallback(PlayFabError error)
         {
             lastReceivedMessage = error.ErrorMessage;
         }
@@ -235,6 +235,9 @@ namespace PlayFab.UUnit
             timeUpdated = testCounterReturn.LastUpdated;
             UUnitAssert.Equals(testCounterValueExpected, testCounterValueActual);
             UUnitAssert.True(timeUpdated > timeInitial);
+
+            // UnityEngine.Debug.Log((DateTime.UtcNow - timeUpdated).TotalSeconds);
+            UUnitAssert.True(Math.Abs((DateTime.UtcNow - timeUpdated).TotalMinutes) < 5); // Make sure that this timestamp is recent - This must also account for the difference between local machine time and server time
         }
         private void GetUserDataCallback(GetUserDataResult result)
         {
@@ -399,5 +402,27 @@ namespace PlayFab.UUnit
             else
                 lastReceivedMessage = "Get Server Leaderboard, empty";
         }
+
+        [UUnitTest]
+        public void AccountInfo()
+        {
+			GetAccountInfoRequest request = new GetAccountInfoRequest();
+			request.PlayFabId = playFabId;
+            PlayFabClientAPI.GetAccountInfo(request, AcctInfoCallback, SharedErrorCallback);
+            WaitForApiCalls();
+
+            UUnitAssert.Equals("Enums tested", lastReceivedMessage);
+        }
+		private void AcctInfoCallback(GetAccountInfoResult result)
+		{
+            if (result.AccountInfo == null || result.AccountInfo.TitleInfo == null || result.AccountInfo.TitleInfo.Origination == null
+            || !Enum.IsDefined(typeof(UserOrigination), result.AccountInfo.TitleInfo.Origination.Value))
+			{
+                lastReceivedMessage = "Enums not properly tested";
+				return;
+			}
+
+            lastReceivedMessage = "Enums tested";
+		}
     }
 }

--- a/targets/csharp-unity/source/Internal/PlayFabHTTP.cs
+++ b/targets/csharp-unity/source/Internal/PlayFabHTTP.cs
@@ -154,7 +154,7 @@ namespace PlayFab.Internal
                 }
                 catch (Exception e)
                 {
-                    Debug.LogException(e, gameObject); // If it's an unexpected exception, we should log it noisily
+                    Debug.LogException(e); // If it's an unexpected exception, we should log it noisily
 
                     HttpStatusCode httpCode = response == null ? HttpStatusCode.ServiceUnavailable : response.StatusCode;
                     var error = GeneratePfError(httpCode, PlayFabErrorCode.ServiceUnavailable, e.ToString(), null);
@@ -214,7 +214,7 @@ namespace PlayFab.Internal
             }
             catch (Exception e)
             {
-                Debug.LogException(e, gameObject);
+                Debug.LogException(e);
 
                 HttpStatusCode httpCode = response == null ? HttpStatusCode.ServiceUnavailable : response.StatusCode;
                 var error = GeneratePfError(httpCode, PlayFabErrorCode.ServiceUnavailable, e.ToString(), null);
@@ -263,6 +263,8 @@ namespace PlayFab.Internal
             switch (code)
             {
                 //TODO: Handle more specific cases as needed.
+                case HttpStatusCode.OK:
+                    return string.Format("Success: {0}", code);
                 case HttpStatusCode.RequestTimeout:
                     return string.Format("Request Timeout: {0}", code);
                 case HttpStatusCode.BadRequest:
@@ -280,7 +282,7 @@ namespace PlayFab.Internal
                 HttpStatus = GetResonseCodeResult(httpCode),
                 Error = pfErrorCode,
                 ErrorMessage = errorMessage,
-                ErrorDetails = null // TODO PAUL: json convert these if possible
+                ErrorDetails = null
             };
         }
         #endregion

--- a/targets/csharp-unity/source/Internal/Testing/UtilTest.cs
+++ b/targets/csharp-unity/source/Internal/Testing/UtilTest.cs
@@ -1,21 +1,89 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Text.RegularExpressions;
+﻿using PlayFab.Json;
+using PlayFab.Json.Converters;
 using PlayFab.UUnit;
+using System;
+using System.Globalization;
 
 namespace PlayFab.Internal
 {
-    class uu_Util : UUnitTestCase
+    class GMFB_327 : UUnitTestCase
     {
-        [UUnitTest]
-        void TimeStampFormat()
+        private class ObjWithTimes
         {
-            string actualTimestamp = Util.timeStamp;
-            string expectedRegex = "[0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9] [0-9][0-9]:[0-9][0-9]\\.[0-9][0-9]\\.[0-9][0-9]";
-            var result = Regex.Match(actualTimestamp, expectedRegex);
-            UUnitAssert.True(result.Success, actualTimestamp);
+            public DateTime timestamp = DateTime.UtcNow;
+        }
+
+        private string[] examples = new string[]{
+            "2015-08-25T10:22:01.654321Z",
+            "2015-08-25T10:22:01.8642Z",
+            "2015-08-25T10:22:01.753Z",
+            "2015-08-25T10:22:01.71Z",
+            "2015-08-25T10:22:01Z",
+
+            "2015-08-25 10:22:01.654321",
+            "2015-08-25 10:22:01.8642",
+            "2015-08-25 10:22:01.753",
+            "2015-08-25 10:22:01.71",
+            "2015-08-25 10:22:01",
+
+            "2015-08-25 10:22.01.8642",
+            "2015-08-25 10:22.01.753",
+            "2015-08-25 10:22.01.71",
+            "2015-08-25 10:22.01",
+
+            Util.timeStamp,
+            Util.utcTimeStamp,
+            // The standard DateTime.ToString() uses slashes instead of dashes, and is currently unsupported
+        };
+
+        [UUnitTest]
+        void TimeStampHandlesAllFormats()
+        {
+            DateTime expectedTime, actualTime;
+            var formats = IsoDateTimeConverter._defaultDateTimeFormats;
+
+            for (int i = 0; i < examples.Length; i++)
+            {
+                string expectedFormat = i < formats.Length ? formats[i] : "default";
+                UUnitAssert.True(DateTime.TryParseExact(examples[i], formats, CultureInfo.CurrentCulture, DateTimeStyles.RoundtripKind, out actualTime), "Index: " + i + "/" + examples.Length + ", " + examples[i] + " with " + expectedFormat);
+            }
+
+            expectedTime = DateTime.Now;
+            for (int i = 0; i < formats.Length; i++)
+            {
+                string timeString = expectedTime.ToString(formats[i], CultureInfo.CurrentCulture);
+                UUnitAssert.True(DateTime.TryParseExact(timeString, formats, CultureInfo.CurrentCulture, DateTimeStyles.RoundtripKind, out actualTime), "Index: " + i + "/" + formats.Length + ", " + formats[i] + " with " + timeString);
+                UUnitAssert.True((actualTime - expectedTime).TotalSeconds < 1, "Expected: " + expectedTime + " vs actual:" + actualTime);
+            }
+        }
+
+        [UUnitTest]
+        void JsonTimeStampHandlesAllFormats()
+        {
+            string expectedJson, actualJson;
+            DateTime expectedTime;
+            ObjWithTimes actualObj = new ObjWithTimes();
+
+            for (int i = 0; i < examples.Length; i++)
+            {
+                // Define the time deserialization expectation
+                UUnitAssert.True(DateTime.TryParseExact(examples[i], IsoDateTimeConverter._defaultDateTimeFormats, CultureInfo.CurrentCulture, DateTimeStyles.RoundtripKind, out expectedTime), "Index: " + i + "/" + examples.Length + ", " + examples[i]);
+
+                // De-serialize the time using json
+                expectedJson = "{\"timestamp\":\"" + examples[i] + "\"}"; // We are provided a json string with every random time format
+                JsonConvert.PopulateObject(expectedJson, actualObj, Util.JsonSettings);
+                actualJson = JsonConvert.SerializeObject(actualObj, Util.JsonFormatting, Util.JsonSettings);
+
+                if (i == IsoDateTimeConverter.DEFAULT_UTC_OUTPUT_INDEX) // This is the only case where the json input will match the json output
+                    UUnitAssert.Equals(expectedJson, actualJson);
+
+                // Verify that the times match
+                double diff = (expectedTime - actualObj.timestamp).TotalSeconds; // We expect that we have parsed the time correctly according to expectations
+                UUnitAssert.True(diff < 1,
+                    "\nActual time: " + actualObj.timestamp + " vs expected time: " + expectedTime + ", diff: " + diff +
+                    "\nActual json: " + actualJson + " vs expected json: " + expectedJson
+                );
+            }
         }
     }
 }

--- a/targets/csharp-unity/source/Internal/Util.cs
+++ b/targets/csharp-unity/source/Internal/Util.cs
@@ -1,6 +1,6 @@
-using System;
 using PlayFab.Json;
 using PlayFab.Json.Converters;
+using System;
 
 namespace PlayFab.Internal
 {
@@ -8,20 +8,25 @@ namespace PlayFab.Internal
     {
         public static string timeStamp
         {
-            get { return DateTime.Now.ToString ("yyyy-MM-dd HH:mm.ss.ff"); }
+            get { return DateTime.Now.ToString(IsoDateTimeConverter._defaultDateTimeFormats[IsoDateTimeConverter.DEFAULT_LOCAL_OUTPUT_INDEX]); }
         }
 
-        public static string Format (string text, params object[] args)
+        public static string utcTimeStamp
         {
-            return args.Length > 0 ? string.Format (text, args) : text;
+            get { return DateTime.UtcNow.ToString(IsoDateTimeConverter._defaultDateTimeFormats[IsoDateTimeConverter.DEFAULT_UTC_OUTPUT_INDEX]); }
+        }
+
+        public static string Format(string text, params object[] args)
+        {
+            return args.Length > 0 ? string.Format(text, args) : text;
         }
 
         public static JsonSerializerSettings JsonSettings = new JsonSerializerSettings()
         {
             NullValueHandling = NullValueHandling.Ignore,
-            Converters = { new IsoDateTimeConverter() { DateTimeFormat = "yyyy'-'MM'-'dd'T'HH':'mm':'ss.FFF'Z'" } },
+            Converters = { new IsoDateTimeConverter() },
         };
-        
+
         public static Formatting JsonFormatting = Formatting.None;
 
     }

--- a/targets/csharp-unity/source/Internal/json/Converters/IsoDateTimeConverter.cs
+++ b/targets/csharp-unity/source/Internal/json/Converters/IsoDateTimeConverter.cs
@@ -5,128 +5,157 @@ using PlayFab.Json.Utilities;
 
 namespace PlayFab.Json.Converters
 {
-  /// <summary>
-  /// Converts a <see cref="DateTime"/> to and from the ISO 8601 date format (e.g. 2008-04-12T12:53Z).
-  /// </summary>
-  public class IsoDateTimeConverter : DateTimeConverterBase
-  {
-    private const string DefaultDateTimeFormat = "yyyy'-'MM'-'dd'T'HH':'mm':'ss.FFFFFFFK";
-
-    private DateTimeStyles _dateTimeStyles = DateTimeStyles.RoundtripKind;
-    private string _dateTimeFormat;
-    private CultureInfo _culture;
-
     /// <summary>
-    /// Gets or sets the date time styles used when converting a date to and from JSON.
+    /// Converts a <see cref="DateTime"/> to and from the ISO 8601 date format (e.g. 2008-04-12T12:53Z).
     /// </summary>
-    /// <value>The date time styles used when converting a date to and from JSON.</value>
-    public DateTimeStyles DateTimeStyles
+    public class IsoDateTimeConverter : DateTimeConverterBase
     {
-      get { return _dateTimeStyles; }
-      set { _dateTimeStyles = value; }
+        public static readonly string[] _defaultDateTimeFormats = new string[]{ // All possible input time formats
+
+            // These are the standard format with ISO 8601 UTC markers (T/Z)
+            "yyyy-MM-ddTHH:mm:ss.FFFFFFZ", // DEFAULT_UTC_OUTPUT_INDEX
+            "yyyy-MM-ddTHH:mm:ss.FFFFZ",
+            "yyyy-MM-ddTHH:mm:ss.FFFZ",
+            "yyyy-MM-ddTHH:mm:ss.FFZ",
+            "yyyy-MM-ddTHH:mm:ssZ",
+
+            // These are the standard format without ISO 8601 UTC markers (T/Z)
+            "yyyy-MM-dd HH:mm:ss.FFFFFF",
+            "yyyy-MM-dd HH:mm:ss.FFFF",
+            "yyyy-MM-dd HH:mm:ss.FFF",
+            "yyyy-MM-dd HH:mm:ss.FF", // DEFAULT_LOCAL_OUTPUT_INDEX
+            "yyyy-MM-dd HH:mm:ss",
+
+            // These are the result of an input bug, which we now have to support as long as the db has entries formatted like this
+            "yyyy-MM-dd HH:mm.ss.FFFF",
+            "yyyy-MM-dd HH:mm.ss.FFF",
+            "yyyy-MM-dd HH:mm.ss.FF",
+            "yyyy-MM-dd HH:mm.ss",
+        };
+        public const int DEFAULT_UTC_OUTPUT_INDEX = 0;
+        public const int DEFAULT_LOCAL_OUTPUT_INDEX = 8;
+
+        private DateTimeStyles _dateTimeStyles = DateTimeStyles.RoundtripKind;
+        private string _dateTimeFormat;
+        private CultureInfo _culture;
+
+        /// <summary>
+        /// Gets or sets the date time styles used when converting a date to and from JSON.
+        /// </summary>
+        /// <value>The date time styles used when converting a date to and from JSON.</value>
+        public DateTimeStyles DateTimeStyles
+        {
+            get { return _dateTimeStyles; }
+            set { _dateTimeStyles = value; }
+        }
+
+        /// <summary>
+        /// Gets or sets the date time format used when converting a date to and from JSON.
+        /// </summary>
+        /// <value>The date time format used when converting a date to and from JSON.</value>
+        public string DateTimeFormat
+        {
+            get { return _dateTimeFormat ?? string.Empty; }
+            set { _dateTimeFormat = StringUtils.NullEmptyString(value); }
+        }
+
+        /// <summary>
+        /// Gets or sets the culture used when converting a date to and from JSON.
+        /// </summary>
+        /// <value>The culture used when converting a date to and from JSON.</value>
+        public CultureInfo Culture
+        {
+            get { return _culture ?? CultureInfo.CurrentCulture; }
+            set { _culture = value; }
+        }
+
+        /// <summary>
+        /// Writes the JSON representation of the object.
+        /// </summary>
+        /// <param name="writer">The <see cref="JsonWriter"/> to write to.</param>
+        /// <param name="value">The value.</param>
+        /// <param name="serializer">The calling serializer.</param>
+        public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
+        {
+            string text;
+
+            if (value is DateTime)
+            {
+                DateTime dateTime = (DateTime)value;
+
+                if ((_dateTimeStyles & DateTimeStyles.AdjustToUniversal) == DateTimeStyles.AdjustToUniversal
+                  || (_dateTimeStyles & DateTimeStyles.AssumeUniversal) == DateTimeStyles.AssumeUniversal)
+                    dateTime = dateTime.ToUniversalTime();
+
+                text = dateTime.ToString(_dateTimeFormat ?? _defaultDateTimeFormats[DEFAULT_UTC_OUTPUT_INDEX], Culture);
+            }
+            else if (value is DateTimeOffset)
+            {
+                DateTimeOffset dateTimeOffset = (DateTimeOffset)value;
+                if ((_dateTimeStyles & DateTimeStyles.AdjustToUniversal) == DateTimeStyles.AdjustToUniversal
+                  || (_dateTimeStyles & DateTimeStyles.AssumeUniversal) == DateTimeStyles.AssumeUniversal)
+                    dateTimeOffset = dateTimeOffset.ToUniversalTime();
+
+                text = dateTimeOffset.ToString(_dateTimeFormat ?? _defaultDateTimeFormats[DEFAULT_UTC_OUTPUT_INDEX], Culture);
+            }
+            else
+            {
+                throw new Exception("Unexpected value when converting date. Expected DateTime or DateTimeOffset, got {0}.".FormatWith(CultureInfo.InvariantCulture, ReflectionUtils.GetObjectType(value)));
+            }
+
+            writer.WriteValue(text);
+        }
+
+        /// <summary>
+        /// Reads the JSON representation of the object.
+        /// </summary>
+        /// <param name="reader">The <see cref="JsonReader"/> to read from.</param>
+        /// <param name="objectType">Type of the object.</param>
+        /// <param name="existingValue">The existing value of object being read.</param>
+        /// <param name="serializer">The calling serializer.</param>
+        /// <returns>The object value.</returns>
+        public override object ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer)
+        {
+            bool nullable = ReflectionUtils.IsNullableType(objectType);
+            Type t = (nullable)
+              ? Nullable.GetUnderlyingType(objectType)
+              : objectType;
+
+            if (reader.TokenType == JsonToken.Null)
+            {
+                if (!ReflectionUtils.IsNullableType(objectType))
+                    throw new Exception("Cannot convert null value to {0}.".FormatWith(CultureInfo.InvariantCulture, objectType));
+
+                return null;
+            }
+
+            if (reader.TokenType != JsonToken.String)
+                throw new Exception("Unexpected token parsing date. Expected String, got {0}.".FormatWith(CultureInfo.InvariantCulture, reader.TokenType));
+
+            string dateText = reader.Value.ToString();
+
+            if (string.IsNullOrEmpty(dateText) && nullable)
+                return null;
+
+            // DateTimeOffset
+            if (t == typeof(DateTimeOffset))
+            {
+                DateTimeOffset outputTimeOffset;
+                if (!string.IsNullOrEmpty(_dateTimeFormat) && DateTimeOffset.TryParseExact(dateText, _dateTimeFormat, Culture, _dateTimeStyles, out outputTimeOffset))
+                    return outputTimeOffset;
+                else if (DateTimeOffset.TryParseExact(dateText, _defaultDateTimeFormats, Culture, _dateTimeStyles, out outputTimeOffset))
+                    return outputTimeOffset;
+                return DateTimeOffset.Parse(dateText, Culture, _dateTimeStyles);
+            }
+
+            // DateTime
+            DateTime outputTime;
+            if (!string.IsNullOrEmpty(_dateTimeFormat) && DateTime.TryParseExact(dateText, _dateTimeFormat, Culture, _dateTimeStyles, out outputTime))
+                return outputTime;
+            else if (DateTime.TryParseExact(dateText, _defaultDateTimeFormats, Culture, _dateTimeStyles, out outputTime))
+                return outputTime;
+            return DateTime.Parse(dateText, Culture, _dateTimeStyles);
+        }
     }
-
-    /// <summary>
-    /// Gets or sets the date time format used when converting a date to and from JSON.
-    /// </summary>
-    /// <value>The date time format used when converting a date to and from JSON.</value>
-    public string DateTimeFormat
-    {
-      get { return _dateTimeFormat ?? string.Empty; }
-      set { _dateTimeFormat = StringUtils.NullEmptyString(value); }
-    }
-
-    /// <summary>
-    /// Gets or sets the culture used when converting a date to and from JSON.
-    /// </summary>
-    /// <value>The culture used when converting a date to and from JSON.</value>
-    public CultureInfo Culture
-    {
-      get { return _culture ?? CultureInfo.CurrentCulture; }
-      set { _culture = value; }
-    }
-
-    /// <summary>
-    /// Writes the JSON representation of the object.
-    /// </summary>
-    /// <param name="writer">The <see cref="JsonWriter"/> to write to.</param>
-    /// <param name="value">The value.</param>
-    /// <param name="serializer">The calling serializer.</param>
-    public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
-    {
-      string text;
-
-      if (value is DateTime)
-      {
-        DateTime dateTime = (DateTime)value;
-
-        if ((_dateTimeStyles & DateTimeStyles.AdjustToUniversal) == DateTimeStyles.AdjustToUniversal
-          || (_dateTimeStyles & DateTimeStyles.AssumeUniversal) == DateTimeStyles.AssumeUniversal)
-          dateTime = dateTime.ToUniversalTime();
-
-        text = dateTime.ToString(_dateTimeFormat ?? DefaultDateTimeFormat, Culture);
-      }
-      else if (value is DateTimeOffset)
-      {
-        DateTimeOffset dateTimeOffset = (DateTimeOffset)value;
-        if ((_dateTimeStyles & DateTimeStyles.AdjustToUniversal) == DateTimeStyles.AdjustToUniversal
-          || (_dateTimeStyles & DateTimeStyles.AssumeUniversal) == DateTimeStyles.AssumeUniversal)
-          dateTimeOffset = dateTimeOffset.ToUniversalTime();
-
-        text = dateTimeOffset.ToString(_dateTimeFormat ?? DefaultDateTimeFormat, Culture);
-      }
-      else
-      {
-        throw new Exception("Unexpected value when converting date. Expected DateTime or DateTimeOffset, got {0}.".FormatWith(CultureInfo.InvariantCulture, ReflectionUtils.GetObjectType(value)));
-      }
-
-      writer.WriteValue(text);
-    }
-
-    /// <summary>
-    /// Reads the JSON representation of the object.
-    /// </summary>
-    /// <param name="reader">The <see cref="JsonReader"/> to read from.</param>
-    /// <param name="objectType">Type of the object.</param>
-    /// <param name="existingValue">The existing value of object being read.</param>
-    /// <param name="serializer">The calling serializer.</param>
-    /// <returns>The object value.</returns>
-    public override object ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer)
-    {
-      bool nullable = ReflectionUtils.IsNullableType(objectType);
-      Type t = (nullable)
-        ? Nullable.GetUnderlyingType(objectType)
-        : objectType;
-
-      if (reader.TokenType == JsonToken.Null)
-      {
-        if (!ReflectionUtils.IsNullableType(objectType))
-          throw new Exception("Cannot convert null value to {0}.".FormatWith(CultureInfo.InvariantCulture, objectType));
- 
-        return null;
-      }
-
-      if (reader.TokenType != JsonToken.String)
-        throw new Exception("Unexpected token parsing date. Expected String, got {0}.".FormatWith(CultureInfo.InvariantCulture, reader.TokenType));
-
-      string dateText = reader.Value.ToString();
-
-      if (string.IsNullOrEmpty(dateText) && nullable)
-        return null;
-
-      if (t == typeof(DateTimeOffset))
-      {
-        if (!string.IsNullOrEmpty(_dateTimeFormat))
-          return DateTimeOffset.ParseExact(dateText, _dateTimeFormat, Culture, _dateTimeStyles);
-        else
-          return DateTimeOffset.Parse(dateText, Culture, _dateTimeStyles);
-      }
-
-      if (!string.IsNullOrEmpty(_dateTimeFormat))
-        return DateTime.ParseExact(dateText, _dateTimeFormat, Culture, _dateTimeStyles);
-      else
-        return DateTime.Parse(dateText, Culture, _dateTimeStyles);
-    }
-  }
 }
 #endif


### PR DESCRIPTION
where the UnitySDK dies if the timestamp it receives is in an alternate format.

Making the timestamp format in util.cs more consistent.
Beefing up the unit-testing around timestamp formats.
Removing some gameObject references from logic that is running outside the unity thread.