### PR TITLE
Final Api Group Cleanup pass

### DIFF
--- a/SDKBuildScripts/NewTarget.bat
+++ b/SDKBuildScripts/NewTarget.bat
@@ -1,20 +1,8 @@
 setlocal
 set repoName=NewTarget
-set destPath=..\sdks\%repoName%
-pushd ..\%destPath%
-rem del /S *.notapplicable
-popd
+set targetSrc=newTarget
+set delSrc=false
+set flagsParams=
 
-cd %~dp0
-pushd ..
-if [%1] == [] (
-rem === BUILDING NewTarget ===
-node generate.js newTarget=%destPath% -apiSpecGitUrl
-) else (
-rem === BUILDING NewTarget with params %* ===
-node generate.js newTarget=%destPath% %*
-)
-popd
-
-pause
+call shared_build.bat
 endlocal

--- a/SDKBuildScripts/SdkTestingCloudScript_build.bat
+++ b/SDKBuildScripts/SdkTestingCloudScript_build.bat
@@ -1,22 +1,9 @@
 setlocal
 set repoName=SdkTestingCloudScript
-set destPath=..\sdks\%repoName%
-pushd ..\%destPath%
+set targetSrc=SdkTestingCloudScript
 rem Doesn't catch what we expect to catch, and is not needed for actual change
-rem del /S *.js
-rem del /S *.ts
-popd
+set delSrc=false
+set flagsParams=
 
-cd %~dp0
-pushd ..
-if [%1] == [] (
-rem === BUILDING NewTarget ===
-node generate.js SdkTestingCloudScript=%destPath% -apiSpecGitUrl
-) else (
-rem === BUILDING NewTarget with params %* ===
-node generate.js SdkTestingCloudScript=%destPath% %*
-)
-popd
-
-pause
+call shared_build.bat
 endlocal

--- a/SDKBuildScripts/XPlat_build.bat
+++ b/SDKBuildScripts/XPlat_build.bat
@@ -1,21 +1,8 @@
 setlocal
 set repoName=XPlatCppSdk
-set destPath=..\sdks\%repoName%
-pushd ..\%destPath%
-del /S *.h
-del /S *.cpp
-popd
+set targetSrc=xplatcppsdk
+set delSrc=true
+set flagsParams=
 
-cd %~dp0
-pushd ..
-if [%1] == [] (
-rem === BUILDING XPlatCppSdk ===
-node generate.js xplatcppsdk=%destPath% -apiSpecGitUrl
-) else (
-rem === BUILDING XPlatCppSdk with params %* ===
-node generate.js xplatcppsdk=%destPath% %*
-)
-popd
-
-pause
+call shared_build.bat
 endlocal

--- a/SDKBuildScripts/actionscript_build.bat
+++ b/SDKBuildScripts/actionscript_build.bat
@@ -1,20 +1,8 @@
 setlocal
 set repoName=ActionScriptSDK
-set destPath=..\sdks\%repoName%
-pushd ..\%destPath%
-del /S *.as
-popd
+set targetSrc=actionscript
+set delSrc=true
+set flagsParams=
 
-cd %~dp0
-pushd ..
-if [%1] == [] (
-rem === BUILDING ActionScriptSDK ===
-node generate.js actionscript=%destPath% -apiSpecGitUrl
-) else (
-rem === BUILDING ActionScriptSDK with params %* ===
-node generate.js actionscript=%destPath% %*
-)
-popd
-
-pause
+call shared_build.bat
 endlocal

--- a/SDKBuildScripts/cocos_build.bat
+++ b/SDKBuildScripts/cocos_build.bat
@@ -1,21 +1,8 @@
 setlocal
 set repoName=Cocos2d-xSDK
-set destPath=..\sdks\%repoName%
-pushd ..\%destPath%
-del /S *.h
-del /S *.cpp
-popd
+set targetSrc=cpp-cocos2dx
+set delSrc=true
+set flagsParams=
 
-cd %~dp0
-pushd ..
-if [%1] == [] (
-rem === BUILDING Cocos2d-xSDK ===
-node generate.js cpp-cocos2dx=%destPath% -apiSpecGitUrl
-) else (
-rem === BUILDING Cocos2d-xSDK with params %* ===
-node generate.js cpp-cocos2dx=%destPath% %*
-)
-popd
-
-pause
+call shared_build.bat
 endlocal

--- a/SDKBuildScripts/csharp_build.bat
+++ b/SDKBuildScripts/csharp_build.bat
@@ -1,20 +1,8 @@
 setlocal
 set repoName=CSharpSDK
-set destPath=..\sdks\%repoName%
-pushd ..\%destPath%
-del /S *.cs
-popd
+set targetSrc=csharp
+set delSrc=true
+set flagsParams=
 
-cd %~dp0
-pushd ..
-if [%1] == [] (
-rem === BUILDING CSharpSDK ===
-node generate.js csharp=%destPath% -apiSpecGitUrl
-) else (
-rem === BUILDING CSharpSDK with params %* ===
-node generate.js csharp=%destPath% %*
-)
-popd
-
-pause
+call shared_build.bat
 endlocal

--- a/SDKBuildScripts/java_build.bat
+++ b/SDKBuildScripts/java_build.bat
@@ -1,20 +1,8 @@
 setlocal
 set repoName=JavaSDK
-set destPath=..\sdks\%repoName%
-pushd ..\%destPath%
-del /S *.java
-popd
+set targetSrc=java
+set delSrc=true
+set flagsParams=
 
-cd %~dp0
-pushd ..
-if [%1] == [] (
-rem === BUILDING JavaSDK ===
-node generate.js java=%destPath% -apiSpecGitUrl
-) else (
-rem === BUILDING JavaSDK with params %* ===
-node generate.js java=%destPath% %*
-)
-popd
-
-pause
+call shared_build.bat
 endlocal

