### PR TITLE
Double checking the compression issue in C++.

### DIFF
--- a/SDKBuildScripts/cocos_example1build.bat
+++ b/SDKBuildScripts/cocos_example1build.bat
@@ -17,5 +17,8 @@ xcopy ..\..\..\SDKGenerator\targets\cpp-cocos2dx\ExampleFiles\main.cpp proj.win3
 xcopy ..\..\..\SDKGenerator\targets\cpp-cocos2dx\ExampleFiles\PlayFabSDKExample.vcxproj proj.win32\ /c /f /y
 xcopy ..\..\..\SDKGenerator\targets\cpp-cocos2dx\ExampleFiles\PlayFabSDKExample.vcxproj.filters proj.win32\ /c /f /y
 
+xcopy ..\..\..\SDKGenerator\targets\cpp-cocos2dx\ExampleFiles\Android.mk proj.android\jni\ /c /f /y
+xcopy ..\..\..\SDKGenerator\targets\cpp-cocos2dx\ExampleFiles\Application.mk proj.android\jni\ /c /f /y
+
 popd
 popd

--- a/targets/cpp-cocos2dx/ExampleFiles/Android.mk
+++ b/targets/cpp-cocos2dx/ExampleFiles/Android.mk
@@ -1,0 +1,48 @@
+LOCAL_PATH := $(call my-dir)
+
+include $(CLEAR_VARS)
+
+$(call import-add-path,$(LOCAL_PATH)/../../cocos2d)
+$(call import-add-path,$(LOCAL_PATH)/../../cocos2d/external)
+$(call import-add-path,$(LOCAL_PATH)/../../cocos2d/cocos)
+
+LOCAL_MODULE := cocos2dcpp_shared
+
+LOCAL_MODULE_FILENAME := libcocos2dcpp
+
+LOCAL_SRC_FILES := hellocpp/main.cpp \
+                   ../../Classes/AppDelegate.cpp \
+                   ../../Classes/HelloWorldScene.cpp \
+                   ../../Classes/core/PlayFabSettings.cpp \
+                   ../../Classes/HttpRequest.cpp \
+                   ../../Classes/HttpRequesterCURL.cpp \
+                   ../../Classes/PlayFabAdminAPI.cpp \
+                   ../../Classes/PlayFabAdminDataModels.cpp \
+                   ../../Classes/PlayFabApiTest.cpp \
+                   ../../Classes/PlayFabBaseModel.cpp \
+                   ../../Classes/PlayFabClientAPI.cpp \
+                   ../../Classes/PlayFabClientDataModels.cpp \
+                   ../../Classes/PlayFabMatchmakerAPI.cpp \
+                   ../../Classes/PlayFabMatchmakerDataModels.cpp \
+                   ../../Classes/PlayFabResultHandler.cpp \
+                   ../../Classes/PlayFabServerAPI.cpp \
+                   ../../Classes/PlayFabServerDataModels.cpp \
+                   ../../Classes/PlayFabVersion.cpp
+
+LOCAL_C_INCLUDES := $(LOCAL_PATH)/../../Classes
+
+# _COCOS_HEADER_ANDROID_BEGIN
+# _COCOS_HEADER_ANDROID_END
+
+
+LOCAL_STATIC_LIBRARIES := cocos2dx_static
+
+# _COCOS_LIB_ANDROID_BEGIN
+# _COCOS_LIB_ANDROID_END
+
+include $(BUILD_SHARED_LIBRARY)
+
+$(call import-module,.)
+
+# _COCOS_LIB_IMPORT_ANDROID_BEGIN
+# _COCOS_LIB_IMPORT_ANDROID_END

