### PR TITLE
Renaming classes that conflict between CPP and BP

### DIFF
--- a/SDKGenerator.njsproj
+++ b/SDKGenerator.njsproj
@@ -152,29 +152,6 @@
     <Compile Include="targets\WindowsSdk\make.js" />
     <Compile Include="targets\XPlatCppSdk\make.js" />
     <Content Include="README.md" />
-    <Content Include="SDKBuildScripts\actionscript_build.bat" />
-    <Content Include="SDKBuildScripts\cocos_build.bat" />
-    <Content Include="SDKBuildScripts\cocos_example1build.bat" />
-    <Content Include="SDKBuildScripts\csharp_build.bat" />
-    <Content Include="SDKBuildScripts\java_build.bat" />
-    <Content Include="SDKBuildScripts\js_build.bat" />
-    <Content Include="SDKBuildScripts\lua_build.bat" />
-    <Content Include="SDKBuildScripts\Lumberyard_build.bat" />
-    <Content Include="SDKBuildScripts\NewTarget.bat" />
-    <Content Include="SDKBuildScripts\node_build.bat" />
-    <Content Include="SDKBuildScripts\objc_build.bat" />
-    <Content Include="SDKBuildScripts\php_build.bat" />
-    <Content Include="SDKBuildScripts\postman_build.bat" />
-    <Content Include="SDKBuildScripts\python_build.bat" />
-    <Content Include="SDKBuildScripts\SdkTestingCloudScript_build.bat" />
-    <Content Include="SDKBuildScripts\ue4_BP_build.bat" />
-    <Content Include="SDKBuildScripts\ue4_CPP_build.bat" />
-    <Content Include="SDKBuildScripts\unity_build.bat" />
-    <Content Include="SDKBuildScripts\unity_build_strangeIoC.bat" />
-    <Content Include="SDKBuildScripts\unity_gameserver.bat" />
-    <Content Include="SDKBuildScripts\unity_RunAutoTests.bat" />
-    <Content Include="SDKBuildScripts\unity_SetupTestProjects.sh" />
-    <Content Include="SDKBuildScripts\winV1_build.bat" />
     <Content Include="targets\actionscript\source\asyncUnitTest\ASyncAssert.as" />
     <Content Include="targets\actionscript\source\asyncUnitTest\ASyncUnitTestCloudScriptReporter.as" />
     <Content Include="targets\actionscript\source\asyncUnitTest\ASyncUnitTestEvent.as" />
@@ -690,14 +667,14 @@
     <Content Include="targets\UnrealMarketplacePlugin\source\PlayFab\Source\PlayFabCpp\Public\Core\PlayFabResultHandler.h.ejs" />
     <Content Include="targets\UnrealMarketplacePlugin\source\PlayFab\Source\PlayFabCpp\Public\Core\PlayFabSettings.h.ejs" />
     <Content Include="targets\UnrealMarketplacePlugin\source\PlayFab\Source\PlayFabCpp\Public\PlayFab.h.ejs" />
-    <Content Include="targets\UnrealMarketplacePlugin\Source\PlayFab\Source\PlayFab\Classes\PlayFabBpBaseModel.h.ejs" />
+    <Content Include="targets\UnrealMarketplacePlugin\source\PlayFab\Source\PlayFab\Classes\PlayFabBaseModel.h.ejs" />
     <Content Include="targets\UnrealMarketplacePlugin\source\PlayFab\Source\PlayFab\Classes\PlayFabEnums.h.ejs" />
     <Content Include="targets\UnrealMarketplacePlugin\source\PlayFab\Source\PlayFab\Classes\PlayFabJsonObject.h.ejs" />
     <Content Include="targets\UnrealMarketplacePlugin\source\PlayFab\Source\PlayFab\Classes\PlayFabJsonValue.h.ejs" />
     <Content Include="targets\UnrealMarketplacePlugin\source\PlayFab\Source\PlayFab\Classes\PlayFabUtilities.h.ejs" />
     <Content Include="targets\UnrealMarketplacePlugin\Source\PlayFab\Source\PlayFab\PlayFab.Build.cs" />
     <Content Include="targets\UnrealMarketplacePlugin\source\PlayFab\Source\PlayFab\Private\PlayFab.cpp.ejs" />
-    <Content Include="targets\UnrealMarketplacePlugin\Source\PlayFab\Source\PlayFab\Private\PlayFabBpBaseModel.cpp.ejs" />
+    <Content Include="targets\UnrealMarketplacePlugin\source\PlayFab\Source\PlayFab\Private\PlayFabBaseModel.cpp.ejs" />
     <Content Include="targets\UnrealMarketplacePlugin\source\PlayFab\Source\PlayFab\Private\PlayFabJsonObject.cpp.ejs" />
     <Content Include="targets\UnrealMarketplacePlugin\source\PlayFab\Source\PlayFab\Private\PlayFabJsonValue.cpp.ejs" />
     <Content Include="targets\UnrealMarketplacePlugin\Source\PlayFab\Source\PlayFab\Private\PlayFabPrivate.h" />
@@ -773,7 +750,6 @@
     <Content Include="targets\XPlatCppSdk\source\testapps\cppWindowsTestApp\packages.config" />
   </ItemGroup>
   <ItemGroup>
-    <Folder Include="SDKBuildScripts\" />
     <Folder Include="targets\" />
     <Folder Include="targets\actionscript\" />
     <Folder Include="targets\actionscript\source\" />