--- a/SDKBuildScripts/js_build.bat
+++ b/SDKBuildScripts/js_build.bat
@@ -1,21 +1,8 @@
 setlocal
 set repoName=JavaScriptSDK
-set destPath=..\sdks\%repoName%
-pushd ..\%destPath%
-del /S *.js
-del /S *.ts
-popd
+set targetSrc=javascript
+set delSrc=true
+set flagsParams=
 
-cd %~dp0
-pushd ..
-if [%1] == [] (
-rem === BUILDING JavascriptSDK ===
-node generate.js javascript=%destPath% -apiSpecGitUrl
-) else (
-rem === BUILDING JavascriptSDK with params %* ===
-node generate.js javascript=%destPath% %*
-)
-popd
-
-pause
+call shared_build.bat
 endlocal

--- a/SDKBuildScripts/lua_build.bat
+++ b/SDKBuildScripts/lua_build.bat
@@ -1,20 +1,8 @@
 setlocal
 set repoName=LuaSdk
-set destPath=..\sdks\%repoName%
-pushd ..\%destPath%
-del /S *.lua
-popd
+set targetSrc=LuaSdk
+set delSrc=true
+set flagsParams=
 
-cd %~dp0
-pushd ..
-if [%1] == [] (
-rem === BUILDING LuaSdk ===
-node generate.js LuaSdk=%destPath% -apiSpecGitUrl
-) else (
-rem === BUILDING LuaSdk with params %* ===
-node generate.js LuaSdk=%destPath% %*
-)
-popd
-
-pause
+call shared_build.bat
 endlocal

--- a/SDKBuildScripts/node_build.bat
+++ b/SDKBuildScripts/node_build.bat
@@ -1,21 +1,8 @@
 setlocal
 set repoName=NodeSDK
-set destPath=..\sdks\%repoName%
-pushd ..\%destPath%
-del /S *.js
-del /S *.ts
-popd
+set targetSrc=js-node
+set delSrc=true
+set flagsParams=
 
-cd %~dp0
-pushd ..
-if [%1] == [] (
-rem === BUILDING NodeSDK ===
-node generate.js js-node=%destPath% -apiSpecGitUrl
-) else (
-rem === BUILDING NodeSDK with params %* ===
-node generate.js js-node=%destPath% %*
-)
-popd
-
-pause
+call shared_build.bat
 endlocal

--- a/SDKBuildScripts/objc_build.bat
+++ b/SDKBuildScripts/objc_build.bat
@@ -1,21 +1,8 @@
 setlocal
 set repoName=Objective_C_SDK
-set destPath=..\sdks\%repoName%
-pushd ..\%destPath%
-del /S *.h
-del /S *.m
-popd
+set targetSrc=objc
+set delSrc=true
+set flagsParams=
 
-cd %~dp0
-pushd ..
-if [%1] == [] (
-rem === BUILDING Objective_C_SDK ===
-node generate.js objc=%destPath% -apiSpecGitUrl
-) else (
-rem === BUILDING Objective_C_SDK with params %* ===
-node generate.js objc=%destPath% %*
-)
-popd
-
-pause
+call shared_build.bat
 endlocal

--- a/SDKBuildScripts/php_build.bat
+++ b/SDKBuildScripts/php_build.bat
@@ -1,20 +1,8 @@
 setlocal
 set repoName=PhpSdk
-set destPath=..\sdks\%repoName%
-pushd ..\%destPath%
-del /S *.php
-popd
+set targetSrc=PhpSdk
+set delSrc=true
+set flagsParams=
 
-cd %~dp0
-pushd ..
-if [%1] == [] (
-rem === BUILDING PhpSdk ===
-node generate.js PhpSdk=%destPath% -apiSpecGitUrl
-) else (
-rem === BUILDING PhpSdk with params %* ===
-node generate.js PhpSdk=%destPath% %*
-)
-popd
-
-pause
+call shared_build.bat
 endlocal

--- a/SDKBuildScripts/postman_build.bat
+++ b/SDKBuildScripts/postman_build.bat
@@ -1,20 +1,8 @@
 setlocal
 set repoName=PostmanCollection
-set destPath=..\sdks\%repoName%
-pushd ..\%destPath%
-rem del /S *.notapplicable
-popd
+set targetSrc=postman
+set delSrc=false
+set flagsParams=
 
-cd %~dp0
-pushd ..
-if [%1] == [] (
-rem === BUILDING PostmanCollection ===
-node generate.js postman=%destPath% -apiSpecGitUrl
-) else (
-rem === BUILDING PostmanCollection with params %* ===
-node generate.js postman=%destPath% %*
-)
-popd
-
-pause
+call shared_build.bat
 endlocal

--- a/SDKBuildScripts/python_build.bat
+++ b/SDKBuildScripts/python_build.bat
@@ -1,20 +1,8 @@
 setlocal
 set repoName=PythonSDK
-set destPath=..\sdks\%repoName%
-pushd ..\%destPath%
-del /S *.py
-popd
+set targetSrc=PythonSdk
+set delSrc=true
+set flagsParams=
 
-cd %~dp0
-pushd ..
-if [%1] == [] (
-rem === BUILDING PythonSDK ===
-node generate.js pythonsdk=%destPath% -apiSpecGitUrl
-) else (
-rem === BUILDING PythonSDK with params %* ===
-node generate.js pythonsdk=%destPath% %*
-)
-popd
-
-pause
+call shared_build.bat
 endlocal

