### PR TITLE
Greg pettyjohn/boxed fix

### DIFF
--- a/targets/WindowsSdk/source/build/TestSrc/PlayFabClientTest.cpp
+++ b/targets/WindowsSdk/source/build/TestSrc/PlayFabClientTest.cpp
@@ -447,7 +447,7 @@ namespace UnittestRunner
                 return;
             }
 
-            auto output = result.AccountInfo->TitleInfo->Origination.mValue; // C++ can't really do anything with this once fetched
+            auto output = result.AccountInfo->TitleInfo->Origination; // C++ can't really do anything with this once fetched
             testMessageReturn = "Enums tested";
         }
 
@@ -473,7 +473,7 @@ namespace UnittestRunner
             if (result.FunctionResult.is_null())
                 testMessageReturn = "Cloud Decode Failure";
             else if (!result.Error.isNull())
-                testMessageReturn = result.Error.mValue.Message;
+                testMessageReturn = result.Error->Message;
             else
                 testMessageReturn = ShortenString(result.FunctionResult[L"messageValue"].as_string());
         }

--- a/targets/WindowsSdk/source/build/TestSrc/PlayFabServerTest.cpp
+++ b/targets/WindowsSdk/source/build/TestSrc/PlayFabServerTest.cpp
@@ -130,7 +130,7 @@ namespace UnittestRunner
             if (result.FunctionResult.is_null())
                 testMessageReturn = "Cloud Decode Failure";
             else if (!result.Error.isNull())
-                testMessageReturn = result.Error.mValue.Message;
+                testMessageReturn = result.Error->Message;
             else
                 testMessageReturn = ShortenString(result.FunctionResult[L"messageValue"].as_string());
         }

--- a/targets/WindowsSdk/source/include/playfab/PlayFabBaseModel.h
+++ b/targets/WindowsSdk/source/include/playfab/PlayFabBaseModel.h
@@ -5,6 +5,7 @@
 #include <functional>
 #include <list>
 #include <map>
+#include <assert.h>
 
 namespace PlayFab
 {
@@ -44,13 +45,11 @@ namespace PlayFab
     class Boxed
     {
     public:
-        BoxedType mValue;
-
         Boxed() : mValue(), mIsSet(false) {}
         Boxed(BoxedType value) : mValue(value), mIsSet(true) {}
 
         inline Boxed& operator=(BoxedType value) { mValue = value; mIsSet = true; return *this; }
-        inline operator BoxedType() { return mValue; }
+        inline operator const BoxedType& () const { assert(notNull()); return *operator->(); }
         inline BoxedType* operator->() { return mIsSet ? &mValue : nullptr; }
         inline const BoxedType* operator->() const { return mIsSet ? &mValue : nullptr; }
 
@@ -58,6 +57,7 @@ namespace PlayFab
         inline bool notNull() const { return mIsSet; }
         inline bool isNull() const { return !mIsSet; }
     private:
+        BoxedType mValue;
         bool mIsSet;
     };
 
@@ -116,7 +116,7 @@ namespace PlayFab
         }
         else
         {
-            ToJsonUtilT(input.mValue, output);
+            ToJsonUtilT(input, output);
         }
     }
     inline void FromJsonUtilT(const web::json::value& input, Boxed<time_t>& output)
@@ -198,7 +198,7 @@ namespace PlayFab
         }
         else
         {
-            ToJsonEnum(input.mValue, output);
+            ToJsonEnum(input, output);
         }
     }
     template <typename EnumType> inline void FromJsonUtilE(const web::json::value& input, Boxed<EnumType>& output)
@@ -357,7 +357,7 @@ namespace PlayFab
         if (input.isNull())
             output = web::json::value();
         else
-            output = input.mValue.ToJson();
+            output = static_cast<ObjectType>(input).ToJson();
     }
     template <typename ObjectType> inline void FromJsonUtilO(web::json::value& input, Boxed<ObjectType>& output)
     {
@@ -476,7 +476,7 @@ namespace PlayFab
         }
         else
         {
-            ToJsonUtilP(input.mValue, output);
+            ToJsonUtilP(input, output);
         }
     }
     template <typename PrimitiveType> inline void FromJsonUtilP(const web::json::value& input, Boxed<PrimitiveType>& output)

--- a/targets/WindowsSdk/source/include/playfab/PlayFabBaseModel.h
+++ b/targets/WindowsSdk/source/include/playfab/PlayFabBaseModel.h
@@ -116,7 +116,7 @@ namespace PlayFab
         }
         else
         {
-            ToJsonUtilT(input, output);
+            ToJsonUtilT(static_cast<time_t>(input), output);
         }
     }
     inline void FromJsonUtilT(const web::json::value& input, Boxed<time_t>& output)
@@ -476,7 +476,7 @@ namespace PlayFab
         }
         else
         {
-            ToJsonUtilP(input, output);
+            ToJsonUtilP(static_cast<PrimitiveType>(input), output);
         }
     }
     template <typename PrimitiveType> inline void FromJsonUtilP(const web::json::value& input, Boxed<PrimitiveType>& output)

