### PR TITLE
Clearing a specific instance of naming conflict

### DIFF
--- a/targets/unity-v2/source/Shared/Internal/PlayFabSignalR/IPlayFabSignalR.cs
+++ b/targets/unity-v2/source/Shared/Internal/PlayFabSignalR/IPlayFabSignalR.cs
@@ -1,22 +1,18 @@
-﻿using System;
-
 namespace PlayFab.Internal
 {
     public interface IPlayFabSignalR
     {
-        event Action<string> OnReceived;
-        event Action OnReconnected;
-        event Action OnDisconnected;
-        event Action<Exception> OnError;
+        event System.Action<string> OnReceived;
+        event System.Action OnReconnected;
+        event System.Action OnDisconnected;
+        event System.Action<System.Exception> OnError;
 
         void Start(string url, string hubName);
         void Stop();
 
         void Update();
-        
-        void Invoke(string api, Action resultCallback, params object[] args);
-        void Subscribe(string onInvoked, Action<object[]> resultCallback);
+
+        void Invoke(string api, System.Action resultCallback, params object[] args);
+        void Subscribe(string onInvoked, System.Action<object[]> resultCallback);
     }
-
 }
-


### PR DESCRIPTION
...recently experienced by a customer.
It probably won't solve the underlying problem, but it'll clear this one instance.