### PR TITLE
Fixing a minor issue with apis that were not hidden properly.

### DIFF
--- a/SDKBuildScripts/actionscript_build.bat
+++ b/SDKBuildScripts/actionscript_build.bat
@@ -1,3 +1,19 @@
+rem === Cleaning existing files from ActionScriptSDK ===
+pushd ../../sdks/ActionScriptSDK/PfApiTest/com/playfab
+pushd AdminModels
+del *.as >nul 2>&1
+popd
+pushd ClientModels
+del *.as >nul 2>&1
+popd
+pushd MatchmakerModels
+del *.as >nul 2>&1
+popd
+pushd ServerModels
+del *.as >nul 2>&1
+popd
+popd
+
 pushd ..
 rem === BUILDING ActionScriptSDK ===
 node generate.js ..\API_Specs actionscript=..\sdks\ActionScriptSDK\PfApiTest

--- a/SDKBuildScripts/actionscript_build.bat
+++ b/SDKBuildScripts/actionscript_build.bat
@@ -1,5 +1,5 @@
 rem === Cleaning existing files from ActionScriptSDK ===
-pushd ../../sdks/ActionScriptSDK/PfApiTest/com/playfab
+pushd ..\..\sdks\ActionScriptSDK\PfApiTest\com\playfab
 pushd AdminModels
 del *.as >nul 2>&1
 popd


### PR DESCRIPTION
Fixing an issue where ActionScript is submitting excessive files.
The Xbox apis aren't live yet, and they were pulled out of API-SPECs.  AS3 creates files for each request and result, and the old script didn't clean them up.
We can more rigorously handle api deletions with this adjustment.  (Deletions should only happen for apis that shouldn't be released yet, never published ones)