--- a/targets/XPlatCppSdk/source/cppsdk/include/playfab/PlayFabBaseModel.h
+++ b/targets/XPlatCppSdk/source/cppsdk/include/playfab/PlayFabBaseModel.h
@@ -113,7 +113,7 @@ namespace PlayFab
         }
         else
         {
-            ToJsonUtilT(input, output);
+            ToJsonUtilT(static_cast<time_t>(input), output);
         }
     }
     inline void FromJsonUtilT(const Json::Value& input, Boxed<time_t>& output)
@@ -465,7 +465,7 @@ namespace PlayFab
         }
         else
         {
-            ToJsonUtilP(input, output);
+            ToJsonUtilP(static_cast<PrimitiveType>(input), output);
         }
     }
     template <typename PrimitiveType> inline void FromJsonUtilP(const Json::Value& input, Boxed<PrimitiveType>& output)

--- a/targets/XPlatCppSdk/source/cppsdk/include/playfab/PlayFabBaseModel.h
+++ b/targets/XPlatCppSdk/source/cppsdk/include/playfab/PlayFabBaseModel.h
@@ -4,6 +4,7 @@
 #include <functional>
 #include <list>
 #include <map>
+#include <assert.h>
 
 #include <sstream>
 #include <iomanip>
@@ -39,13 +40,11 @@ namespace PlayFab
     class Boxed
     {
     public:
-        BoxedType mValue;
-
         Boxed() : mValue(), mIsSet(false) {}
         Boxed(BoxedType value) : mValue(value), mIsSet(true) {}
 
         inline Boxed& operator=(BoxedType value) { mValue = value; mIsSet = true; return *this; }
-        inline operator BoxedType() { return mValue; }
+        inline operator const BoxedType& () const { assert(notNull()); return *operator->(); }
         inline BoxedType* operator->() { return mIsSet ? &mValue : nullptr; }
         inline const BoxedType* operator->() const { return mIsSet ? &mValue : nullptr; }
 
@@ -53,6 +52,7 @@ namespace PlayFab
         inline bool notNull() const { return mIsSet; }
         inline bool isNull() const { return !mIsSet; }
     private:
+        BoxedType mValue;
         bool mIsSet;
     };
 
@@ -113,7 +113,7 @@ namespace PlayFab
         }
         else
         {
-            ToJsonUtilT(input.mValue, output);
+            ToJsonUtilT(input, output);
         }
     }
     inline void FromJsonUtilT(const Json::Value& input, Boxed<time_t>& output)
@@ -193,7 +193,7 @@ namespace PlayFab
         }
         else
         {
-            ToJsonEnum(input.mValue, output);
+            ToJsonEnum(input, output);
         }
     }
     template <typename EnumType> inline void FromJsonUtilE(const Json::Value& input, Boxed<EnumType>& output)
@@ -348,7 +348,7 @@ namespace PlayFab
         if (input.isNull())
             output = Json::Value();
         else
-            output = input.mValue.ToJson();
+            output = static_cast<ObjectType>(input).ToJson();
     }
     template <typename ObjectType> inline void FromJsonUtilO(Json::Value& input, Boxed<ObjectType>& output)
     {
@@ -465,7 +465,7 @@ namespace PlayFab
         }
         else
         {
-            ToJsonUtilP(input.mValue, output);
+            ToJsonUtilP(input, output);
         }
     }
     template <typename PrimitiveType> inline void FromJsonUtilP(const Json::Value& input, Boxed<PrimitiveType>& output)

--- a/targets/XPlatCppSdk/source/testapps/cppWindowsTestApp/cppWindowsTestApp.cpp
+++ b/targets/XPlatCppSdk/source/testapps/cppWindowsTestApp/cppWindowsTestApp.cpp
@@ -22,14 +22,14 @@ void OnPlayFabFail(const PlayFab::PlayFabError& error, void*)
 
 void OnGetProfile(const PlayFab::ProfilesModels::GetEntityProfileResponse& result, void*)
 {
-    printf(("========== PlayFab Profiles Success: " + result.Profile.mValue.Entity.mValue.Type + "\n").c_str());
+    printf(("========== PlayFab Profiles Success: " + result.Profile->Entity->Type + "\n").c_str());
 }
 
 void OnGetEntityToken(const PlayFab::AuthenticationModels::GetEntityTokenResponse& result, void*)
 {
     printf(("========== PlayFab GetEntityToken Success: " + result.EntityToken + "\n").c_str());
-    _id = result.Entity.mValue.Id;
-    _type = result.Entity.mValue.Type;
+    _id = result.Entity->Id;
+    _type = result.Entity->Type;
 
 
     auto req = PlayFab::ProfilesModels::GetEntityProfileRequest();


### PR DESCRIPTION
This fixes the infinite recursion problems introduced in the previous iteration.
Infinite recursions were happening because certain template functions were specialized on types which made the type-cast ambiguous between Boxed<T> and T.  Introducing static_cast<T> forces the cast operator to be called as desired.