--- a/SDKBuildScripts/shared_build.bat
+++ b/SDKBuildScripts/shared_build.bat
@@ -1,0 +1,35 @@
+set destPath=..\sdks\%repoName%
+pushd ..\%destPath%
+if [%delSrc%] == [true] (
+    del /S *.as
+    del /S *.cpp
+    del /S *.cs
+    del /S *.h
+    del /S *.java
+    del /S *.js
+    del /S *.lua
+    del /S *.m
+    del /S *.php
+    del /S *.py
+    del /S *.ts
+    attrib -H *.meta /S /D
+)
+popd
+
+
+if [%specSrc%] == [] (
+    set specSrc=-apiSpecGitUrl
+)
+
+cd %~dp0
+pushd ..
+if [%1] == [] (
+    rem === BUILDING %repoName% ===
+    node generate.js %targetSrc%=%destPath% %flagsParams% %specSrc%
+) else (
+    rem === BUILDING %repoName% with params %* ===
+    node generate.js %targetSrc%=%destPath% %*
+)
+popd
+
+pause

--- a/SDKBuildScripts/ue4_BP_build.bat
+++ b/SDKBuildScripts/ue4_BP_build.bat
@@ -1,21 +1,8 @@
 setlocal
 set repoName=UnrealBlueprintSDK
-set destPath=..\sdks\%repoName%
-pushd ..\%destPath%
-del /S *.h
-del /S *.cpp
-popd
+set targetSrc=cpp-unreal
+set delSrc=true
+set flagsParams=-flags nonnullable
 
-cd %~dp0
-pushd ..
-if [%1] == [] (
-rem === BUILDING UnrealBlueprintSDK ===
-node generate.js cpp-unreal=%destPath% -flags nonnullable -apiSpecGitUrl
-) else (
-rem === BUILDING UnrealBlueprintSDK with params %* ===
-node generate.js cpp-unreal=%destPath% %*
-)
-popd
-
-pause
+call shared_build.bat
 endlocal

--- a/SDKBuildScripts/ue4_CPP_build.bat
+++ b/SDKBuildScripts/ue4_CPP_build.bat
@@ -1,21 +1,8 @@
 setlocal
 set repoName=UnrealCppSdk
-set destPath=..\sdks\%repoName%
-pushd ..\%destPath%
-del /S *.h
-del /S *.cpp
-popd
+set targetSrc=cpp-ue4
+set delSrc=true
+set flagsParams=-flags nonnullable
 
-cd %~dp0
-pushd ..
-if [%1] == [] (
-rem === BUILDING UnrealCppSdk ===
-node generate.js cpp-ue4=%destPath% -apiSpecGitUrl -flags nonnullable
-) else (
-rem === BUILDING UnrealCppSdk with params %* ===
-node generate.js cpp-ue4=%destPath% %*
-)
-popd
-
-pause
+call shared_build.bat
 endlocal

--- a/SDKBuildScripts/unity_SetupTestProjects.sh
+++ b/SDKBuildScripts/unity_SetupTestProjects.sh
@@ -99,13 +99,13 @@ MainScript () {
     rm -f *.txt || true
     DoWorkEditor "${SdkName}_BUP"
     if [ $? -ne 0 ]; then return 1; fi
-    DoWorkTesting "${SdkName}_TA" "ENABLE_PLAYFABADMIN_API;DISABLE_PLAYFABCLIENT_API;ENABLE_PLAYFABENTITY_API"
+    DoWorkTesting "${SdkName}_TA" "ENABLE_PLAYFABADMIN_API;DISABLE_PLAYFABCLIENT_API"
     if [ $? -ne 0 ]; then return 1; fi
-    DoWorkTesting "${SdkName}_TC" "ENABLE_PLAYFABENTITY_API"
+    DoWorkTesting "${SdkName}_TC" ""
     if [ $? -ne 0 ]; then return 1; fi
-    DoWorkTesting "${SdkName}_TS" "ENABLE_PLAYFABSERVER_API;DISABLE_PLAYFABCLIENT_API;ENABLE_PLAYFABENTITY_API"
+    DoWorkTesting "${SdkName}_TS" "ENABLE_PLAYFABSERVER_API;DISABLE_PLAYFABCLIENT_API"
     if [ $? -ne 0 ]; then return 1; fi
-    DoWorkTesting "${SdkName}_TZ" "ENABLE_PLAYFABADMIN_API;ENABLE_PLAYFABSERVER_API;ENABLE_PLAYFABMATCHMAKER_API;ENABLE_PLAYFABENTITY_API"
+    DoWorkTesting "${SdkName}_TZ" "ENABLE_PLAYFABADMIN_API;ENABLE_PLAYFABSERVER_API"
     if [ $? -ne 0 ]; then return 1; fi
 }
 

--- a/SDKBuildScripts/unity_build.bat
+++ b/SDKBuildScripts/unity_build.bat
@@ -1,21 +1,8 @@
 setlocal
 set repoName=UnitySDK
-set destPath=..\sdks\%repoName%
-pushd ..\%destPath%
-del /S *.cs
-attrib -H *.meta /S /D
-popd
+set targetSrc=unity-v2
+set delSrc=true
+set flagsParams=
 
-cd %~dp0
-pushd ..
-if [%1] == [] (
-rem === BUILDING UnitySDK ===
-node generate.js unity-v2=%destPath% -apiSpecGitUrl
-) else (
-rem === BUILDING UnitySDK with params %* ===
-node generate.js unity-v2=%destPath% %*
-)
-popd
-
-pause
+call shared_build.bat
 endlocal

--- a/SDKBuildScripts/unity_gameserver.bat
+++ b/SDKBuildScripts/unity_gameserver.bat
@@ -1,21 +1,8 @@
 setlocal
 set repoName=PlayFabGameServer
-set destPath=..\sdks\%repoName%
-pushd ..\%destPath%
-del /S *entity*.cs
-attrib -H *.meta /S /D
-popd
+set targetSrc=csharp-unity-gameserver
+set delSrc=true
+set flagsParams=
 
-cd %~dp0
-pushd ..
-if [%1] == [] (
-rem === BUILDING Unity PlayFabGameServer ===
-node generate.js csharp-unity-gameserver=%destPath% -apiSpecGitUrl
-) else (
-rem === BUILDING Unity PlayFabGameServer with params %* ===
-node generate.js csharp-unity-gameserver=%destPath% %*
-)
-popd
-
-pause
+call shared_build.bat
 endlocal