--- a/targets/cpp-cocos2dx/ExampleFiles/Application.mk
+++ b/targets/cpp-cocos2dx/ExampleFiles/Application.mk
@@ -1,0 +1,16 @@
+APP_STL := gnustl_static
+
+APP_CPPFLAGS := -frtti -DCC_ENABLE_CHIPMUNK_INTEGRATION=1 -std=c++11 -fsigned-char
+APP_LDFLAGS := -latomic
+
+# Pick your processor here
+APP_ABI := x86
+# APP_ABI := armeabi
+
+ifeq ($(NDK_DEBUG),1)
+  APP_CPPFLAGS += -DCOCOS2D_DEBUG=1
+  APP_OPTIM := debug
+else
+  APP_CPPFLAGS += -DNDEBUG
+  APP_OPTIM := release
+endif

--- a/targets/cpp-shared/source/source/curl/HttpRequesterCURL.cpp
+++ b/targets/cpp-shared/source/source/curl/HttpRequesterCURL.cpp
@@ -54,7 +54,7 @@ PlayFabErrorCode HttpRequesterCURL::AddRequest(HttpRequest* request, RequestComp
         std::string body = request->GetBody();
         char* buffer = NULL;
         size_t bodyLen = 0;
-        int compressionLevel = 0; //request->GetCompressionLevel(); Temporarily disabled due to problems
+        int compressionLevel = 0; //request->GetCompressionLevel(); Temporarily disabled due to mobile problems
         if (compressionLevel != 0)
         {
             unsigned long ret = 0;

--- a/targets/cpp-windows/source/source/curl/HttpRequesterCURL.cpp
+++ b/targets/cpp-windows/source/source/curl/HttpRequesterCURL.cpp
@@ -55,7 +55,7 @@ PlayFabErrorCode HttpRequesterCURL::AddRequest(HttpRequest* request, RequestComp
         std::string body = request->GetBody();
         char* buffer = NULL;
         size_t bodyLen = 0;
-        int compressionLevel = request->GetCompressionLevel();
+        int compressionLevel = 0; //request->GetCompressionLevel(); Temporarily disabled due to mobile problems
         if(compressionLevel != 0)
         {
             unsigned long ret = 0;
@@ -93,8 +93,8 @@ PlayFabErrorCode HttpRequesterCURL::AddRequest(HttpRequest* request, RequestComp
                 deflateEnd(&zStream);
 
                 bodyLen = tempString.length();
-                buffer = new char[bodyLen+1];
-                memcpy(buffer, tempString.c_str(), bodyLen);
+                buffer = new char[bodyLen + 1];
+                sprintf(buffer, "%s", tempString.c_str());
                 buffer[bodyLen] = 0;
 
                 headers = curl_slist_append(headers, "Content-Encoding: gzip");
@@ -104,8 +104,9 @@ PlayFabErrorCode HttpRequesterCURL::AddRequest(HttpRequest* request, RequestComp
         else if(body.length() > 0)
         {
             bodyLen = body.length();
-            buffer = new char[body.length()+1];
-            std::strncpy(buffer, body.c_str(), body.length());
+            buffer = new char[bodyLen + 1];
+            sprintf(buffer, "%s", body.c_str());
+            buffer[body.length()] = 0;
         }
 
 #if LOCALHOST_PROXY
@@ -185,7 +186,8 @@ void HttpRequesterCURL::FinalizeRequests()
             {
                 CurlRequest request = mHandles[i];
 
-                curl_easy_getinfo(request.handle, CURLINFO_RESPONSE_CODE, &httpResponseStatus);
+                CURLcode curlCode = curl_easy_getinfo(request.handle, CURLINFO_RESPONSE_CODE, &httpResponseStatus);
+                // TODO: utilize the curlCode
 
                 if(request.callback != NULL)
                 {


### PR DESCRIPTION
The compression-disable was set differently in (win/cocos) projects, which was part of the confusion.
It should be disabled everywhere now.
It doesn't fix the Cocos Android build (it was already disabled).
Earlier fixes from CocosSDK (memcpy and such) are now ported to WinSDK.
Definitely a huge future TODO to stop having two versions of HttpRequesterCURL in SDKGenerator - only 2 functional lines different from one another.