@@ -925,7 +901,6 @@
     <Folder Include="targets\UnrealMarketplacePlugin\Source\PlayFab\Source\PlayFab\Private\" />
     <Folder Include="targets\UnrealMarketplacePlugin\Source\PlayFab\Source\PlayFab\Public\" />
     <Folder Include="targets\UnrealMarketplacePlugin\Templates\" />
-    <Folder Include="targets\UnrealMarketplacePlugin\templates\PlayFabCommon\" />
     <Folder Include="targets\UnrealMarketplacePlugin\templates\PlayFabCpp\" />
     <Folder Include="targets\UnrealMarketplacePlugin\templates\PlayFabCpp\core\" />
     <Folder Include="targets\UnrealMarketplacePlugin\templates\PlayFab\" />

--- a/targets/UnrealMarketplacePlugin/examplesource/ExampleProject/Plugins/PlayFab/Source/PlayFab/Classes/PfTestActor.h.ejs
+++ b/targets/UnrealMarketplacePlugin/examplesource/ExampleProject/Plugins/PlayFab/Source/PlayFab/Classes/PfTestActor.h.ejs
@@ -37,7 +37,7 @@ enum class PlayFabApiTestFinishState : uint8
 };
 
 UCLASS(Blueprintable, BlueprintType)
-class UPfTestContext : public UObject
+class PLAYFAB_API UPfTestContext : public UObject
 {
     GENERATED_BODY()
 public:

--- a/targets/UnrealMarketplacePlugin/examplesource/ExampleProject/Source/ExampleProject/PlayFabApiTests.cpp
+++ b/targets/UnrealMarketplacePlugin/examplesource/ExampleProject/Source/ExampleProject/PlayFabApiTests.cpp
@@ -4,12 +4,14 @@
 
 #include "ExampleProject.h"
 #include "PlayFabApiTests.h"
+#include "PlayFabError.h"
 
-DEFINE_LOG_CATEGORY(LogPlayFabTest); // This is a separate project from the PlayFab plugin, so this has to be re-defined in this project - This is not standard, but these tests should log as playfab, even from another project
+// This is a separate project from the PlayFab plugin, so this has to be re-defined in this project - This is not standard, but these tests should log as playfab, even from another project
+DEFINE_LOG_CATEGORY(LogPlayFabTest);
 
-									 /*
-									 * ==== Test Suite ====
-									 */
+/*
+* ==== Test Suite ====
+*/
 FString PlayFabApiTestSuite::playFabId;
 FString PlayFabApiTestSuite::entityId;
 FString PlayFabApiTestSuite::entityType;
@@ -49,7 +51,7 @@ void PlayFabApiTest_0LoginWithEmail::OnSuccess(const PlayFab::ClientModels::FLog
 	UE_LOG(LogPlayFabTest, Error, TEXT("LoginWithEmailAddress Succeeded where it should have failed"));
 }
 
-void PlayFabApiTest_0LoginWithEmail::OnError(const PlayFab::FPlayFabError& ErrorResult) const
+void PlayFabApiTest_0LoginWithEmail::OnError(const PlayFab::FPlayFabCppError& ErrorResult) const
 {
 	if (ErrorResult.ErrorMessage.Find(TEXT("password")) == -1) // Check that we correctly received a notice about invalid password
 	{
@@ -94,7 +96,7 @@ void PlayFabApiTest_0LoginWithCustomID::OnSuccess(const PlayFab::ClientModels::F
 	UE_LOG(LogPlayFabTest, Log, TEXT("PlayFab login successful: %s, %s"), *PlayFabApiTestSuite::playFabId, *customId);
 }
 
-void PlayFabApiTest_0LoginWithCustomID::OnError(const PlayFab::FPlayFabError& ErrorResult) const
+void PlayFabApiTest_0LoginWithCustomID::OnError(const PlayFab::FPlayFabCppError& ErrorResult) const
 {
 	UE_LOG(LogPlayFabTest, Error, TEXT("Login failed"));
 }
@@ -142,7 +144,7 @@ void PlayFabApiTest_0LoginWithAdvertisingId::OnSuccess(const PlayFab::ClientMode
 	UE_LOG(LogPlayFabTest, Log, TEXT("PlayFab login successful: %s, %s"), *PlayFabApiTestSuite::playFabId, *customId);
 }
 
-void PlayFabApiTest_0LoginWithAdvertisingId::OnError(const PlayFab::FPlayFabError& ErrorResult) const
+void PlayFabApiTest_0LoginWithAdvertisingId::OnError(const PlayFab::FPlayFabCppError& ErrorResult) const
 {
 	UE_LOG(LogPlayFabTest, Error, TEXT("LoginWithAdvertisingId Failed: %s"), *(ErrorResult.ErrorMessage));
 }
@@ -222,7 +224,7 @@ void PlayFabApiTest_GetUserData::CheckTimestamp(const FDateTime& updateTime) con
 	}
 }
 
-void PlayFabApiTest_GetUserData::OnError(const PlayFab::FPlayFabError& ErrorResult) const
+void PlayFabApiTest_GetUserData::OnError(const PlayFab::FPlayFabCppError& ErrorResult) const
 {
 	UE_LOG(LogPlayFabTest, Error, TEXT("GetUserData Failed: %s"), *(ErrorResult.ErrorMessage));
 }
@@ -267,7 +269,7 @@ void PlayFabApiTest_UpdateUserData::OnSuccess(const PlayFab::ClientModels::FUpda
 	ADD_LATENT_AUTOMATION_COMMAND(PlayFabApiTest_GetUserData(TEST_DATA_KEY_1, TEST_DATA_KEY_2, updateValue));
 }
 
-void PlayFabApiTest_UpdateUserData::OnError(const PlayFab::FPlayFabError& ErrorResult) const
+void PlayFabApiTest_UpdateUserData::OnError(const PlayFab::FPlayFabCppError& ErrorResult) const
 {
 	UE_LOG(LogPlayFabTest, Error, TEXT("UpdateUserData Failed: %s"), *(ErrorResult.ErrorMessage));
 }
@@ -324,7 +326,7 @@ void PlayFabApiTest_GetPlayerStatistics::OnSuccess(const PlayFab::ClientModels::
 	}
 }
 
