### PR TITLE
targets/PythonSdk: fixed issues #5 and #6 for the PythonSdk

### DIFF
--- a/targets/PythonSdk/make.js
+++ b/targets/PythonSdk/make.js
@@ -207,17 +207,20 @@ function getRequestActions(tabbing, apiCall) {
 
 function getResultActions(tabbing, apiCall, api) {
     if (apiCall.result === "LoginResult")
-        return tabbing + "PlayFabSettings._internalSettings.ClientSessionTicket = playFabResult[\"SessionTicket\"] or PlayFabSettings._internalSettings.ClientSessionTicket\n"
-            + tabbing + "PlayFabSettings._internalSettings.EntityToken = playFabResult[\"EntityToken\"][\"EntityToken\"] or PlayFabSettings._internalSettings.EntityToken\n"
-            + tabbing + "MultiStepClientLogin(playFabResult[\"SettingsForUser\"])\n";
+        return tabbing + "if playFabResult:\n" 
+            + tabbing + "    PlayFabSettings._internalSettings.ClientSessionTicket = playFabResult[\"SessionTicket\"] if \"SessionTicket\" in playFabResult else PlayFabSettings._internalSettings.ClientSessionTicket\n"
+            + tabbing + "    PlayFabSettings._internalSettings.EntityToken = playFabResult[\"EntityToken\"][\"EntityToken\"] if \"EntityToken\" in playFabResult else PlayFabSettings._internalSettings.EntityToken\n"
+            + tabbing + "    MultiStepClientLogin(playFabResult.get(\"SettingsForUser\"))\n";
     else if (apiCall.result === "RegisterPlayFabUserResult")
-        return tabbing + "PlayFabSettings._internalSettings.ClientSessionTicket = playFabResult[\"SessionTicket\"] or PlayFabSettings._internalSettings.ClientSessionTicket\n"
-            + tabbing + "MultiStepClientLogin(playFabResult[\"SettingsForUser\"])\n";
+        return tabbing + "if playFabResult:\n" 
+            + tabbing + "    PlayFabSettings._internalSettings.ClientSessionTicket = playFabResult[\"SessionTicket\"] if \"SessionTicket\" in playFabResult else PlayFabSettings._internalSettings.ClientSessionTicket\n"
+            + tabbing + "    MultiStepClientLogin(playFabResult.get(\"SettingsForUser\"))\n";
     else if (api.name === "Client" && apiCall.result === "AttributeInstallResult")
         return tabbing + "# Modify AdvertisingIdType:  Prevents us from sending the id multiple times, and allows automated tests to determine id was sent successfully\n"
             + tabbing + "PlayFabSettings.AdvertisingIdType += \"_Successful\"\n";
     else if (apiCall.result === "GetEntityTokenResponse")
-        return tabbing + "PlayFabSettings._internalSettings.EntityToken = playFabResult[\"EntityToken\"] or PlayFabSettings._internalSettings.EntityToken\n";
+        return tabbing + "if playFabResult:\n"
+            + tabbing + "    PlayFabSettings._internalSettings.EntityToken = playFabResult[\"EntityToken\"] if \"EntityToken\" in playFabResult else PlayFabSettings._internalSettings.EntityToken\n";
     return "";
 }
 

--- a/targets/PythonSdk/templates/API.py.ejs
+++ b/targets/PythonSdk/templates/API.py.ejs
@@ -13,7 +13,7 @@ def MultiStepClientLogin(settingsForUser):
     adIdType = PlayFabSettings.AdvertisingIdType
     adIdVal = PlayFabSettings.AdvertisingIdValue
 
-    if settingsForUser["NeedsAttribution"] and not disabledAds and adIdType and adIdVal:
+    if settingsForUser and settingsForUser["NeedsAttribution"] and not disabledAds and adIdType and adIdVal:
         request = {}
         if adIdType == PlayFabSettings.AD_TYPE_IDFA:
             request["Idfa"] = adIdVal


### PR DESCRIPTION
This repairs issues #6 and #5 for the PythonSdk regarding LoginWithPlayFab calls.

- <a href="https://github.com/PlayFab/PythonSdk/issues/5">Issue #5 "TypeError on incorrect PlayFab login"<a/>
- <a href="https://github.com/PlayFab/PythonSdk/issues/6">Issue #5 "KeyError on PlayFab Login"<a/>