--- a/SDKBuildScripts/winV1_build.bat
+++ b/SDKBuildScripts/winV1_build.bat
@@ -1,21 +1,8 @@
 setlocal
 set repoName=WindowsSDK
-set destPath=..\sdks\%repoName%
-pushd ..\%destPath%
-del /S *.h
-del /S *.cpp
-popd
+set targetSrc=windowssdk
+set delSrc=true
+set flagsParams=
 
-cd %~dp0
-pushd ..
-if [%1] == [] (
-rem === BUILDING WindowsSDK ===
-node generate.js windowssdk=%destPath% -apiSpecGitUrl
-) else (
-rem === BUILDING WindowsSDK with params %* ===
-node generate.js windowssdk=%destPath% %*
-)
-popd
-
-pause
+call shared_build.bat
 endlocal

--- a/SDKGenerator.njsproj
+++ b/SDKGenerator.njsproj
@@ -422,7 +422,7 @@
     <Content Include="targets\LuaSdk\GlobalFiles\_Build\CoronaPluginBuilders\combo\bin\README.markdown" />
     <Content Include="targets\LuaSdk\GlobalFiles\_Build\CoronaPluginBuilders\combo\create_project.bat" />
     <Content Include="targets\LuaSdk\GlobalFiles\_Build\CoronaPluginBuilders\combo\create_project.sh" />
-    <Content Include="targets\LuaSdk\GlobalFiles\_Build\CoronaPluginBuilders\combo\lua\plugin\playfab\combo.lua" />
+    <Content Include="targets\LuaSdk\GlobalFiles\_Build\CoronaPluginBuilders\combo\lua\plugin\playfab\combo.lua.ejs" />
     <Content Include="targets\LuaSdk\GlobalFiles\_Build\CoronaPluginBuilders\combo\metadata.json" />
     <Content Include="targets\LuaSdk\GlobalFiles\_Build\CoronaPluginBuilders\combo\README.markdown" />
     <Content Include="targets\LuaSdk\GlobalFiles\_Build\CoronaPluginBuilders\combo\tmp\build.bat" />
@@ -438,7 +438,7 @@
     <Content Include="targets\LuaSdk\GlobalFiles\_Build\CoronaPluginBuilders\server\bin\README.markdown" />
     <Content Include="targets\LuaSdk\GlobalFiles\_Build\CoronaPluginBuilders\server\create_project.bat" />
     <Content Include="targets\LuaSdk\GlobalFiles\_Build\CoronaPluginBuilders\server\create_project.sh" />
-    <Content Include="targets\LuaSdk\GlobalFiles\_Build\CoronaPluginBuilders\server\lua\plugin\playfab\server.lua" />
+    <Content Include="targets\LuaSdk\GlobalFiles\_Build\CoronaPluginBuilders\server\lua\plugin\playfab\server.lua.ejs" />
     <Content Include="targets\LuaSdk\GlobalFiles\_Build\CoronaPluginBuilders\server\metadata.json" />
     <Content Include="targets\LuaSdk\GlobalFiles\_Build\CoronaPluginBuilders\server\README.markdown" />
     <Content Include="targets\LuaSdk\GlobalFiles\_Build\CoronaPluginBuilders\server\tmp\build.bat" />

--- a/targets/LuaSdk/GlobalFiles/_Build/CoronaPluginBuilders/combo/lua/plugin/playfab/combo.lua.ejs
+++ b/targets/LuaSdk/GlobalFiles/_Build/CoronaPluginBuilders/combo/lua/plugin/playfab/combo.lua.ejs
@@ -96,11 +96,9 @@ end
 
 lib.IPlayFabHttps = require("plugin.playfab.combo.IPlayFabHttps")
 lib.json = require("plugin.playfab.combo.json")
-lib.PlayFabAdminApi = require("plugin.playfab.combo.PlayFabAdminApi")
-lib.PlayFabClientApi = require("plugin.playfab.combo.PlayFabClientApi")
-lib.PlayFabMatchmakerApi = require("plugin.playfab.combo.PlayFabMatchmakerApi")
-lib.PlayFabServerApi = require("plugin.playfab.combo.PlayFabServerApi")
-lib.PlayFabSettings = require("plugin.playfab.combo.PlayFabSettings")
+<% for(var i = 0; i < apis.length; i++) { var api = apis[i];
+%>lib.PlayFab<%- api.name %>Api = require("plugin.playfab.combo.PlayFab<%- api.name %>Api")
+<% } %>
 
 local PlayFabHttpsCorona = require("plugin.playfab.combo.PlayFabHttpsCorona")
 lib.IPlayFabHttps.SetHttp(PlayFabHttpsCorona) -- Assign the Corona-specific IHttps wrapper

--- a/targets/LuaSdk/GlobalFiles/_Build/CoronaPluginBuilders/server/lua/plugin/playfab/server.lua.ejs
+++ b/targets/LuaSdk/GlobalFiles/_Build/CoronaPluginBuilders/server/lua/plugin/playfab/server.lua.ejs
@@ -96,9 +96,9 @@ end
 
 lib.IPlayFabHttps = require("plugin.playfab.server.IPlayFabHttps")
 lib.json = require("plugin.playfab.server.json")
-lib.PlayFabServerApi = require("plugin.playfab.server.PlayFabServerApi")
-lib.PlayFabMatchmakerApi = require("plugin.playfab.server.PlayFabMatchmakerApi")
-lib.PlayFabSettings = require("plugin.playfab.server.PlayFabSettings")
+<% for(var i = 0; i < apis.length; i++) { var api = apis[i];
+%>lib.PlayFab<%- api.name %>Api = require("plugin.playfab.combo.PlayFab<%- api.name %>Api")
+<% } %>
 
 local PlayFabHttpsCorona = require("plugin.playfab.server.PlayFabHttpsCorona")
 lib.IPlayFabHttps.SetHttp(PlayFabHttpsCorona) -- Assign the Corona-specific IHttps wrapper

