### PR TITLE
Binding ScreenTimeTracker to ENABLE_PLAYFAB_BETA define

### DIFF
--- a/SDKGenerator.njsproj
+++ b/SDKGenerator.njsproj
@@ -111,6 +111,11 @@
     <OutputPath>bin\</OutputPath>
     <ScriptArguments>unity-v2=..\sdks\UnitySDK -apiSpecPath -buildIdentifier UnitySDK_manual</ScriptArguments>
   </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)' == 'UnityBeta' ">
+    <DebugSymbols>true</DebugSymbols>
+    <OutputPath>bin\</OutputPath>
+    <ScriptArguments>unity-v2=..\sdks\UnityBeta -apiSpecPath -buildIdentifier UnityBetaSDK_manual -flags beta</ScriptArguments>
+  </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)' == 'UnrealBlueprintSDK' ">
     <DebugSymbols>true</DebugSymbols>
     <OutputPath>bin\</OutputPath>

--- a/SDKGenerator.sln
+++ b/SDKGenerator.sln
@@ -24,6 +24,7 @@ Global
 		PostmanCollection|Any CPU = PostmanCollection|Any CPU
 		Python|Any CPU = Python|Any CPU
 		UnitySdk|Any CPU = UnitySdk|Any CPU
+		UnityBeta|Any CPU = UnityBeta|Any CPU
 		UnrealBlueprintSDK|Any CPU = UnrealBlueprintSDK|Any CPU
 		UnrealCppSdk|Any CPU = UnrealCppSdk|Any CPU
 		WindowsSDK|Any CPU = WindowsSDK|Any CPU
@@ -64,6 +65,8 @@ Global
 		{2BA807EF-310C-43B5-8D42-1ABCFFF39BE9}.Python|Any CPU.Build.0 = Python|Any CPU
 		{2BA807EF-310C-43B5-8D42-1ABCFFF39BE9}.UnitySdk|Any CPU.ActiveCfg = UnitySdk|Any CPU
 		{2BA807EF-310C-43B5-8D42-1ABCFFF39BE9}.UnitySdk|Any CPU.Build.0 = UnitySdk|Any CPU
+		{2BA807EF-310C-43B5-8D42-1ABCFFF39BE9}.UnityBeta|Any CPU.ActiveCfg = UnityBeta|Any CPU
+		{2BA807EF-310C-43B5-8D42-1ABCFFF39BE9}.UnityBeta|Any CPU.Build.0 = UnityBeta|Any CPU
 		{2BA807EF-310C-43B5-8D42-1ABCFFF39BE9}.UnrealBlueprintSDK|Any CPU.ActiveCfg = UnrealBlueprintSDK|Any CPU
 		{2BA807EF-310C-43B5-8D42-1ABCFFF39BE9}.UnrealBlueprintSDK|Any CPU.Build.0 = UnrealBlueprintSDK|Any CPU
 		{2BA807EF-310C-43B5-8D42-1ABCFFF39BE9}.UnrealCppSdk|Any CPU.ActiveCfg = UnrealCppSdk|Any CPU

--- a/targets/unity-v2/source/Client/PlayFabDeviceUtil.cs
+++ b/targets/unity-v2/source/Client/PlayFabDeviceUtil.cs
@@ -9,8 +9,7 @@ namespace PlayFab.Internal
 {
     public static class PlayFabDeviceUtil
     {
-        private static bool _needsAttribution;
-        private static bool _gatherInfo;
+        private static bool _needsAttribution, _gatherInfo, _gatherScreenTime;
 
         #region Make Attribution API call
         private static void DoAttributeInstall()
@@ -60,8 +59,7 @@ namespace PlayFab.Internal
             if (loginResult == null && registerResult == null)
                 return;
 
-            _needsAttribution = false;
-            _gatherInfo = false;
+            _needsAttribution = _gatherInfo = _gatherScreenTime = false;
             if (loginResult != null && loginResult.SettingsForUser != null)
                 _needsAttribution = loginResult.SettingsForUser.NeedsAttribution;
             else if (registerResult != null && registerResult.SettingsForUser != null)
@@ -70,6 +68,11 @@ namespace PlayFab.Internal
                 _gatherInfo = loginResult.SettingsForUser.GatherDeviceInfo;
             else if (registerResult != null && registerResult.SettingsForUser != null)
                 _gatherInfo = registerResult.SettingsForUser.GatherDeviceInfo;
+            // TODO: Uncomment when GatherFocusInfo field is released
+            //if (loginResult != null && loginResult.SettingsForUser != null)
+            //    _gatherInfo = loginResult.SettingsForUser.GatherFocusInfo;
+            //else if (registerResult != null && registerResult.SettingsForUser != null)
+            //    _gatherInfo = registerResult.SettingsForUser.GatherFocusInfo;
 
             // Device attribution (adid or idfa)
             if (PlayFabSettings.AdvertisingIdType != null && PlayFabSettings.AdvertisingIdValue != null)
@@ -80,10 +83,10 @@ namespace PlayFab.Internal
             // Device information gathering
             SendDeviceInfoToPlayFab();
 
-#if ENABLE_PLAYFABENTITY_API
+#if ENABLE_PLAYFABENTITY_API && ENABLE_PLAYFAB_BETA
             string playFabUserId = loginResult.PlayFabId;
             EntityModels.EntityKey entityKey = new EntityModels.EntityKey();
-            if (loginResult.EntityToken != null)
+            if (loginResult.EntityToken != null && _gatherInfo)
             {
                 entityKey.Id = loginResult.EntityToken.Entity.Id;
                 entityKey.Type = (PlayFab.EntityModels.EntityTypes)(int)loginResult.EntityToken.Entity.Type; // possible loss of data 
@@ -93,7 +96,7 @@ namespace PlayFab.Internal
             }
             else
             {
-                PlayFabHttp.shouldCollectScreenTime = false;
+                PlayFabSettings.DisableScreenTimeCollection = true;
             }
 #endif
         }

--- a/targets/unity-v2/source/Client/PlayFabSettings.cs
+++ b/targets/unity-v2/source/Client/PlayFabSettings.cs
@@ -11,6 +11,7 @@ namespace PlayFab
         public static string AdvertisingIdValue = null;
         public static bool DisableAdvertising = false;
         public static bool DisableDeviceInfo = false;
+        public static bool DisableScreenTimeCollection = false;
     }
 }
 #endif