-void PlayFabApiTest_GetPlayerStatistics::OnError(const PlayFab::FPlayFabError& ErrorResult) const
+void PlayFabApiTest_GetPlayerStatistics::OnError(const PlayFab::FPlayFabCppError& ErrorResult) const
 {
 	UE_LOG(LogPlayFabTest, Error, TEXT("GetPlayerStatistics Failed: %s"), *(ErrorResult.ErrorMessage));
 }
@@ -368,7 +370,7 @@ void PlayFabApiTest_UpdatePlayerStatistics::OnSuccess(const PlayFab::ClientModel
 	ADD_LATENT_AUTOMATION_COMMAND(PlayFabApiTest_GetPlayerStatistics(TEST_STAT_NAME, updateValue));
 }
 
-void PlayFabApiTest_UpdatePlayerStatistics::OnError(const PlayFab::FPlayFabError& ErrorResult) const
+void PlayFabApiTest_UpdatePlayerStatistics::OnError(const PlayFab::FPlayFabCppError& ErrorResult) const
 {
 	UE_LOG(LogPlayFabTest, Error, TEXT("UpdatePlayerStatistics Failed: %s"), *(ErrorResult.ErrorMessage));
 }
@@ -404,7 +406,7 @@ void PlayFabApiTest_GetAllUsersCharacters::OnSuccess(const PlayFab::ClientModels
 	UE_LOG(LogPlayFabTest, Log, TEXT("GetAllUsersCharacters Success (Can't fail)"));
 }
 
-void PlayFabApiTest_GetAllUsersCharacters::OnError(const PlayFab::FPlayFabError& ErrorResult) const
+void PlayFabApiTest_GetAllUsersCharacters::OnError(const PlayFab::FPlayFabCppError& ErrorResult) const
 {
 	UE_LOG(LogPlayFabTest, Error, TEXT("GetAllUsersCharacters Failed: %s"), *(ErrorResult.ErrorMessage));
 }
@@ -452,7 +454,7 @@ void PlayFabApiTest_GetLeaderboardC::OnSuccess(const PlayFab::ClientModels::FGet
 	}
 }
 
-void PlayFabApiTest_GetLeaderboardC::OnError(const PlayFab::FPlayFabError& ErrorResult) const
+void PlayFabApiTest_GetLeaderboardC::OnError(const PlayFab::FPlayFabCppError& ErrorResult) const
 {
 	UE_LOG(LogPlayFabTest, Error, TEXT("GetLeaderboard Failed: %s"), *(ErrorResult.ErrorMessage));
 }
@@ -500,7 +502,7 @@ void PlayFabApiTest_GetLeaderboardS::OnSuccess(const PlayFab::ServerModels::FGet
 	}
 }
 
-void PlayFabApiTest_GetLeaderboardS::OnError(const PlayFab::FPlayFabError& ErrorResult) const
+void PlayFabApiTest_GetLeaderboardS::OnError(const PlayFab::FPlayFabCppError& ErrorResult) const
 {
 	UE_LOG(LogPlayFabTest, Error, TEXT("GetLeaderboard Failed: %s"), *(ErrorResult.ErrorMessage));
 }
@@ -537,7 +539,7 @@ void PlayFabApiTest_GetAccountInfo::OnSuccess(const PlayFab::ClientModels::FGetA
 	UE_LOG(LogPlayFabTest, Log, TEXT("GetAccountInfo Succeeded"));
 }
 
-void PlayFabApiTest_GetAccountInfo::OnError(const PlayFab::FPlayFabError& ErrorResult) const
+void PlayFabApiTest_GetAccountInfo::OnError(const PlayFab::FPlayFabCppError& ErrorResult) const
 {
 	UE_LOG(LogPlayFabTest, Error, TEXT("GetAccountInfo Failed: %s"), *(ErrorResult.ErrorMessage));
 }
@@ -582,7 +584,7 @@ void PlayFabApiTest_ExecuteCloudScript::OnSuccess(const PlayFab::ClientModels::F
 	}
 }
 
