### PR TITLE
Improved exceptions in PlayFab SDK for Unity

### DIFF
--- a/targets/unity-v2/make.js
+++ b/targets/unity-v2/make.js
@@ -379,11 +379,11 @@ function getRequestActions(tabbing, apiCall, api) {
 
     if (api.name === "Client" && (apiCall.result === "LoginResult" || apiCall.request === "RegisterPlayFabUserRequest"))
         return tabbing + "request.TitleId = request.TitleId ?? PlayFabSettings.TitleId;\n"
-            + tabbing + "if (request.TitleId == null) throw new Exception(\"Must be have PlayFabSettings.TitleId set to call this method\");\n";
+            + tabbing + "if (request.TitleId == null) throw new TitleIdNotSetException();\n";
     if (api.name === "Client" && apiCall.auth === "SessionTicket")
-        return tabbing + "if (!IsClientLoggedIn()) throw new Exception(\"Must be logged in to call this method\");\n";
+        return tabbing + "if (!IsClientLoggedIn()) throw new ClientNotLoggedInException();\n";
     if (apiCall.auth === "SecretKey")
-        return tabbing + "if (PlayFabSettings.DeveloperSecretKey == null) throw new Exception(\"Must have PlayFabSettings.DeveloperSecretKey set to call this method\");\n";
+        return tabbing + "if (PlayFabSettings.DeveloperSecretKey == null) throw new DeveloperSecretKeyNotSetException();\n";
     return "";
 }
 

--- a/targets/unity-v2/source/Client/PlayFabClientExceptions.cs
+++ b/targets/unity-v2/source/Client/PlayFabClientExceptions.cs
@@ -1,0 +1,37 @@
+#if !DISABLE_PLAYFABCLIENT_API
+using System;
+using System.Runtime.Serialization;
+
+namespace PlayFab
+{
+    /// <summary>
+    /// Exception that occurs when call to PlayFabClientAPI is made and client is not logged in
+    /// </summary>
+    [Serializable]
+    public class ClientNotLoggedInException : PlayFabException
+    {
+        private const string ErrorText = "Must be logged in to call this method";
+
+        public ClientNotLoggedInException()
+            : base(ErrorText) { }
+
+        protected ClientNotLoggedInException(SerializationInfo info, StreamingContext context)
+            : base(info, context) { }
+    }
+
+    /// <summary>
+    /// Exception that occurs when call to PlayFabClientAPI is made and PlayFabSettings.TitleId is not set
+    /// </summary>
+    [Serializable]
+    public class TitleIdNotSetException : PlayFabSettingsException
+    {
+        private const string ErrorText = "Must have PlayFabSettings.TitleId set to call this method";
+
+        public TitleIdNotSetException()
+            : base(ErrorText) { }
+
+        protected TitleIdNotSetException(SerializationInfo info, StreamingContext context)
+            : base(info, context) { }
+    }
+}
+#endif

--- a/targets/unity-v2/source/Shared/Internal/PlayFabHttp/PlayFabHTTP.cs
+++ b/targets/unity-v2/source/Shared/Internal/PlayFabHttp/PlayFabHTTP.cs
@@ -93,7 +93,7 @@ namespace PlayFab.Internal
         public static void InitializeLogger(IPlayFabLogger setLogger = null)
         {
             if (_logger != null)
-                throw new Exception("Once initialized, the logger cannot be reset.");
+                throw new InvalidOperationException("Once initialized, the logger cannot be reset.");
             if (setLogger == null)
                 setLogger = new PlayFabLogger();
             _logger = setLogger;

--- a/targets/unity-v2/source/Shared/Public/PlayFabExceptions.cs
+++ b/targets/unity-v2/source/Shared/Public/PlayFabExceptions.cs
@@ -1,0 +1,51 @@
+using System;
+using System.Runtime.Serialization;
+
+namespace PlayFab
+{
+    /// <summary>
+    /// Base class for PlayFab exceptions
+    /// </summary>
+    [Serializable]
+    public class PlayFabException : Exception
+    {
+        public PlayFabException() { }
+
+        public PlayFabException(string message)
+            : base(message) { }
+
+        public PlayFabException(string message, Exception inner)
+            : base(message, inner) { }
+
+        protected PlayFabException(SerializationInfo info, StreamingContext context)
+            : base(info, context) { }
+    }
+
+    /// <summary>
+    /// Base class for PlayFab exceptions caused by incorrect settings
+    /// </summary>
+    [Serializable]
+    public class PlayFabSettingsException : PlayFabException
+    {
+        public PlayFabSettingsException(string message)
+            : base(message) { }
+
+        protected PlayFabSettingsException(SerializationInfo info, StreamingContext context)
+            : base(info, context) { }
+    }
+
+    /// <summary>
+    /// Exception that occurs when call to PlayFab APIs is made while PlayFabSettings.DeveloperSecretKey is not set
+    /// </summary>
+    [Serializable]
+    public class DeveloperSecretKeyNotSetException : PlayFabSettingsException
+    {
+        private const string ErrorText = "Must have PlayFabSettings.DeveloperSecretKey set to call this method";
+
+        public DeveloperSecretKeyNotSetException()
+            : base(ErrorText) { }
+
+        protected DeveloperSecretKeyNotSetException(SerializationInfo info, StreamingContext context)
+            : base(info, context) { }
+    }
+}

--- a/targets/unity-v2/source/Shared/Public/PlayFabExceptions.cs.meta
+++ b/targets/unity-v2/source/Shared/Public/PlayFabExceptions.cs.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: 623bffd82326ec642a1d98ab8700ed5f
+timeCreated: 1510261037
+licenseType: Pro
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
Most throwed exceptions are now derived from PlayFabException and can be explicitly caugth by type in client code.