--- a/targets/unity-v2/source/Entity/ScreenTimeTracker.cs
+++ b/targets/unity-v2/source/Entity/ScreenTimeTracker.cs
@@ -1,4 +1,4 @@
-﻿#if ENABLE_PLAYFABENTITY_API
+#if ENABLE_PLAYFABENTITY_API && ENABLE_PLAYFAB_BETA
 using System;
 using System.Collections.Generic;
 using PlayFab.EntityModels;

--- a/targets/unity-v2/source/Shared/Internal/PlayFabHttp/PlayFabHTTP.cs
+++ b/targets/unity-v2/source/Shared/Internal/PlayFabHttp/PlayFabHTTP.cs
@@ -28,8 +28,7 @@ namespace PlayFab.Internal
 #endif
 
         private static IPlayFabLogger _logger;
-#if ENABLE_PLAYFABENTITY_API
-        internal static bool shouldCollectScreenTime = true;
+#if ENABLE_PLAYFABENTITY_API && ENABLE_PLAYFAB_BETA
         private static IScreenTimeTracker screenTimeTracker = new ScreenTimeTracker();
         private const float delayBetweenBatches = 5.0f;
 #endif
@@ -111,7 +110,7 @@ namespace PlayFab.Internal
             _logger = setLogger;
         }
 
-#if ENABLE_PLAYFABENTITY_API
+#if ENABLE_PLAYFABENTITY_API && ENABLE_PLAYFAB_BETA
         /// <summary>
         /// This initializes ScreenTimeTracker object and notifying it to start sending info.
         /// </summary>
@@ -120,7 +119,6 @@ namespace PlayFab.Internal
         public static void InitializeScreenTimeTracker(EntityModels.EntityKey entityKey, string playFabUserId)
         {
             screenTimeTracker.ClientSessionStart(entityKey, playFabUserId);
-            shouldCollectScreenTime = true;
             instance.StartCoroutine(SendScreenTimeEvents(delayBetweenBatches));
         }
 
@@ -132,7 +130,7 @@ namespace PlayFab.Internal
         {
             WaitForSeconds delay = new WaitForSeconds(secondsBetweenBatches);
 
-            while (shouldCollectScreenTime)
+            while (PlayFabSettings.ShouldCollectScreenTime)
             {
                 screenTimeTracker.Send();
                 yield return delay;
@@ -290,8 +288,8 @@ namespace PlayFab.Internal
                 _logger.OnEnable();
             }
 
-#if ENABLE_PLAYFABENTITY_API
-            if ((screenTimeTracker != null) && (shouldCollectScreenTime != false))
+#if ENABLE_PLAYFABENTITY_API && ENABLE_PLAYFAB_BETA
+            if ((screenTimeTracker != null) && (PlayFabSettings.PlayFabSettings.ShouldCollectScreenTime != false))
             {
                 screenTimeTracker.OnEnable();
             }
@@ -308,8 +306,8 @@ namespace PlayFab.Internal
                 _logger.OnDisable();
             }
 
-#if ENABLE_PLAYFABENTITY_API
-            if ((screenTimeTracker != null) && (shouldCollectScreenTime != false))
+#if ENABLE_PLAYFABENTITY_API && ENABLE_PLAYFAB_BETA
+            if ((screenTimeTracker != null) && (PlayFabSettings.ShouldCollectScreenTime != false))
             {
                 screenTimeTracker.OnDisable();
             }