-void PlayFabApiTest_ExecuteCloudScript::OnError(const PlayFab::FPlayFabError& ErrorResult) const
+void PlayFabApiTest_ExecuteCloudScript::OnError(const PlayFab::FPlayFabCppError& ErrorResult) const
 {
 	if (expectFail) {
 		UE_LOG(LogPlayFabTest, Log, TEXT("ExecuteCloudScript failed as expected"));
@@ -627,7 +629,7 @@ void PlayFabApiTest_WriteEvent::OnSuccess(const PlayFab::ClientModels::FWriteEve
 	UE_LOG(LogPlayFabTest, Log, TEXT("WriteEvent Succeeded"));
 }
 
-void PlayFabApiTest_WriteEvent::OnError(const PlayFab::FPlayFabError& ErrorResult) const
+void PlayFabApiTest_WriteEvent::OnError(const PlayFab::FPlayFabCppError& ErrorResult) const
 {
 	UE_LOG(LogPlayFabTest, Error, TEXT("WriteEvent Failed: %s"), *(ErrorResult.ErrorMessage));
 }
@@ -666,7 +668,7 @@ void PlayFabApiTest_GetEntityToken::OnSuccess(const PlayFab::AuthenticationModel
 	UE_LOG(LogPlayFabTest, Log, TEXT("GetEntityToken Succeeded"));
 }
 
-void PlayFabApiTest_GetEntityToken::OnError(const PlayFab::FPlayFabError& ErrorResult) const
+void PlayFabApiTest_GetEntityToken::OnError(const PlayFab::FPlayFabCppError& ErrorResult) const
 {
 	UE_LOG(LogPlayFabTest, Error, TEXT("GetEntityToken Failed: %s"), *(ErrorResult.ErrorMessage));
 }
@@ -706,7 +708,7 @@ void PlayFabApiTest_ObjectApi::OnSuccess(const PlayFab::DataModels::FGetObjectsR
 	UE_LOG(LogPlayFabTest, Log, TEXT("ObjectApi Succeeded"));
 }
 
-void PlayFabApiTest_ObjectApi::OnError(const PlayFab::FPlayFabError& ErrorResult) const
+void PlayFabApiTest_ObjectApi::OnError(const PlayFab::FPlayFabCppError& ErrorResult) const
 {
 	UE_LOG(LogPlayFabTest, Error, TEXT("ObjectApi Failed: %s"), *(ErrorResult.ErrorMessage));
 }

--- a/targets/UnrealMarketplacePlugin/examplesource/ExampleProject/Source/ExampleProject/PlayFabApiTests.h
+++ b/targets/UnrealMarketplacePlugin/examplesource/ExampleProject/Source/ExampleProject/PlayFabApiTests.h
@@ -16,21 +16,12 @@
 #include "Core/PlayFabDataAPI.h"
 #include "Core/PlayFabServerDataModels.h"
 #include "Core/PlayFabServerAPI.h"
+#include "PlayFabBaseModel.h"
+#include "PlayFabError.h"
 
 #include "Misc/AutomationTest.h"
 
 DECLARE_LOG_CATEGORY_EXTERN(LogPlayFabTest, Log, All);
-
-// forward declaration
-namespace PlayFab
-{
-	namespace ClientModels
-	{
-		struct FLoginResult;
-	}
-
-	struct FPlayFabError;
-}
 
 /*
 * ==== LoginWithEmail ====
@@ -43,7 +34,7 @@ public:
 	bool Update() override;
 private:
 	void OnSuccess(const PlayFab::ClientModels::FLoginResult& result) const;
-	void OnError(const PlayFab::FPlayFabError& ErrorResult) const;
+	void OnError(const PlayFab::FPlayFabCppError& ErrorResult) const;
 
 	FString email;
 	FString password;
@@ -61,7 +52,7 @@ public:
 	bool Update() override;
 private:
 	void OnSuccess(const PlayFab::ClientModels::FLoginResult& result) const;
-	void OnError(const PlayFab::FPlayFabError& ErrorResult) const;
+	void OnError(const PlayFab::FPlayFabCppError& ErrorResult) const;
 
 	FString customId;
 	PlayFabClientPtr clientAPI = nullptr;
@@ -78,7 +69,7 @@ public:
 	bool Update() override;
 private:
 	void OnSuccess(const PlayFab::ClientModels::FLoginResult& result) const;
-	void OnError(const PlayFab::FPlayFabError& ErrorResult) const;
+	void OnError(const PlayFab::FPlayFabCppError& ErrorResult) const;
 
 	int tickCounter = 0;
 	FString customId;
@@ -97,7 +88,7 @@ public:
 private:
 	void OnSuccess(const PlayFab::ClientModels::FGetUserDataResult& result) const;
 	void CheckTimestamp(const FDateTime& updateTime) const;
-	void OnError(const PlayFab::FPlayFabError& ErrorResult) const;
+	void OnError(const PlayFab::FPlayFabCppError& ErrorResult) const;
 
 	FString TEST_DATA_KEY_1;
 	FString TEST_DATA_KEY_2;
@@ -114,7 +105,7 @@ public:
 	bool Update() override;
 private:
 	void OnSuccess(const PlayFab::ClientModels::FUpdateUserDataResult& result) const;
-	void OnError(const PlayFab::FPlayFabError& ErrorResult) const;
+	void OnError(const PlayFab::FPlayFabCppError& ErrorResult) const;
 
 	FString TEST_DATA_KEY_1;
 	FString TEST_DATA_KEY_2;
@@ -134,7 +125,7 @@ public:
 	bool Update() override;
 private:
 	void OnSuccess(const PlayFab::ClientModels::FGetPlayerStatisticsResult& result) const;
-	void OnError(const PlayFab::FPlayFabError& ErrorResult) const;
+	void OnError(const PlayFab::FPlayFabCppError& ErrorResult) const;
 
 	FString TEST_STAT_NAME;
 	int expectedValue = -1;
@@ -150,7 +141,7 @@ public:
 	bool Update() override;
 private:
 	void OnSuccess(const PlayFab::ClientModels::FUpdatePlayerStatisticsResult& result) const;
-	void OnError(const PlayFab::FPlayFabError& ErrorResult) const;
+	void OnError(const PlayFab::FPlayFabCppError& ErrorResult) const;
 
 	FString TEST_STAT_NAME;
 	int updateValue = -1;
@@ -169,7 +160,7 @@ public:
 	bool Update() override;
 private:
 	void OnSuccess(const PlayFab::ClientModels::FGetLeaderboardResult& result) const;
-	void OnError(const PlayFab::FPlayFabError& ErrorResult) const;
+	void OnError(const PlayFab::FPlayFabCppError& ErrorResult) const;
 
 	FString TEST_STAT_NAME;
 	bool expectSuccess = false;
@@ -185,7 +176,7 @@ public:
 	bool Update() override;
 private:
 	void OnSuccess(const PlayFab::ServerModels::FGetLeaderboardResult& result) const;
-	void OnError(const PlayFab::FPlayFabError& ErrorResult) const;
+	void OnError(const PlayFab::FPlayFabCppError& ErrorResult) const;
 
 	FString TEST_STAT_NAME;
 
@@ -203,7 +194,7 @@ public:
 	bool Update() override;
 private:
 	void OnSuccess(const PlayFab::ClientModels::FListUsersCharactersResult& result) const;
-	void OnError(const PlayFab::FPlayFabError& ErrorResult) const;
+	void OnError(const PlayFab::FPlayFabCppError& ErrorResult) const;
 
 	PlayFabClientPtr clientAPI = nullptr;
 };
@@ -219,7 +210,7 @@ public:
 	bool Update() override;
 private:
 	void OnSuccess(const PlayFab::ClientModels::FGetAccountInfoResult& result) const;
-	void OnError(const PlayFab::FPlayFabError& ErrorResult) const;
+	void OnError(const PlayFab::FPlayFabCppError& ErrorResult) const;
 
 	PlayFabClientPtr clientAPI = nullptr;
 };
@@ -235,7 +226,7 @@ public:
 	bool Update() override;
 private:
 	void OnSuccess(const PlayFab::ClientModels::FExecuteCloudScriptResult& result) const;
-	void OnError(const PlayFab::FPlayFabError& ErrorResult) const;
+	void OnError(const PlayFab::FPlayFabCppError& ErrorResult) const;
 
 	FString functionName;
 	bool expectFail;
@@ -254,7 +245,7 @@ public:
 	bool Update() override;
 private:
 	void OnSuccess(const PlayFab::ClientModels::FWriteEventResponse& result) const;
-	void OnError(const PlayFab::FPlayFabError& ErrorResult) const;
+	void OnError(const PlayFab::FPlayFabCppError& ErrorResult) const;
 
 	FString functionName;
 	bool expectFail;
@@ -274,7 +265,7 @@ public:
 	bool Update() override;
 private:
 	void OnSuccess(const PlayFab::AuthenticationModels::FGetEntityTokenResponse& result) const;
-	void OnError(const PlayFab::FPlayFabError& ErrorResult) const;
+	void OnError(const PlayFab::FPlayFabCppError& ErrorResult) const;
 
 	PlayFabAuthenticationPtr authenticationAPI = nullptr;
 };
@@ -291,7 +282,7 @@ public:
 	bool Update() override;
 private:
 	void OnSuccess(const PlayFab::DataModels::FGetObjectsResponse& result) const;
-	void OnError(const PlayFab::FPlayFabError& ErrorResult) const;
+	void OnError(const PlayFab::FPlayFabCppError& ErrorResult) const;
 
 	PlayFabDataPtr dataAPI = nullptr;
 };

--- a/targets/UnrealMarketplacePlugin/makeCpp.js
+++ b/targets/UnrealMarketplacePlugin/makeCpp.js
@@ -600,15 +600,15 @@ function getRequestActions(tabbing, apiCall) {
             + tabbing + "}\n";
     else if (apiCall.auth === "EntityToken")
         return tabbing + "if (PlayFabSettings::GetEntityToken().Len() == 0) {\n"
-            + tabbing + "    UE_LOG(LogPlayFab, Error, TEXT(\"You must call GetEntityToken API Method before calling this function.\"));\n"
+            + tabbing + "    UE_LOG(LogPlayFabCpp, Error, TEXT(\"You must call GetEntityToken API Method before calling this function.\"));\n"
             + tabbing + "}\n";
     else if (apiCall.auth === "SecretKey")
         return tabbing + "if (PlayFabSettings::GetDeveloperSecretKey().Len() == 0) {\n"
-            + tabbing + "    UE_LOG(LogPlayFab, Error, TEXT(\"You must first set your PlayFab developerSecretKey to use this function (Unreal Settings Menu, or in C++ code)\"));\n"
+            + tabbing + "    UE_LOG(LogPlayFabCpp, Error, TEXT(\"You must first set your PlayFab developerSecretKey to use this function (Unreal Settings Menu, or in C++ code)\"));\n"
             + tabbing + "}\n";
     else if (apiCall.auth === "SessionTicket")
         return tabbing + "if (PlayFabSettings::GetClientSessionTicket().Len() == 0) {\n"
-            + tabbing + "    UE_LOG(LogPlayFab, Error, TEXT(\"You must log in before calling this function\"));\n"
+            + tabbing + "    UE_LOG(LogPlayFabCpp, Error, TEXT(\"You must log in before calling this function\"));\n"
             + tabbing + "}\n";
     else if (apiCall.result === "LoginResult" || apiCall.request === "RegisterPlayFabUserRequest")
         return tabbing + "if (PlayFabSettings::GetTitleId().Len() > 0)\n"

--- a/targets/UnrealMarketplacePlugin/source/PlayFab/Source/PlayFab/Classes/PlayFabBaseModel.h.ejs
+++ b/targets/UnrealMarketplacePlugin/source/PlayFab/Source/PlayFab/Classes/PlayFabBaseModel.h.ejs
@@ -7,12 +7,12 @@
 //////////////////////////////////////////////////////////////////////////////////////////////
 
 #include "CoreMinimal.h"
-#include "PlayFabBpBaseModel.generated.h"
+#include "PlayFabBaseModel.generated.h"
 
 class UPlayFabJsonObject;
 
 USTRUCT(BlueprintType)
-struct FPlayFabError
+struct PLAYFAB_API FPlayFabError
 {
     GENERATED_USTRUCT_BODY()
 
@@ -42,7 +42,7 @@ struct FPlayFabError
 };
 
 USTRUCT(BlueprintType)
-struct FPlayFabBpBaseModel
+struct PLAYFAB_API FPlayFabBaseModel
 {
     GENERATED_USTRUCT_BODY()
 

--- a/targets/UnrealMarketplacePlugin/source/PlayFab/Source/PlayFab/Private/PlayFabBaseModel.cpp.ejs
+++ b/targets/UnrealMarketplacePlugin/source/PlayFab/Source/PlayFab/Private/PlayFabBaseModel.cpp.ejs
@@ -4,11 +4,9 @@
 // This files holds the code for the play fab base model.
 //////////////////////////////////////////////////////////////////////////////////////////////
 
-#include "PlayFabBpBaseModel.h"
+#include "PlayFabBaseModel.h"
 #include "PlayFabJsonObject.h"
 #include "PlayFabPrivate.h"
-
-#include "Json.h"
 
 const int ERROR_DETAILS_INIT_BUFFER_SIZE = 10000;
 

--- a/targets/UnrealMarketplacePlugin/source/PlayFab/Source/PlayFabCpp/Private/Core/PlayFabCppBaseModel.cpp.ejs
+++ b/targets/UnrealMarketplacePlugin/source/PlayFab/Source/PlayFabCpp/Private/Core/PlayFabCppBaseModel.cpp.ejs
@@ -100,7 +100,7 @@ FDateTime PlayFab::readDatetime(const TSharedPtr<FJsonValue>& value)
     FString DateString = value->AsString();
     if (!FDateTime::ParseIso8601(*DateString, DateTimeOut))
     {
-        UE_LOG(LogPlayFab, Error, TEXT("readDatetime - Unable to import FDateTime from Iso8601 String"));
+        UE_LOG(LogPlayFabCpp, Error, TEXT("readDatetime - Unable to import FDateTime from Iso8601 String"));
     }
 
     return DateTimeOut;

--- a/targets/UnrealMarketplacePlugin/source/PlayFab/Source/PlayFabCpp/Private/Core/PlayFabResultHandler.cpp.ejs
+++ b/targets/UnrealMarketplacePlugin/source/PlayFab/Source/PlayFabCpp/Private/Core/PlayFabResultHandler.cpp.ejs
@@ -16,7 +16,7 @@ int PlayFabRequestHandler::GetPendingCalls()
 TSharedRef<IHttpRequest> PlayFabRequestHandler::SendRequest(const FString& url, const FString& callBody, const FString& authKey, const FString& authValue)
 {
     if (PlayFabSettings::GetTitleId().Len() == 0) {
-        UE_LOG(LogPlayFab, Error, TEXT("You must define a titleID before making API Calls."));
+        UE_LOG(LogPlayFabCpp, Error, TEXT("You must define a titleID before making API Calls."));
     }
     PlayFabRequestHandler::pendingCalls += 1;
 
@@ -33,7 +33,7 @@ TSharedRef<IHttpRequest> PlayFabRequestHandler::SendRequest(const FString& url, 
     return HttpRequest;
 }
 
-bool PlayFabRequestHandler::DecodeRequest(FHttpRequestPtr HttpRequest, FHttpResponsePtr HttpResponse, bool bSucceeded, PlayFab::FPlayFabCppBaseModel& OutResult, PlayFab::FPlayFabError& OutError)
+bool PlayFabRequestHandler::DecodeRequest(FHttpRequestPtr HttpRequest, FHttpResponsePtr HttpResponse, bool bSucceeded, PlayFab::FPlayFabCppBaseModel& OutResult, PlayFab::FPlayFabCppError& OutError)
 {
     PlayFabRequestHandler::pendingCalls -= 1;
 
@@ -87,12 +87,12 @@ bool PlayFabRequestHandler::DecodeRequest(FHttpRequestPtr HttpRequest, FHttpResp
     return false;
 }
 
-bool PlayFabRequestHandler::DecodeError(TSharedPtr<FJsonObject> JsonObject, PlayFab::FPlayFabError& OutError)
+bool PlayFabRequestHandler::DecodeError(TSharedPtr<FJsonObject> JsonObject, PlayFab::FPlayFabCppError& OutError)
 {
     // check if returned json indicates an error
     if (JsonObject->HasField(TEXT("errorCode")))
     {
-        // deserialize the FPlayFabError object 
+        // deserialize the FPlayFabCppError object 
         JsonObject->TryGetNumberField(TEXT("errorCode"), OutError.ErrorCode);
         JsonObject->TryGetNumberField(TEXT("code"), OutError.HttpCode);
         JsonObject->TryGetStringField(TEXT("status"), OutError.HttpStatus);

--- a/targets/UnrealMarketplacePlugin/source/PlayFab/Source/PlayFabCpp/Private/PlayFab.cpp.ejs
+++ b/targets/UnrealMarketplacePlugin/source/PlayFab/Source/PlayFabCpp/Private/PlayFab.cpp.ejs
@@ -8,7 +8,7 @@
 <% for(var i = 0; i < apis.length; i++) { var api = apis[i];
 %>#include "Core/PlayFab<%- api.name %>API.h"
 <% } %>
-DEFINE_LOG_CATEGORY(LogPlayFab);
+DEFINE_LOG_CATEGORY(LogPlayFabCpp);
 
 class FPlayFabModule : public IPlayFabModuleInterface
 {

--- a/targets/UnrealMarketplacePlugin/source/PlayFab/Source/PlayFabCpp/Public/Core/PlayFabCppBaseModel.h.ejs
+++ b/targets/UnrealMarketplacePlugin/source/PlayFab/Source/PlayFabCpp/Public/Core/PlayFabCppBaseModel.h.ejs
@@ -11,7 +11,7 @@ namespace PlayFab
     typedef TSharedRef< TJsonReader<TCHAR> > JsonReader;
 
     template <typename BoxedType>
-    class Boxed
+    class PLAYFABCPP_API Boxed
     {
     public:
         BoxedType mValue;

--- a/targets/UnrealMarketplacePlugin/source/PlayFab/Source/PlayFabCpp/Public/Core/PlayFabError.h.ejs
+++ b/targets/UnrealMarketplacePlugin/source/PlayFab/Source/PlayFabCpp/Public/Core/PlayFabError.h.ejs
@@ -8,7 +8,7 @@
 namespace PlayFab
 {
 
-    enum PlayFabErrorCode
+    enum PLAYFABCPP_API PlayFabErrorCode
     {
         PlayFabErrorHostnameNotFound=1,
         PlayFabErrorConnectionTimeout,
@@ -18,7 +18,7 @@ namespace PlayFab
         <% } %>PlayFabError<% var errorProps = errors[errorList[errorList.length-1]] %><%- errorProps.name %> = <%- errorProps.id %>
     };
 
-    struct FPlayFabError
+    struct PLAYFABCPP_API FPlayFabCppError
     {
         int32 HttpCode;
         FString HttpStatus;
@@ -38,5 +38,5 @@ namespace PlayFab
         }
     };
 
-    DECLARE_DELEGATE_OneParam(FPlayFabErrorDelegate, const FPlayFabError&);
+    DECLARE_DELEGATE_OneParam(FPlayFabErrorDelegate, const FPlayFabCppError&);
 }

--- a/targets/UnrealMarketplacePlugin/source/PlayFab/Source/PlayFabCpp/Public/Core/PlayFabResultHandler.h.ejs
+++ b/targets/UnrealMarketplacePlugin/source/PlayFab/Source/PlayFabCpp/Public/Core/PlayFabResultHandler.h.ejs
@@ -16,7 +16,7 @@ namespace PlayFab
     public:
         static int GetPendingCalls();
         static TSharedRef<IHttpRequest> SendRequest(const FString& url, const FString& callBody, const FString& authKey, const FString& authValue);
-        static bool DecodeRequest(FHttpRequestPtr HttpRequest, FHttpResponsePtr HttpResponse, bool bSucceeded, PlayFab::FPlayFabCppBaseModel& OutResult, PlayFab::FPlayFabError& OutError);
-        static bool DecodeError(TSharedPtr<FJsonObject> JsonObject, PlayFab::FPlayFabError& OutError);
+        static bool DecodeRequest(FHttpRequestPtr HttpRequest, FHttpResponsePtr HttpResponse, bool bSucceeded, PlayFab::FPlayFabCppBaseModel& OutResult, PlayFab::FPlayFabCppError& OutError);
+        static bool DecodeError(TSharedPtr<FJsonObject> JsonObject, PlayFab::FPlayFabCppError& OutError);
     };
 };

--- a/targets/UnrealMarketplacePlugin/source/PlayFab/Source/PlayFabCpp/Public/PlayFab.h.ejs
+++ b/targets/UnrealMarketplacePlugin/source/PlayFab/Source/PlayFabCpp/Public/PlayFab.h.ejs
@@ -1,11 +1,11 @@
 <%- copyright %>
 
-  #pragma once
+#pragma once
 
-  #include "CoreMinimal.h"
-  #include "Modules/ModuleManager.h"
+#include "CoreMinimal.h"
+#include "Modules/ModuleManager.h"
 
-  DECLARE_LOG_CATEGORY_EXTERN(LogPlayFab, Log, All);
+DECLARE_LOG_CATEGORY_EXTERN(LogPlayFabCpp, Log, All);
 
 // forward declaration of classes
 namespace PlayFab

--- a/targets/UnrealMarketplacePlugin/templates/PlayFab/PlayFab_API.cpp.ejs
+++ b/targets/UnrealMarketplacePlugin/templates/PlayFab/PlayFab_API.cpp.ejs
@@ -119,7 +119,7 @@ for(var subgroup in api.subgroups)
 <%            %>}
 <%            %>
 <%            %>// Implements FOnPlayFab<%- api.name %>RequestCompleted
-<%            %>void UPlayFab<%- api.name %>API::Helper<%- apiCall.name %>(FPlayFabBpBaseModel response, UObject* customData, bool successful)
+<%            %>void UPlayFab<%- api.name %>API::Helper<%- apiCall.name %>(FPlayFabBaseModel response, UObject* customData, bool successful)
 <%            %>{
 <%            %>    FPlayFabError error = response.responseError;
 <%            %>    if (error.hasError && OnFailure.IsBound())
@@ -183,7 +183,7 @@ void UPlayFab<%- api.name %>API::OnProcessRequestComplete(FHttpRequestPtr Reques
         return;
     }
 
-    FPlayFabBpBaseModel myResponse;
+    FPlayFabBaseModel myResponse;
 
     // Check we have result to process further
     if (!bWasSuccessful)

--- a/targets/UnrealMarketplacePlugin/templates/PlayFab/PlayFab_API.h.ejs
+++ b/targets/UnrealMarketplacePlugin/templates/PlayFab/PlayFab_API.h.ejs
@@ -12,14 +12,14 @@
 #include "CoreMinimal.h"
 #include "Http.h"
 #include "Net/OnlineBlueprintCallProxyBase.h"
-#include "PlayFabBpBaseModel.h"
+#include "PlayFabBaseModel.h"
 #include "PlayFab<%- api.name %>Models.h"
 #include "PlayFab<%- api.name %>API.generated.h"
 
-DECLARE_DYNAMIC_MULTICAST_DELEGATE_ThreeParams(FOnPlayFab<%- api.name %>RequestCompleted, FPlayFabBpBaseModel, response, UObject*, customData, bool, successful);
+DECLARE_DYNAMIC_MULTICAST_DELEGATE_ThreeParams(FOnPlayFab<%- api.name %>RequestCompleted, FPlayFabBaseModel, response, UObject*, customData, bool, successful);
 
 UCLASS(Blueprintable, BlueprintType)
-class UPlayFab<%- api.name %>API : public UOnlineBlueprintCallProxyBase
+class PLAYFAB_API UPlayFab<%- api.name %>API : public UOnlineBlueprintCallProxyBase
 {
     GENERATED_UCLASS_BODY()
 
@@ -80,7 +80,7 @@ public:
 <%            %>
 <%            %>    // Implements FOnPlayFab<%- api.name %>RequestCompleted
 <%            %>    UFUNCTION(BlueprintCallable, Category = "PlayFab | <%- api.name %> | <%- api.subgroups[subgroup].name %> ", meta = (BlueprintInternalUseOnly = "true"))
-<%            %>        void Helper<%- apiCall.name %>(FPlayFabBpBaseModel response, UObject* customData, bool successful);
+<%            %>        void Helper<%- apiCall.name %>(FPlayFabBaseModel response, UObject* customData, bool successful);
 <%            %>
 <%
             }

--- a/targets/UnrealMarketplacePlugin/templates/PlayFab/PlayFab_Models.h.ejs
+++ b/targets/UnrealMarketplacePlugin/templates/PlayFab/PlayFab_Models.h.ejs
@@ -57,7 +57,7 @@ for(var subgroup in api.subgroups)
 %>
 <%- generateApiSummary("", datatype, "description")
 %>USTRUCT(BlueprintType)
-struct F<%- api.name %><%- getDataTypeSafeName(datatype, "name") %>
+struct PLAYFAB_API F<%- api.name %><%- getDataTypeSafeName(datatype, "name") %>
 {
     GENERATED_USTRUCT_BODY()
 public:

--- a/targets/UnrealMarketplacePlugin/templates/PlayFabCpp/core/PlayFab_API.cpp.ejs
+++ b/targets/UnrealMarketplacePlugin/templates/PlayFabCpp/core/PlayFab_API.cpp.ejs
@@ -85,7 +85,7 @@ bool UPlayFab<%- api.name %>API::<%- apiCall.name %>(
 void UPlayFab<%- api.name %>API::On<%- apiCall.name %>Result(FHttpRequestPtr HttpRequest, FHttpResponsePtr HttpResponse, bool bSucceeded, F<%- apiCall.name %>Delegate SuccessDelegate, FPlayFabErrorDelegate ErrorDelegate)
 {
     <%- api.name %>Models::F<%- apiCall.result%> outResult;
-    FPlayFabError errorResult;
+    FPlayFabCppError errorResult;
     if (PlayFabRequestHandler::DecodeRequest(HttpRequest, HttpResponse, bSucceeded, outResult, errorResult))
     {
 <%- getResultActions("        ", apiCall)

--- a/targets/UnrealMarketplacePlugin/templates/PlayFabCpp/core/PlayFab_DataModels.h.ejs
+++ b/targets/UnrealMarketplacePlugin/templates/PlayFabCpp/core/PlayFab_DataModels.h.ejs
@@ -4,7 +4,7 @@
 #pragma once
 
 #include "CoreMinimal.h"
-#include "Core/PlayFabCppBaseModel.h"
+#include "PlayFabCppBaseModel.h"
 
 namespace PlayFab
 {
@@ -21,7 +21,7 @@ namespace <%- api.name %>Models
     PLAYFABCPP_API <%- datatype.name %> read<%- datatype.name %>FromValue(const TSharedPtr<FJsonValue>& value);
     PLAYFABCPP_API <%- datatype.name %> read<%- datatype.name %>FromValue(const FString& value);
 <% } else { %>
-    struct PLAYFABCPP_API F<%- datatype.name %> : public FPlayFabCppBaseModel
+    struct PLAYFABCPP_API F<%- datatype.name %> : public PlayFab::FPlayFabCppBaseModel
     {
 <% for(var i in datatype.properties) { var property = datatype.properties[i]
 %><%- generateApiSummary("        ", property, "description")


### PR DESCRIPTION
LogPlayFab -> LogPlayFabCpp
FPlayFabError -> FPlayFabCppError
FPlayFabBaseModel -> FPlayFabCppBaseModel
Adding some missing module class/struct tags
Adding an include that will theoretically solve the UPackage error that Unreal saw (Can't repro)
Adding some dependencies that will theoretically solve some Json related issues we can't repro
Adding some missing includes, which only show up as a problem when Unity build is off
Fixing some nonstandard tabbing
Fixing a cross-module import which was totally wrong
Reverting a BP module rename which would possibly have caused BP breaking changes
