### PR TITLE
A proposed change which creates an interface to type the handlers object.

### DIFF
--- a/targets/SdkTestingCloudScript/templates/CloudScript.d.ts.ejs
+++ b/targets/SdkTestingCloudScript/templates/CloudScript.d.ts.ejs
@@ -1,5 +1,9 @@
 /** Static object you add your CloudScript endpoints to */
-declare var handlers: any;
+declare var handlers: Handlers;
+interface IPlayFabHandlers {
+  [handlerId:string]: (args?:any, context?:IPlayFabContext) => any;
+}
+
 /** The playfab id for the user who called into CloudScript */
 declare var currentPlayerId: string;
 

--- a/targets/SdkTestingCloudScript/templates/CloudScript.d.ts.ejs
+++ b/targets/SdkTestingCloudScript/templates/CloudScript.d.ts.ejs
@@ -1,5 +1,5 @@
 /** Static object you add your CloudScript endpoints to */
-declare var handlers: Handlers;
+declare var handlers: IPlayFabHandlers;
 interface IPlayFabHandlers {
   [handlerId:string]: (args?:any, context?:IPlayFabContext) => any;
 }


### PR DESCRIPTION
The IPlayFabHandlers interface types handlers object to more closely match its intended function.(A mapping of functions)

This would cause a semi-breaking change in that attaching a handler using `handlers.MyHandler = function(args) {}` would cause a compiler error. Instead a developer would need to use the mapping notation `handlers["MyHandler"] = function(args) {}` or use [declaration merging](https://www.typescriptlang.org/docs/handbook/declaration-merging.html) to merge the new handlers declaration into the Handlers interface. 
```
interface Handlers {
   MyHandler(args:IMyHandlerRequest):void
}
handlers.MyHandler = function(args){ }
```