--- a/targets/WindowsSdk/make.js
+++ b/targets/WindowsSdk/make.js
@@ -11,7 +11,7 @@ exports.makeCombinedAPI = function (apis, sourceDir, apiOutputDir) {
     var locals = {
         apis: apis,
         buildIdentifier: exports.buildIdentifier,
-        extraDefines: "ENABLE_PLAYFABADMIN_API;ENABLE_PLAYFABENTITY_API;ENABLE_PLAYFABMATCHMAKER_API;ENABLE_PLAYFABSERVER_API;",
+        extraDefines: "ENABLE_PLAYFABADMIN_API;ENABLE_PLAYFABSERVER_API;",
         sdkVersion: exports.sdkVersion,
         sdkDate: exports.sdkVersion.split(".")[2],
         sdkYear: exports.sdkVersion.split(".")[2].substr(0, 2),
@@ -90,14 +90,14 @@ function getSortedClasses(datatypes) {
 // *************************** ejs-exposed methods ***************************
 function getApiDefine(api) {
     if (api.name === "Client")
-        return "DISABLE_PLAYFABCLIENT_API";
+        return "#ifndef DISABLE_PLAYFABCLIENT_API";
     if (api.name === "Matchmaker")
-        return "ENABLE_PLAYFABSERVER_API"; // Matchmaker is bound to server, which is just a legacy design decision at this point
+        return "#ifdef ENABLE_PLAYFABSERVER_API"; // Matchmaker is bound to server, which is just a legacy design decision at this point
     if (api.name === "Admin" || api.name === "Server")
-        return "ENABLE_PLAYFAB" + api.name.toUpperCase() + "_API";
+        return "#ifdef ENABLE_PLAYFAB" + api.name.toUpperCase() + "_API";
 
     // For now, everything else is considered ENTITY
-    return "ENABLE_PLAYFABENTITY_API";
+    return "#ifndef DISABLE_PLAYFABENTITY_API";
 }
 
 function getAuthParams(apiCall) {

--- a/targets/WindowsSdk/source/build/TestSrc/PlayFabEntityTest.cpp
+++ b/targets/WindowsSdk/source/build/TestSrc/PlayFabEntityTest.cpp
@@ -1,4 +1,4 @@
-#if defined(ENABLE_PLAYFABENTITY_API) && !defined(DISABLE_PLAYFABCLIENT_API)
+#if !defined(DISABLE_PLAYFABENTITY_API) && !defined(DISABLE_PLAYFABCLIENT_API)
 
 #include "CppUnitTest.h"
 #include <stdlib.h> // _dupenv_s

--- a/targets/WindowsSdk/templates/PlayFab_Api.cpp.ejs
+++ b/targets/WindowsSdk/templates/PlayFab_Api.cpp.ejs
@@ -1,8 +1,5 @@
-<% if (api.name === "Client") { %>
-#ifndef <%- getApiDefine(api) %>
-<% } else { %>
-#ifdef <%- getApiDefine(api) %>
-<% } %>
+<%- getApiDefine(api) %>
+
 #include "playfab/PlayFab<%- api.name %>Api.h"
 #include "playfab/PlayFabHttp.h"
 #include "playfab/PlayFabSettings.h"

--- a/targets/WindowsSdk/templates/PlayFab_Api.h.ejs
+++ b/targets/WindowsSdk/templates/PlayFab_Api.h.ejs
@@ -1,9 +1,7 @@
 #pragma once
-<% if (api.name === "Client") { %>
-#ifndef <%- getApiDefine(api) %>
-<% } else { %>
-#ifdef <%- getApiDefine(api) %>
-<% } %>
+
+<%- getApiDefine(api) %>
+
 #include "playfab/PlayFabHttp.h"
 #include "playfab/PlayFab<%- api.name %>DataModels.h"
 

--- a/targets/WindowsSdk/templates/PlayFab_DataModels.h.ejs
+++ b/targets/WindowsSdk/templates/PlayFab_DataModels.h.ejs
@@ -1,9 +1,7 @@
 #pragma once
-<% if (api.name === "Client") { %>
-#ifndef <%- getApiDefine(api) %>
-<% } else { %>
-#ifdef <%- getApiDefine(api) %>
-<% } %>
+
+<%- getApiDefine(api) %>
+
 #include "playfab/PlayFabBaseModel.h"
 
 namespace PlayFab

--- a/targets/XPlatCppSdk/make.js
+++ b/targets/XPlatCppSdk/make.js
@@ -7,7 +7,7 @@ if (typeof (templatizeTree) === "undefined") templatizeTree = function () { };
 exports.makeCombinedAPI = function (apis, sourceDir, apiOutputDir) {
     console.log("Generating Combined api from: " + sourceDir + " to: " + apiOutputDir);
 
-    var extraDefines = "ENABLE_PLAYFABADMIN_API;ENABLE_PLAYFABENTITY_API;ENABLE_PLAYFABMATCHMAKER_API;ENABLE_PLAYFABSERVER_API;";
+    var extraDefines = "ENABLE_PLAYFABADMIN_API;ENABLE_PLAYFABSERVER_API;";
 
     var locals = {
         apis: apis,
@@ -98,7 +98,7 @@ function getApiDefine(api) {
         return "#ifdef ENABLE_PLAYFAB" + api.name.toUpperCase() + "_API";
 
     // For now, everything else is considered ENTITY
-    return "#ifdef ENABLE_PLAYFABENTITY_API";
+    return "#ifndef DISABLE_PLAYFABENTITY_API";
 }
 
 function getAuthParams(apiCall) {

--- a/targets/cpp-ue4/Plugins/PlayFab/Source/PlayFab/Private/PlayFab.cpp.ejs
+++ b/targets/cpp-ue4/Plugins/PlayFab/Source/PlayFab/Private/PlayFab.cpp.ejs
@@ -45,16 +45,10 @@ void FPlayFabModule::StartupModule()
     RegisterSettings();
     HandleSettingsSaved();
 
-    // create the API
-    AuthenticationAPI = MakeShareable(new PlayFab::UPlayFabAuthenticationAPI());
-    ClientAPI = MakeShareable(new PlayFab::UPlayFabClientAPI());
-    DataAPI = MakeShareable(new PlayFab::UPlayFabDataAPI());
-
-#if WITH_SERVER_CODE
-    ServerAPI = MakeShareable(new PlayFab::UPlayFabServerAPI());
-    MatchmakerAPI = MakeShareable(new PlayFab::UPlayFabMatchmakerAPI());
-    AdminAPI = MakeShareable(new PlayFab::UPlayFabAdminAPI());
-#endif
+    // create the APIs
+<% for(var i = 0; i < apis.length; i++) { var api = apis[i];
+%>    <%- api.name %>API = MakeShareable(new PlayFab::UPlayFab<%- api.name %>API());
+<% } %>
 }
 
 void FPlayFabModule::ShutdownModule()

--- a/targets/csharp/make.js
+++ b/targets/csharp/make.js
@@ -15,7 +15,7 @@ exports.makeClientAPI2 = function (apis, sourceDir, apiOutputDir) {
     for (var i = 0; i < apis.length; i++)
         makeApi(apis[i], sourceDir, apiOutputDir);
     generateSimpleFiles(apis, sourceDir, apiOutputDir);
-    generateProject(apis, sourceDir, apiOutputDir, "Client", "ENABLE_PLAYFABENTITY_API");
+    generateProject(apis, sourceDir, apiOutputDir, "Client", "");
 }
 
 exports.makeServerAPI = function (apis, sourceDir, apiOutputDir) {
@@ -27,7 +27,7 @@ exports.makeServerAPI = function (apis, sourceDir, apiOutputDir) {
     for (var i = 0; i < apis.length; i++)
         makeApi(apis[i], sourceDir, apiOutputDir);
     generateSimpleFiles(apis, sourceDir, apiOutputDir);
-    generateProject(apis, sourceDir, apiOutputDir, "Server", ";DISABLE_PLAYFABCLIENT_API;ENABLE_PLAYFABENTITY_API");
+    generateProject(apis, sourceDir, apiOutputDir, "Server", ";DISABLE_PLAYFABCLIENT_API");
 }
 
 exports.makeCombinedAPI = function (apis, sourceDir, apiOutputDir) {
@@ -41,7 +41,7 @@ exports.makeCombinedAPI = function (apis, sourceDir, apiOutputDir) {
     for (var i = 0; i < apis.length; i++)
         makeApi(apis[i], sourceDir, apiOutputDir);
     generateSimpleFiles(apis, sourceDir, apiOutputDir);
-    generateProject(apis, sourceDir, apiOutputDir, "All", "ENABLE_PLAYFABADMIN_API;ENABLE_PLAYFABSERVER_API;ENABLE_PLAYFABMATCHMAKER_API;ENABLE_PLAYFABENTITY_API");
+    generateProject(apis, sourceDir, apiOutputDir, "All", "ENABLE_PLAYFABADMIN_API;ENABLE_PLAYFABSERVER_API");
     generateNugetTemplate(sourceDir, apiOutputDir);
 }
 

--- a/targets/csharp/source/source/Uunit/PlayFabApiTest.cs
+++ b/targets/csharp/source/source/Uunit/PlayFabApiTest.cs
@@ -7,7 +7,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
-#if ENABLE_PLAYFABENTITY_API
+#if !DISABLE_PLAYFABENTITY_API
 using PlayFab.AuthenticationModels;
 using PlayFab.DataModels;
 #endif
@@ -448,7 +448,7 @@ namespace PlayFab.UUnit
             });
         }
 
-#if ENABLE_PLAYFABENTITY_API
+#if !DISABLE_PLAYFABENTITY_API
         /// <summary>
         /// ENTITY API
         /// Get the EntityToken for the client player

--- a/targets/newTarget/make.js
+++ b/targets/newTarget/make.js
@@ -15,7 +15,7 @@ exports.makeClientAPI2 = function (apis, sourceDir, apiOutputDir) {
 
 // generate.js looks for some specific exported functions (as defined in TOC.json) in make.js, like:
 exports.makeServerAPI = function (apis, sourceDir, apiOutputDir) {
-    // Builds the server api.  The provided "apis" variable is a list of objects, built from: API_SPECS/admin.api.json, API_SPECS/matchmaker.api.json, and API_SPECS/server.api.json
+    // Builds the server api.  The provided "apis" variable is a list of objects, Examples: API_SPECS/Legacy/PlayFab/admin.api.json and API_SPECS/Legacy/PlayFab/server.api.json
     // If you don't want admin, you should filter it out yourself (for now)
     
     console.log("Generating Server api from: " + sourceDir + " to: " + apiOutputDir);
@@ -25,7 +25,7 @@ exports.makeServerAPI = function (apis, sourceDir, apiOutputDir) {
 
 // generate.js looks for some specific exported functions (as defined in TOC.json) in make.js, like:
 exports.makeCombinedAPI = function (apis, sourceDir, apiOutputDir) {
-    // Builds every api.  The provided "apis" variable is a list of objects, built from: API_SPECS/admin.api.json, API_SPECS/matchmaker.api.json, API_SPECS/server.api.json, and API_SPECS/client.api.json
+    // Builds every api.  The provided "apis" variable is a list of objects, Examples: API_SPECS/Legacy/PlayFab/admin.api.json, API_SPECS/Legacy/PlayFab/server.api.json, and API_SPECS/Legacy/PlayFab/client.api.json
     
     console.log("Generating Combined api from: " + sourceDir + " to: " + apiOutputDir);
     copyTree(path.resolve(sourceDir, "source"), apiOutputDir); // Copy the whole source directory as-is

--- a/targets/postman/replacements.json
+++ b/targets/postman/replacements.json
@@ -18,7 +18,5 @@
     "Server": {
     },
     "Admin": {
-    },
-    "Matchmaker": {
     }
 }

--- a/targets/unity-v2/Testing/Tests/Entity/EntityApiTests.cs
+++ b/targets/unity-v2/Testing/Tests/Entity/EntityApiTests.cs
@@ -1,4 +1,4 @@
-#if !DISABLE_PLAYFABCLIENT_API && ENABLE_PLAYFABENTITY_API
+#if !DISABLE_PLAYFABCLIENT_API && !DISABLE_PLAYFABENTITY_API
 using PlayFab.Internal;
 using System.Collections.Generic;
 using System.Linq;

--- a/targets/unity-v2/Testing/Tests/Shared/TestTitleDataLoader.cs
+++ b/targets/unity-v2/Testing/Tests/Shared/TestTitleDataLoader.cs
@@ -21,7 +21,7 @@ namespace PlayFab.UUnit
             // More details available here: https://github.com/PlayFab/SDKGenerator/blob/master/JenkinsConsoleUtility/testTitleData.md
             public string titleId;
             public string userEmail;
-#if ENABLE_PLAYFABSERVER_API || ENABLE_PLAYFABADMIN_API || ENABLE_PLAYFABMATCHMAKER_API || UNITY_EDITOR
+#if ENABLE_PLAYFABSERVER_API || ENABLE_PLAYFABADMIN_API || UNITY_EDITOR
             public string developerSecretKey;
 #endif
             public Dictionary<string, string> extraHeaders;
@@ -74,7 +74,7 @@ namespace PlayFab.UUnit
                 return;
 
             PlayFabSettings.TitleId = _loadedData.titleId;
-#if ENABLE_PLAYFABSERVER_API || ENABLE_PLAYFABADMIN_API || ENABLE_PLAYFABMATCHMAKER_API || UNITY_EDITOR
+#if ENABLE_PLAYFABSERVER_API || ENABLE_PLAYFABADMIN_API || UNITY_EDITOR
             PlayFabSettings.DeveloperSecretKey = _loadedData.developerSecretKey;
 #endif
         }

--- a/targets/unity-v2/make.js
+++ b/targets/unity-v2/make.js
@@ -358,7 +358,7 @@ function getRequestActions(tabbing, apiCall) {
             tabbing + "if (authType == AuthType.None && PlayFabClientAPI.IsClientLoggedIn())\n" +
             tabbing + "    authType = AuthType.LoginSession;\n" +
             "#endif\n" +
-            "#if ENABLE_PLAYFABSERVER_API || ENABLE_PLAYFABADMIN_API || ENABLE_PLAYFABMATCHMAKER_API || UNITY_EDITOR\n" +
+            "#if ENABLE_PLAYFABSERVER_API || ENABLE_PLAYFABADMIN_API || UNITY_EDITOR\n" +
             tabbing + "if (authType == AuthType.None && !string.IsNullOrEmpty(PlayFabSettings.DeveloperSecretKey))\n" +
             tabbing + "    authType = AuthType.DevSecretKey;\n" +
             "#endif\n";
@@ -409,5 +409,5 @@ function getApiDefineFlag(api) {
         return "ENABLE_PLAYFAB" + api.name.toUpperCase() + "_API";
 
     // For now, everything else is considered ENTITY
-    return "ENABLE_PLAYFABENTITY_API";
+    return "!DISABLE_PLAYFABENTITY_API";
 }

--- a/targets/unity-v2/source/Client/PlayFabDeviceUtil.cs
+++ b/targets/unity-v2/source/Client/PlayFabDeviceUtil.cs
@@ -118,7 +118,7 @@ namespace PlayFab.Internal
             // Device information gathering
             SendDeviceInfoToPlayFab();
 
-#if ENABLE_PLAYFABENTITY_API
+#if !DISABLE_PLAYFABENTITY_API
             if (!string.IsNullOrEmpty(entityId) && !string.IsNullOrEmpty(entityType) && _gatherScreenTime)
             {
                 PlayFabHttp.InitializeScreenTimeTracker(entityId, entityType, playFabId);

--- a/targets/unity-v2/source/Entity/ScreenTimeTracker.cs
+++ b/targets/unity-v2/source/Entity/ScreenTimeTracker.cs
@@ -1,4 +1,4 @@
-#if ENABLE_PLAYFABENTITY_API && !DISABLE_PLAYFABCLIENT_API
+#if !DISABLE_PLAYFABENTITY_API && !DISABLE_PLAYFABCLIENT_API
 using System;
 using System.Collections.Generic;
 using UnityEngine;

--- a/targets/unity-v2/source/Shared/Internal/PlayFabHttp/PlayFabHTTP.cs
+++ b/targets/unity-v2/source/Shared/Internal/PlayFabHttp/PlayFabHTTP.cs
@@ -27,7 +27,7 @@ namespace PlayFab.Internal
 #endif
 
         private static IPlayFabLogger _logger;
-#if ENABLE_PLAYFABENTITY_API && !DISABLE_PLAYFABCLIENT_API
+#if !DISABLE_PLAYFABENTITY_API && !DISABLE_PLAYFABCLIENT_API
         private static IScreenTimeTracker screenTimeTracker = new ScreenTimeTracker();
         private const float delayBetweenBatches = 5.0f;
 #endif
@@ -103,7 +103,7 @@ namespace PlayFab.Internal
             _logger = setLogger;
         }
 
-#if ENABLE_PLAYFABENTITY_API && !DISABLE_PLAYFABCLIENT_API
+#if !DISABLE_PLAYFABENTITY_API && !DISABLE_PLAYFABCLIENT_API
         /// <summary>
         /// This initializes ScreenTimeTracker object and notifying it to start sending info.
         /// </summary>
@@ -211,7 +211,7 @@ namespace PlayFab.Internal
             reqContainer.RequestHeaders["X-PlayFabSDK"] = PlayFabSettings.VersionString; // Tell PlayFab which SDK this is
             switch (authType)
             {
-#if ENABLE_PLAYFABSERVER_API || ENABLE_PLAYFABADMIN_API || ENABLE_PLAYFABMATCHMAKER_API || UNITY_EDITOR
+#if ENABLE_PLAYFABSERVER_API || ENABLE_PLAYFABADMIN_API || UNITY_EDITOR
                 case AuthType.DevSecretKey: reqContainer.RequestHeaders["X-SecretKey"] = PlayFabSettings.DeveloperSecretKey; break;
 #endif
                 case AuthType.LoginSession: reqContainer.RequestHeaders["X-Authorization"] = transport.AuthKey; break;
@@ -249,7 +249,7 @@ namespace PlayFab.Internal
         /// </summary>
         internal void OnPlayFabApiResult(PlayFabResultCommon result)
         {
-#if ENABLE_PLAYFABENTITY_API
+#if !DISABLE_PLAYFABENTITY_API
             var entRes = result as AuthenticationModels.GetEntityTokenResponse;
             if (entRes != null)
             {
@@ -287,7 +287,7 @@ namespace PlayFab.Internal
                 _logger.OnEnable();
             }
 
-#if ENABLE_PLAYFABENTITY_API && !DISABLE_PLAYFABCLIENT_API
+#if !DISABLE_PLAYFABENTITY_API && !DISABLE_PLAYFABCLIENT_API
             if ((screenTimeTracker != null) && !PlayFabSettings.DisableFocusTimeCollection)
             {
                 screenTimeTracker.OnEnable();
@@ -305,7 +305,7 @@ namespace PlayFab.Internal
                 _logger.OnDisable();
             }
 
-#if ENABLE_PLAYFABENTITY_API && !DISABLE_PLAYFABCLIENT_API
+#if !DISABLE_PLAYFABENTITY_API && !DISABLE_PLAYFABCLIENT_API
             if ((screenTimeTracker != null) && !PlayFabSettings.DisableFocusTimeCollection)
             {
                 screenTimeTracker.OnDisable();
@@ -334,7 +334,7 @@ namespace PlayFab.Internal
                 _logger.OnDestroy();
             }
 
-#if ENABLE_PLAYFABENTITY_API && !DISABLE_PLAYFABCLIENT_API
+#if !DISABLE_PLAYFABENTITY_API && !DISABLE_PLAYFABCLIENT_API
             if ((screenTimeTracker != null) && !PlayFabSettings.DisableFocusTimeCollection)
             {
                 screenTimeTracker.OnDestroy();
@@ -347,7 +347,7 @@ namespace PlayFab.Internal
         /// </summary>
         public void OnApplicationFocus(bool isFocused)
         {
-#if ENABLE_PLAYFABENTITY_API && !DISABLE_PLAYFABCLIENT_API
+#if !DISABLE_PLAYFABENTITY_API && !DISABLE_PLAYFABCLIENT_API
             if ((screenTimeTracker != null) && !PlayFabSettings.DisableFocusTimeCollection)
             {
                 screenTimeTracker.OnApplicationFocus(isFocused);
@@ -360,7 +360,7 @@ namespace PlayFab.Internal
         /// </summary>
         public void OnApplicationQuit()
         {
-#if ENABLE_PLAYFABENTITY_API && !DISABLE_PLAYFABCLIENT_API
+#if !DISABLE_PLAYFABENTITY_API && !DISABLE_PLAYFABCLIENT_API
             if ((screenTimeTracker != null) && !PlayFabSettings.DisableFocusTimeCollection)
             {
                 screenTimeTracker.OnApplicationQuit();

--- a/targets/unity-v2/source/Shared/Models/PlayFabSharedSettings.cs
+++ b/targets/unity-v2/source/Shared/Models/PlayFabSharedSettings.cs
@@ -7,7 +7,7 @@ using PlayFab;
 public class PlayFabSharedSettings : ScriptableObject
 {
     public string TitleId;
-#if ENABLE_PLAYFABSERVER_API || ENABLE_PLAYFABADMIN_API || ENABLE_PLAYFABMATCHMAKER_API || UNITY_EDITOR
+#if ENABLE_PLAYFABSERVER_API || ENABLE_PLAYFABADMIN_API || UNITY_EDITOR
     public string DeveloperSecretKey;
 #endif
 #if ENABLE_PLAYFABPLAYSTREAM_API && ENABLE_PLAYFABSERVER_API

--- a/targets/unity-v2/source/Shared/Public/PlayFabSettings.cs.ejs
+++ b/targets/unity-v2/source/Shared/Public/PlayFabSettings.cs.ejs
@@ -59,7 +59,7 @@ namespace PlayFab
             return GetSharedSettingsObjectPrivate();
         }
 
-#if ENABLE_PLAYFABSERVER_API || ENABLE_PLAYFABADMIN_API || ENABLE_PLAYFABMATCHMAKER_API || UNITY_EDITOR
+#if ENABLE_PLAYFABSERVER_API || ENABLE_PLAYFABADMIN_API || UNITY_EDITOR
         public static string DeveloperSecretKey
         {
             set { PlayFabSharedPrivate.DeveloperSecretKey = value;}


### PR DESCRIPTION
Revamped build scripts
- All the shared logic is moved to a shared file, and driven with variables
A handful of missed hard coded ApiGroup lists have been resolved (Lua, UeCpp)
The Matchmaker define toggle was inconsistent everywhere, and so it's been locked down to match Server everywhere.
The Entity define toggle was changed from "disabled until enabled" to "enabled until disabled", in all relevant SDKs.
A few minor documentation tweaks, and changes to support the above.