### PR TITLE
Updated Jenkins Scripts, and build utilities

### DIFF
--- a/JenkinsConsoleUtility/JenkinsScripts/gitInitNuke.sh
+++ b/JenkinsConsoleUtility/JenkinsScripts/gitInitNuke.sh
@@ -14,10 +14,10 @@ CheckDefault WORKSPACE C:/proj
 ResetRepo (){
     # Assumes the current directory is set to the repo to be reset
     SetGitHubCreds
-    git checkout master
-    git pull origin master
+    git checkout master2
+    git pull origin master2
 
-    if [ "$gitTarget"!="master" ]; then
+    if [ "$gitTarget"!="master2" ]; then
         git fetch --progress origin
         if [ "$PublishToGit"!="true" ]; then
             git branch -D $gitTarget || true

--- a/JenkinsConsoleUtility/JenkinsScripts/util.sh
+++ b/JenkinsConsoleUtility/JenkinsScripts/util.sh
@@ -76,10 +76,10 @@ CleanCurrentRepo () {
     git fetch --progress origin || CleanCurrentRepo hard 3 $retryCounter
     if [ -n "$1" ]; then
         git reset --hard || CleanCurrentRepo hard 3 $retryCounter
-        git checkout master || git checkout -b master || CleanCurrentRepo hard 3 $retryCounter
-        git reset --hard origin/master || CleanCurrentRepo hard 3 $retryCounter
+        git checkout master2 || git checkout -b master2 || CleanCurrentRepo hard 3 $retryCounter
+        git reset --hard origin/master2 || CleanCurrentRepo hard 3 $retryCounter
     else
-        git checkout master || git checkout -b master || CleanCurrentRepo hard 3 $retryCounter
+        git checkout master2 || git checkout -b master2 || CleanCurrentRepo hard 3 $retryCounter
         git pull --ff-only || CleanCurrentRepo hard 3 $retryCounter
     fi
     git remote prune origin

--- a/SDKBuildScripts/.gitignore
+++ b/SDKBuildScripts/.gitignore
@@ -1,1 +1,2 @@
 beta_*.bat
+var_*.bat

--- a/SDKBuildScripts/SdkTestingCloudScript_build.bat
+++ b/SDKBuildScripts/SdkTestingCloudScript_build.bat
@@ -2,8 +2,9 @@ setlocal
 set repoName=SdkTestingCloudScript
 set destPath=..\sdks\%repoName%
 pushd ..\%destPath%
-del /S *.js
-del /S *.ts
+rem Doesn't catch what we expect to catch, and is not needed for actual change
+rem del /S *.js
+rem del /S *.ts
 popd
 
 cd %~dp0

--- a/SDKBuildScripts/ue4_BP_build.bat
+++ b/SDKBuildScripts/ue4_BP_build.bat
@@ -10,7 +10,7 @@ cd %~dp0
 pushd ..
 if [%1] == [] (
 rem === BUILDING UnrealBlueprintSDK ===
-node generate.js cpp-unreal=%destPath% %*-flags nonnullable -apiSpecGitUrl
+node generate.js cpp-unreal=%destPath% -flags nonnullable -apiSpecGitUrl
 ) else (
 rem === BUILDING UnrealBlueprintSDK with params %* ===
 node generate.js cpp-unreal=%destPath% %*


### PR DESCRIPTION
Build scripts selectively delete files out of the target repo before running SdkGenerator, ensuring that some/most/all files that are no longer referenced should be deleted
Consolidate how the build scripts do the deletion (if they formerly did it), and set up a future shared utility
Temporarily switch Jenkins testing over to "master2" until we can get this Entity Api Delete done.