### PR TITLE
adding /bigobj to windows versions of xplat cpp.

### DIFF
--- a/targets/XPlatCppSdk/source/cppsdk/XPlatCppWindows.vcxproj.ejs
+++ b/targets/XPlatCppSdk/source/cppsdk/XPlatCppWindows.vcxproj.ejs
@@ -66,7 +66,7 @@
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
       <DisableSpecificWarnings>4251</DisableSpecificWarnings>
       <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
-      <AdditionalOptions>/Zc:__cplusplus %(AdditionalOptions)</AdditionalOptions>
+      <AdditionalOptions>/Zc:__cplusplus /bigobj %(AdditionalOptions)</AdditionalOptions>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
@@ -95,7 +95,7 @@
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
       <DisableSpecificWarnings>4251</DisableSpecificWarnings>
       <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
-      <AdditionalOptions>/Zc:__cplusplus %(AdditionalOptions)</AdditionalOptions>
+      <AdditionalOptions>/Zc:__cplusplus /bigobj %(AdditionalOptions)</AdditionalOptions>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>

--- a/targets/XPlatCppSdk/source/testapps/cppWindowsTestApp/cppWindowsTestApp.vcxproj.ejs
+++ b/targets/XPlatCppSdk/source/testapps/cppWindowsTestApp/cppWindowsTestApp.vcxproj.ejs
@@ -66,7 +66,7 @@
       <MinimalRebuild>false</MinimalRebuild>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
       <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
-      <AdditionalOptions>/Zc:__cplusplus %(AdditionalOptions)</AdditionalOptions>
+      <AdditionalOptions>/Zc:__cplusplus /bigobj %(AdditionalOptions)</AdditionalOptions>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -89,7 +89,7 @@
       <MinimalRebuild>false</MinimalRebuild>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
       <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
-      <AdditionalOptions>/Zc:__cplusplus %(AdditionalOptions)</AdditionalOptions>
+      <AdditionalOptions>/Zc:__cplusplus /bigobj %(AdditionalOptions)</AdditionalOptions>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>


### PR DESCRIPTION
adding /bigobj to compiler options for windows xplat cpp sdk projects.

Currently seen in Jenkins build:  https://pf-jenkins.playfab.com/view/SDK/job/SDK_Shared_XPlatCppSdk/1244/console 

---------
C:\program files\jenkins\workspace\SDK_Shared_XPlatCppSdk@2\sdks\XPlatBetaSdk\cppsdk\source\playfab\PlayFabClientApi.cpp : fatal error C1128: number of sections exceeded object file format limit: compile with /bigobj [C:\program files\jenkins\workspace\SDK_Shared_XPlatCppSdk@2\sdks\XPlatBetaSdk\cppsdk\XPlatCppWindows.vcxproj]
18:01:08 cl : Command line error D8040: error creating or communicating with child process [C:\program files\jenkins\workspace\SDK_Shared_XPlatCppSdk@2\sdks\XPlatBetaSdk\cppsdk\XPlatCppWindows.vcxproj]

---------
