### PR TITLE
Fixed UnrealMarketPlace plugin crashing packaged builds upon launch

### DIFF
--- a/targets/UnrealMarketplacePlugin/source/PlayFab/Source/PlayFabCpp/Private/Core/PlayFabSettings.cpp.ejs
+++ b/targets/UnrealMarketplacePlugin/source/PlayFab/Source/PlayFabCpp/Private/Core/PlayFabSettings.cpp.ejs
@@ -5,12 +5,12 @@
 
 namespace PlayFab
 {
-	const FString PlayFabSettings::sdkVersion = IPlayFabCommonModuleInterface::Get().GetSdkVersion();
-	const FString PlayFabSettings::buildIdentifier = IPlayFabCommonModuleInterface::Get().GetBuildIdentifier();
-	const FString PlayFabSettings::versionString = IPlayFabCommonModuleInterface::Get().GetVersionString();
+	FString PlayFabSettings::sdkVersion;
+	FString PlayFabSettings::buildIdentifier;
+	FString PlayFabSettings::versionString;
 
-	const FString PlayFabSettings::AD_TYPE_IDFA = IPlayFabCommonModuleInterface::Get().GetAD_TYPE_IDFA();
-	const FString PlayFabSettings::AD_TYPE_ANDROID_ID = IPlayFabCommonModuleInterface::Get().GetAD_TYPE_ANDROID_ID();
+	FString PlayFabSettings::AD_TYPE_IDFA;
+	FString PlayFabSettings::AD_TYPE_ANDROID_ID;
 
 	// Getters
 	FString PlayFabSettings::GetServerURL()

--- a/targets/UnrealMarketplacePlugin/source/PlayFab/Source/PlayFabCpp/Private/PlayFab.cpp.ejs
+++ b/targets/UnrealMarketplacePlugin/source/PlayFab/Source/PlayFabCpp/Private/PlayFab.cpp.ejs
@@ -3,6 +3,7 @@
 #include "PlayFab.h"
 
 #include "PlayFabSettings.h"
+#include "PlayFabCommon.h"
 
 // Api's
 <% for(var i = 0; i < apis.length; i++) { var api = apis[i];
@@ -29,6 +30,13 @@ class FPlayFabModule : public IPlayFabModuleInterface
 
 void FPlayFabModule::StartupModule()
 {
+    PlayFab::PlayFabSettings::sdkVersion = IPlayFabCommonModuleInterface::Get().GetSdkVersion();
+    PlayFab::PlayFabSettings::buildIdentifier = IPlayFabCommonModuleInterface::Get().GetBuildIdentifier();
+    PlayFab::PlayFabSettings::versionString = IPlayFabCommonModuleInterface::Get().GetVersionString();
+
+    PlayFab::PlayFabSettings::AD_TYPE_IDFA = IPlayFabCommonModuleInterface::Get().GetAD_TYPE_IDFA();
+    PlayFab::PlayFabSettings::AD_TYPE_ANDROID_ID = IPlayFabCommonModuleInterface::Get().GetAD_TYPE_ANDROID_ID();
+
     // create the API
 	<% for(var a in apis) { %>
         <%- apis[a].name %>API = MakeShareable(new PlayFab::UPlayFab<%- apis[a].name %>API());<% } %>

--- a/targets/UnrealMarketplacePlugin/source/PlayFab/Source/PlayFabCpp/Public/Core/PlayFabSettings.h.ejs
+++ b/targets/UnrealMarketplacePlugin/source/PlayFab/Source/PlayFabCpp/Public/Core/PlayFabSettings.h.ejs
@@ -10,9 +10,9 @@ namespace PlayFab
 	class PlayFabSettings
 	{
 	public:
-		static const FString sdkVersion;
-		static const FString buildIdentifier;
-		static const FString versionString;
+		static FString sdkVersion;
+		static FString buildIdentifier;
+		static FString versionString;
 
 		static bool GetUseDevelopmentEnvironment();
 		static FString GetServerURL();
@@ -38,8 +38,8 @@ namespace PlayFab
 		static void SetAdvertisingIdValue(const FString& advertisingIdValue);
 		static void SetDisableAdvertising(bool disableAdvertising);
 		
-		static const FString AD_TYPE_IDFA;
-		static const FString AD_TYPE_ANDROID_ID;
+		static FString AD_TYPE_IDFA;
+		static FString AD_TYPE_ANDROID_ID;
 
         static FString GetUrl(const FString& callPath);
     };


### PR DESCRIPTION
The initialization of static variables in the PlayFabSettings.cpp crashes on packaged builds due to the PlayFabSettings module not being loaded during C++ static initialization phase. It only works in the Unreal editor because there each module is a separate dll loaded one after the other in an order that respects their dependence.