@@ -336,8 +334,8 @@ namespace PlayFab.Internal
                 _logger.OnDestroy();
             }
 
-#if ENABLE_PLAYFABENTITY_API
-            if ((screenTimeTracker != null) && (shouldCollectScreenTime != false))
+#if ENABLE_PLAYFABENTITY_API && ENABLE_PLAYFAB_BETA
+            if ((screenTimeTracker != null) && (PlayFabSettings.ShouldCollectScreenTime != false))
             {
                 screenTimeTracker.OnDestroy();
             }
@@ -349,8 +347,8 @@ namespace PlayFab.Internal
         /// </summary>
         public void OnApplicationFocus(bool isFocused)
         {
-#if ENABLE_PLAYFABENTITY_API
-            if ((screenTimeTracker != null) && (shouldCollectScreenTime != false))
+#if ENABLE_PLAYFABENTITY_API && ENABLE_PLAYFAB_BETA
+            if ((screenTimeTracker != null) && (PlayFabSettings.ShouldCollectScreenTime != false))
             {
                 screenTimeTracker.OnApplicationFocus(isFocused);
             }
@@ -362,8 +360,8 @@ namespace PlayFab.Internal
         /// </summary>
         public void OnApplicationQuit()
         {
-#if ENABLE_PLAYFABENTITY_API
-            if ((screenTimeTracker != null) && (shouldCollectScreenTime != false))
+#if ENABLE_PLAYFABENTITY_API && ENABLE_PLAYFAB_BETA
+            if ((screenTimeTracker != null) && (PlayFabSettings.ShouldCollectScreenTime != false))
             {
                 screenTimeTracker.OnApplicationQuit();
             }

--- a/targets/unity-v2/source/Shared/Internal/PlayFabHttp/PlayFabHTTP.cs
+++ b/targets/unity-v2/source/Shared/Internal/PlayFabHttp/PlayFabHTTP.cs
@@ -130,7 +130,7 @@ namespace PlayFab.Internal
         {
             WaitForSeconds delay = new WaitForSeconds(secondsBetweenBatches);
 
-            while (PlayFabSettings.ShouldCollectScreenTime)
+            while (!PlayFabSettings.DisableScreenTimeCollection)
             {
                 screenTimeTracker.Send();
                 yield return delay;
@@ -289,7 +289,7 @@ namespace PlayFab.Internal
             }
 
 #if ENABLE_PLAYFABENTITY_API && ENABLE_PLAYFAB_BETA
-            if ((screenTimeTracker != null) && (PlayFabSettings.PlayFabSettings.ShouldCollectScreenTime != false))
+            if ((screenTimeTracker != null) && (!PlayFabSettings.DisableScreenTimeCollection != false))
             {
                 screenTimeTracker.OnEnable();
             }
@@ -307,7 +307,7 @@ namespace PlayFab.Internal
             }
 
 #if ENABLE_PLAYFABENTITY_API && ENABLE_PLAYFAB_BETA
-            if ((screenTimeTracker != null) && (PlayFabSettings.ShouldCollectScreenTime != false))
+            if ((screenTimeTracker != null) && (!PlayFabSettings.DisableScreenTimeCollection != false))
             {
                 screenTimeTracker.OnDisable();
             }
@@ -335,7 +335,7 @@ namespace PlayFab.Internal
             }
 
 #if ENABLE_PLAYFABENTITY_API && ENABLE_PLAYFAB_BETA
-            if ((screenTimeTracker != null) && (PlayFabSettings.ShouldCollectScreenTime != false))
+            if ((screenTimeTracker != null) && (!PlayFabSettings.DisableScreenTimeCollection != false))
             {
                 screenTimeTracker.OnDestroy();
             }
@@ -348,7 +348,7 @@ namespace PlayFab.Internal
         public void OnApplicationFocus(bool isFocused)
         {
 #if ENABLE_PLAYFABENTITY_API && ENABLE_PLAYFAB_BETA
-            if ((screenTimeTracker != null) && (PlayFabSettings.ShouldCollectScreenTime != false))
+            if ((screenTimeTracker != null) && (!PlayFabSettings.DisableScreenTimeCollection != false))
             {
                 screenTimeTracker.OnApplicationFocus(isFocused);
             }
@@ -361,7 +361,7 @@ namespace PlayFab.Internal
         public void OnApplicationQuit()
         {
 #if ENABLE_PLAYFABENTITY_API && ENABLE_PLAYFAB_BETA
-            if ((screenTimeTracker != null) && (PlayFabSettings.ShouldCollectScreenTime != false))
+            if ((screenTimeTracker != null) && (!PlayFabSettings.DisableScreenTimeCollection != false))
             {
                 screenTimeTracker.OnApplicationQuit();
             }


### PR DESCRIPTION
This feature relies on beta-only API methods, which aren't released yet, and can only exist in UnityBetaSdk, should not be made active for non-beta.