### PR TITLE
added specialization support via an optional -- command line parameter in generate.ts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,4 +11,4 @@
 *.user
 *.dat
 *.tmp
-generate.js.map
+*.js.map

--- a/SDKGenerator.njsproj
+++ b/SDKGenerator.njsproj
@@ -989,6 +989,12 @@
     <None Include="targets\javascript\testingFiles\PlayFabApiTest.ts" />
   </ItemGroup>
   <ItemGroup>
+    <TypeScriptCompile Include="generate-plugins.ts">
+      <SubType>Code</SubType>
+    </TypeScriptCompile>
+    <TypeScriptCompile Include="generate-sdk.ts">
+      <SubType>Code</SubType>
+    </TypeScriptCompile>
     <TypeScriptCompile Include="generate.ts" />
     <TypeScriptCompile Include="node.d.ts" />
     <TypeScriptCompile Include="targets\js-node\source\Scripts\typings\PlayFab\PlayFab.d.ts" />

--- a/SDKGenerator.njsproj
+++ b/SDKGenerator.njsproj
@@ -989,12 +989,8 @@
     <None Include="targets\javascript\testingFiles\PlayFabApiTest.ts" />
   </ItemGroup>
   <ItemGroup>
-    <TypeScriptCompile Include="generate-plugins.ts">
-      <SubType>Code</SubType>
-    </TypeScriptCompile>
-    <TypeScriptCompile Include="generate-sdk.ts">
-      <SubType>Code</SubType>
-    </TypeScriptCompile>
+    <TypeScriptCompile Include="generate-plugins.ts" />
+    <TypeScriptCompile Include="generate-sdk.ts" />
     <TypeScriptCompile Include="generate.ts" />
     <TypeScriptCompile Include="node.d.ts" />
     <TypeScriptCompile Include="targets\js-node\source\Scripts\typings\PlayFab\PlayFab.d.ts" />

--- a/generate-plugins.js
+++ b/generate-plugins.js
@@ -1,0 +1,2 @@
+// This script includes only logic specific to generation of PlayFab plugins (used in Composite SDKs) 
+//# sourceMappingURL=generate-plugins.js.map

--- a/generate-plugins.ts
+++ b/generate-plugins.ts
@@ -1,0 +1,1 @@
+﻿// This script includes only logic specific to generation of PlayFab plugins (used in Composite SDKs)

--- a/generate-sdk.js
+++ b/generate-sdk.js
@@ -1,0 +1,2 @@
+// This script includes only logic specific to generation of whole PlayFab SDKs (classic process) 
+//# sourceMappingURL=generate-sdk.js.map

--- a/generate-sdk.ts
+++ b/generate-sdk.ts
@@ -1,0 +1,1 @@
+﻿// This script includes only logic specific to generation of whole PlayFab SDKs (classic process)

--- a/generate.js
+++ b/generate.js
@@ -19,6 +19,8 @@ var defaultApiSpecGitHubUrl = "https://raw.githubusercontent.com/PlayFab/API_Spe
 var defaultApiSpecPlayFabUrl = "https://www.playfabapi.com/apispec";
 var tocFilename = "TOC.json";
 var tocCacheKey = "TOC";
+var defaultSpecialization = "sdk";
+var specializationContent;
 /////////////////////////////////// The main build sequence for this program ///////////////////////////////////
 function parseAndLoadApis() {
     console.log("My args:" + process.argv.join(" "));
@@ -36,7 +38,7 @@ function reportErrorsAndExit(errorMessages) {
     if (errorMessages.length === 0)
         return; // No errors to report, so continue
     // Else, report all errors and exit the program
-    console.log("Synatax: node generate.js\n" +
+    console.log("Syntax: node generate.js\n" +
         "\t\t<targetName>=<targetOutputPath>\n" +
         "\t\t-(apiSpecPath|apiSpecGitUrl|apiSpecPfUrl)[ (<apiSpecPath>|<apiSpecGitUrl>|<apiSpecPfUrl>)]\n" +
         "\t\t[ -flags <flag>[ <flag> ...]]\n\n" +
@@ -57,7 +59,21 @@ function reportErrorsAndExit(errorMessages) {
 function parseCommandInputs(args, argsByName, errorMessages, targetOutputPathList) {
     // Parse the command line arguments into key-value-pairs
     extractArgs(args, argsByName, targetOutputPathList, errorMessages);
-    // Apply defaults 
+    // Apply defaults
+    var specialization = defaultSpecialization;
+    if (argsByName.specialization) {
+        specialization = argsByName.specialization;
+    }
+    var specializationFile = path.resolve("generate-" + specialization + ".ts");
+    try {
+        specializationContent = require(specializationFile);
+        if (!specializationContent) {
+            errorMessages.push("Could not load specialization (" + specializationFile + "). Make sure that file has a valid content.");
+        }
+    }
+    catch (err) {
+        errorMessages.push("Failed to load specialization (" + specializationFile + "). Make sure that file exists.");
+    }
     if (!argsByName.hasOwnProperty("apispecpath") && !argsByName.hasOwnProperty("apispecgiturl") && !argsByName.hasOwnProperty("apispecpfurl"))
         argsByName.apispecgiturl = ""; // If nothing is defined, default to GitHub
     // A source key set, with no value means use the default for that input format
@@ -90,9 +106,19 @@ function parseCommandInputs(args, argsByName, errorMessages, targetOutputPathLis
 function extractArgs(args, argsByName, targetOutputPathList, errorMessages) {
     var cmdArgs = args.slice(2, args.length); // remove "node.exe generate.js"
     var activeKey = null;
+    var specialization;
     for (var i = 0; i < cmdArgs.length; i++) {
         var lcArg = cmdArgs[i].toLowerCase();
-        if (cmdArgs[i].indexOf("-") === 0) {
+        if (cmdArgs[i].indexOf("--") === 0) {
+            if (specialization) {
+                errorMessages.push("Specialization is already specified: (" + specialization + ") but additional parameter encountered: (" + cmdArgs[i] + ")");
+            }
+            else {
+                specialization = lcArg.substring(2); // remove the "--", lowercase the value
+                argsByName["specialization"] = specialization;
+            }
+        }
+        else if (cmdArgs[i].indexOf("-") === 0) {
             activeKey = lcArg.substring(1); // remove the "-", lowercase the argsByName-key
             argsByName[activeKey] = "";
         }


### PR DESCRIPTION
Addition of PluginGenerator functionality in near future requires some minor refactoring of generate.ts. The idea is to keep all shared functionality between different generation processes in generate.ts and then also have "specializations" - scripts that will contain functions/overrides specified to a particular generation process. The default specialization will be "sdk" - i.e. the process we already have today.
Specialization files will be named using pattern "generate-<specialization>.ts". 
This PR introduces basic support of this. It has been tested to make sure that it doesn't break the current generate functionality.