### PR TITLE
Fix a typo in IPlayFabEnvironment definition. 

### DIFF
--- a/targets/SdkTestingCloudScript/templates/CloudScript.d.ts.ejs
+++ b/targets/SdkTestingCloudScript/templates/CloudScript.d.ts.ejs
@@ -38,7 +38,7 @@ interface IPlayFabPlayerProfile {
 declare var script: IPlayFabEnvironment;
 interface IPlayFabEnvironment {
     revision: number;
-    titleId; string;
+    titleId: string;
 }
 
 /** Static object which allows access to PlayFab ServerAPI calls */


### PR DESCRIPTION
The typo causes IPlayFabEnvionment to have an extra property `string:any` and implicitly types the titleId property to any. This is instead of having titleId be OF type string.