### PR TITLE
Revising the LeaderBoard tests to match the intended goal, and avoids…

### DIFF
--- a/targets/actionscript/source/PlayFabApiTests.as
+++ b/targets/actionscript/source/PlayFabApiTests.as
@@ -403,23 +403,22 @@ package
         /// </summary>
         private function LeaderBoard() : void
         {
-            var clientRequest:com.playfab.ClientModels.GetLeaderboardAroundCurrentUserRequest = new com.playfab.ClientModels.GetLeaderboardAroundCurrentUserRequest();
+            var clientRequest:com.playfab.ClientModels.GetLeaderboardRequest = new com.playfab.ClientModels.GetLeaderboardRequest();
             clientRequest.MaxResultsCount = 3;
             clientRequest.StatisticName = TEST_STAT_NAME;
-            PlayFabClientAPI.GetLeaderboardAroundCurrentUser(clientRequest, Wrap(GetClientLbCallback, "ClientLB"), Wrap(Shared_ApiCallFailure, "ClientLB_Fail"));
+            PlayFabClientAPI.GetLeaderboard(clientRequest, Wrap(GetClientLbCallback, "ClientLB"), Wrap(Shared_ApiCallFailure, "ClientLB_Fail"));
         }
-        private function GetClientLbCallback(result:com.playfab.ClientModels.GetLeaderboardAroundCurrentUserResult) : void
+        private function GetClientLbCallback(result:com.playfab.ClientModels.GetLeaderboardResult) : void
         {
             if (result.Leaderboard.length == 0)
                 ASyncAssert.Fail("Client leaderboard results not found");
 
-            var serverRequest:com.playfab.ServerModels.GetLeaderboardAroundUserRequest = new com.playfab.ServerModels.GetLeaderboardAroundUserRequest();
+            var serverRequest:com.playfab.ServerModels.GetLeaderboardRequest = new com.playfab.ServerModels.GetLeaderboardRequest();
             serverRequest.MaxResultsCount = 3;
             serverRequest.StatisticName = TEST_STAT_NAME;
-            serverRequest.PlayFabId = playFabId;
-            PlayFabServerAPI.GetLeaderboardAroundUser(serverRequest, Wrap(GetServerLbCallback, "ServerLB"), Wrap(Shared_ApiCallFailure, "ServerLB_Fail"));
+            PlayFabServerAPI.GetLeaderboard(serverRequest, Wrap(GetServerLbCallback, "ServerLB"), Wrap(Shared_ApiCallFailure, "ServerLB_Fail"));
         }
-        private function GetServerLbCallback(result:com.playfab.ServerModels.GetLeaderboardAroundUserResult) : void
+        private function GetServerLbCallback(result:com.playfab.ServerModels.GetLeaderboardResult) : void
         {
             if (result.Leaderboard.length == 0)
                 ASyncAssert.Fail("Server leaderboard results not found");


### PR DESCRIPTION
… unintended accidental outputs from the "AroundTarget" style LeaderBoard calls.