### PR TITLE
Add sdk info in get params in Postman

### DIFF
--- a/targets/postman/make.js
+++ b/targets/postman/make.js
@@ -50,7 +50,7 @@ function CallSorter(a, b) {
 }
 
 function GetUrl(apiCall) {
-    return "https://{{TitleId}}.playfabapi.com" + apiCall.url;
+    return "https://{{TitleId}}.playfabapi.com" + apiCall.url + "?sdk=PostmanCollection-" + exports.sdkVersion;
 }
 
 function GetPostmanHeader(apiCall) {


### PR DESCRIPTION
Postman doesn't have settings file like other SDKs so handling this a bit differently (same as how the headers are directly encoded)