### PR TITLE
Refactored HTTP layer to support plugin architecture

### DIFF
--- a/SDKGenerator.njsproj
+++ b/SDKGenerator.njsproj
@@ -716,8 +716,10 @@
     <Content Include="targets\XPlatCppSdk\source\cppsdk\configWindows.json" />
     <Content Include="targets\XPlatCppSdk\source\cppsdk\include\playfab\PlayFabCallRequestContainer.h" />
     <Content Include="targets\XPlatCppSdk\source\cppsdk\include\playfab\PlayFabBaseModel.h" />
+    <Content Include="targets\XPlatCppSdk\source\cppsdk\include\playfab\PlayFabCallRequestContainerBase.h" />
     <Content Include="targets\XPlatCppSdk\source\cppsdk\include\playfab\PlayFabPluginManager.h" />
     <Content Include="targets\XPlatCppSdk\source\cppsdk\source\playfab\PlayFabCallRequestContainer.cpp" />
+    <Content Include="targets\XPlatCppSdk\source\cppsdk\source\playfab\PlayFabCallRequestContainerBase.cpp" />
     <Content Include="targets\XPlatCppSdk\source\cppsdk\source\playfab\PlayFabPluginManager.cpp" />
     <Content Include="targets\XPlatCppSdk\source\LibUnitTest\LibUnitTest.vcxproj.ejs" />
     <Content Include="targets\XPlatCppSdk\source\LibUnitTest\LibUnitTest.vcxproj.filters" />

--- a/targets/XPlatCppSdk/make.js
+++ b/targets/XPlatCppSdk/make.js
@@ -218,8 +218,14 @@ function getPropertySafeName(property) {
 }
 
 function getRequestActions(tabbing, apiCall) {
+    //TODO Bug 6594: add to this titleId check. 
+    // If this titleId does not exist we should be throwing an error informing the user MUST have a titleId.
     if (apiCall.result === "LoginResult" || apiCall.result === "RegisterPlayFabUserResult")
-        return tabbing + "if (PlayFabSettings::titleId.length() > 0) request.TitleId = PlayFabSettings::titleId;\n";
+        return tabbing + "if (PlayFabSettings::titleId.length() > 0)\n"
+            + tabbing + "{\n"
+            + tabbing + "    request.TitleId = PlayFabSettings::titleId;\n"
+            + tabbing + "}\n";
+        
     if (apiCall.url === "/Authentication/GetEntityToken")
         return tabbing + "std::string authKey, authValue;\n"
             + tabbing + "if (PlayFabSettings::entityToken.length() > 0) {\n"
@@ -235,7 +241,10 @@ function getRequestActions(tabbing, apiCall) {
 
 function getResultActions(tabbing, apiCall) {
     if (apiCall.url === "/Authentication/GetEntityToken")
-        return tabbing + "if (outResult.EntityToken.length() > 0) PlayFabSettings::entityToken = outResult.EntityToken;\n";
+        return tabbing + "if (outResult.EntityToken.length() > 0)"
+            + tabbing + "{\n"
+            + tabbing + "    PlayFabSettings::entityToken = outResult.EntityToken; \n"
+            + tabbing + "}\n";
     if (apiCall.result === "LoginResult")
         return tabbing + "if (outResult.SessionTicket.length() > 0)\n"
             + tabbing + "{\n"

--- a/targets/XPlatCppSdk/source/cppsdk/XPlatCppLinux.vcxproj.ejs
+++ b/targets/XPlatCppSdk/source/cppsdk/XPlatCppLinux.vcxproj.ejs
@@ -75,6 +75,7 @@
     <ClInclude Include="include\playfab\PlayFabHttp.h" />
     <ClInclude Include="include\playfab\PlayFabSettings.h" />
     <ClInclude Include="include\playfab\PlayFabCallRequestContainer.h" />
+    <ClInclude Include="include\playfab\PlayFabCallRequestContainerBase.h" />
     <ClInclude Include="include\playfab\PlayFabPluginManager.h" />
     <ClInclude Include="stdafx.h" />
   </ItemGroup>
@@ -87,6 +88,7 @@
     <ClCompile Include="source\playfab\PlayFabHttp.cpp" />
     <ClCompile Include="source\playfab\PlayFabSettings.cpp" />
     <ClCompile Include="source\playfab\PlayFabCallRequestContainer.cpp" />
+    <ClCompile Include="source\playfab\PlayFabCallRequestContainerBase.cpp" />
     <ClCompile Include="source\playfab\PlayFabPluginManager.cpp" />
     <ClCompile Include="stdafx.cpp" />
   </ItemGroup>

--- a/targets/XPlatCppSdk/source/cppsdk/XPlatCppLinux.vcxproj.filters.ejs
+++ b/targets/XPlatCppSdk/source/cppsdk/XPlatCppLinux.vcxproj.filters.ejs
@@ -39,6 +39,9 @@
     <ClInclude Include="include\playfab\PlayFabError.h">
       <Filter>Header Files\playfab</Filter>
     </ClInclude>
+    <ClInclude Include="include\playfab\PlayFabCallRequestContainerBase.h">
+      <Filter>Header Files\playfab</Filter>
+    </ClInclude>
     <ClInclude Include="include\playfab\PlayFabCallRequestContainer.h">
       <Filter>Header Files\playfab</Filter>
     </ClInclude>
@@ -61,6 +64,9 @@
       <Filter>Source Files\playfab</Filter>
     </ClCompile>
     <ClCompile Include="source\playfab\PlayFabSettings.cpp">
+      <Filter>Source Files\playfab</Filter>
+    </ClCompile>
+    <ClCompile Include="source\playfab\PlayFabCallRequestContainerBase.cpp">
       <Filter>Source Files\playfab</Filter>
     </ClCompile>
     <ClCompile Include="source\playfab\PlayFabCallRequestContainer.cpp">

--- a/targets/XPlatCppSdk/source/cppsdk/XPlatCppWindows.vcxproj.ejs
+++ b/targets/XPlatCppSdk/source/cppsdk/XPlatCppWindows.vcxproj.ejs
@@ -121,6 +121,7 @@
     <ClInclude Include="include\playfab\PlayFabHttp.h" />
     <ClInclude Include="include\playfab\PlayFabSettings.h" />
     <ClInclude Include="include\playfab\PlayFabCallRequestContainer.h" />
+    <ClInclude Include="include\playfab\PlayFabCallRequestContainerBase.h" />
     <ClInclude Include="include\playfab\PlayFabPluginManager.h" />
     <ClInclude Include="stdafx.h" />
   </ItemGroup>
@@ -132,6 +133,7 @@
     <ClCompile Include="source\playfab\PlayFabError.cpp" />
     <ClCompile Include="source\playfab\PlayFabHttp.cpp" />
     <ClCompile Include="source\playfab\PlayFabSettings.cpp" />
+    <ClCompile Include="source\playfab\PlayFabCallRequestContainerBase.cpp" />
     <ClCompile Include="source\playfab\PlayFabCallRequestContainer.cpp" />
     <ClCompile Include="source\playfab\PlayFabPluginManager.cpp" />
     <ClCompile Include="stdafx.cpp">

--- a/targets/XPlatCppSdk/source/cppsdk/XPlatCppWindows.vcxproj.filters.ejs
+++ b/targets/XPlatCppSdk/source/cppsdk/XPlatCppWindows.vcxproj.filters.ejs
@@ -42,6 +42,9 @@
     <ClInclude Include="include\playfab\PlayFabCallRequestContainer.h">
       <Filter>Header Files\playfab</Filter>
     </ClInclude>
+    <ClInclude Include="include\playfab\PlayFabCallRequestContainerBase.h">
+      <Filter>Header Files\playfab</Filter>
+    </ClInclude>
     <ClInclude Include="include\playfab\PlayFabPluginManager.h">
       <Filter>Header Files\playfab</Filter>
     </ClInclude>
@@ -61,6 +64,9 @@
       <Filter>Source Files\playfab</Filter>
     </ClCompile>
     <ClCompile Include="source\playfab\PlayFabSettings.cpp">
+      <Filter>Source Files\playfab</Filter>
+    </ClCompile>
+    <ClCompile Include="source\playfab\PlayFabCallRequestContainerBase.cpp">
       <Filter>Source Files\playfab</Filter>
     </ClCompile>
     <ClCompile Include="source\playfab\PlayFabCallRequestContainer.cpp">

--- a/targets/XPlatCppSdk/source/cppsdk/include/playfab/PlayFabCallRequestContainer.h
+++ b/targets/XPlatCppSdk/source/cppsdk/include/playfab/PlayFabCallRequestContainer.h
@@ -6,8 +6,6 @@
 // Intellisense-only includes
 #include <curl/curl.h>
 
-#include <unordered_map>
-
 namespace PlayFab
 {
     /// <summary>
@@ -16,7 +14,11 @@ namespace PlayFab
     class CallRequestContainer : public CallRequestContainerBase
     {
     public:
-        CallRequestContainer(const CallRequestContainerBase& reqContainer);
+        CallRequestContainer(std::string url,
+            const std::unordered_map<std::string, std::string>& headers,
+            std::string requestBody,
+            CallRequestContainerCallback callback,
+            void* customData = nullptr);
 
         virtual ~CallRequestContainer() override;
 
@@ -30,7 +32,7 @@ namespace PlayFab
         std::string responseString;
         Json::Value responseJson = Json::Value::null;
         PlayFabError errorWrapper;
-        SharedVoidPointer successCallback;
+        std::shared_ptr<void> successCallback;
         ErrorCallback errorCallback;
     };
 }

--- a/targets/XPlatCppSdk/source/cppsdk/include/playfab/PlayFabCallRequestContainer.h
+++ b/targets/XPlatCppSdk/source/cppsdk/include/playfab/PlayFabCallRequestContainer.h
@@ -10,19 +10,13 @@
 
 namespace PlayFab
 {
-    typedef void(*RequestCompleteCallback)(CallRequestContainerBase& reqContainer);
-    typedef std::shared_ptr<void> SharedVoidPointer;
-
     /// <summary>
     /// Internal PlayFabHttp container for each api call
-    /// This object is reusable in its callback usage. 
-    /// A user should not hold on to this explicit object, 
-    /// but copy any needed info out of it in their callback.
     /// </summary>
     class CallRequestContainer : public CallRequestContainerBase
     {
     public:
-        CallRequestContainer(const CallRequestContainerBase& base);
+        CallRequestContainer(const CallRequestContainerBase& reqContainer);
 
         virtual ~CallRequestContainer() override;
 
@@ -36,7 +30,7 @@ namespace PlayFab
         std::string responseString;
         Json::Value responseJson = Json::Value::null;
         PlayFabError errorWrapper;
-        std::function<void(CallRequestContainerBase&)> internalCallback;
         SharedVoidPointer successCallback;
+        ErrorCallback errorCallback;
     };
 }

--- a/targets/XPlatCppSdk/source/cppsdk/include/playfab/PlayFabCallRequestContainerBase.h
+++ b/targets/XPlatCppSdk/source/cppsdk/include/playfab/PlayFabCallRequestContainerBase.h
@@ -1,0 +1,75 @@
+#pragma once
+
+#include <unordered_map>
+
+namespace PlayFab
+{
+    typedef std::shared_ptr<void> SharedVoidPointer;
+
+    //typedef std::function<void(int, std::string, void* customContext = nullptr)> CallRequestContainerCallback;
+    typedef void(*CallRequestContainerCallback)(int, std::string, void* customContext);
+
+    /// <summary>
+    /// A Container meant for holding everything necessary to make a full HTTP request and respond appropriatley
+    /// A user is expected to inherit from this if they are to make their own Http plugin.
+    /// </summary>
+    class CallRequestContainerBase
+    {
+    public:
+        
+        /// url is the relative url to the API a user wishes to call
+        /// headers should contain any optional headers that may be associated with this same API call
+        /// requestBody is the actual Json object as a string
+        /// CallRequestContainerCallback is an internal callback that will handle the logic of calling an error callback or success
+        /// externalCallback is the user's callback that they hand to us.
+        /// PlayFabError contains the error callback.
+        /// customContext can be any object a user expects to be associated with this particular transaction (id/hash etc.)
+        CallRequestContainerBase(
+            std::string url,
+            const std::unordered_map<std::string, std::string>& headers,
+            std::string requestBody,
+            CallRequestContainerCallback callback,
+            SharedVoidPointer externalCallback = nullptr,
+            ErrorCallback errorCallback = nullptr, 
+            void* customContext = nullptr);
+
+        CallRequestContainerBase(const CallRequestContainerBase& rCrc);
+        const CallRequestContainerBase& operator=(const CallRequestContainerBase& rCrc);
+
+        virtual ~CallRequestContainerBase();
+
+        std::string getUrl() const;
+        std::unordered_map<std::string, std::string> getHeaders() const;
+        std::string getRequestBody() const;
+
+        /// <summary>
+        /// This function is meant to handle logic of calling the error callback or success
+        /// </summary>
+        CallRequestContainerCallback getCallback() const;
+
+        /// <summary>
+        /// If the HTTP call fails, this function is called.
+        /// The user's other function will not be called.
+        /// </summary>
+        ErrorCallback getErrorCallback() const;
+
+        /// <summary>
+        /// returns a user specific callback (like an OnLogInWithCustomId)
+        /// </summary>
+        SharedVoidPointer* getAPICallback();
+
+        void* getCustomContext() const;
+
+    private:
+        std::string mUrl;
+        std::unordered_map<std::string, std::string> mHeaders;
+        std::string mRequestBody;
+        CallRequestContainerCallback mCallback;
+
+        ErrorCallback mErrorCallback;
+        //std::function<void(CallRequestContainerBase&)> internalCallback; // this is an old version of the callback that we did internally. This should no longer be needed as it has been refactored to take different parameters
+        SharedVoidPointer mSuccessCallback;
+
+        void* mCustomContext;
+    };
+}

--- a/targets/XPlatCppSdk/source/cppsdk/include/playfab/PlayFabCallRequestContainerBase.h
+++ b/targets/XPlatCppSdk/source/cppsdk/include/playfab/PlayFabCallRequestContainerBase.h
@@ -5,7 +5,6 @@
 namespace PlayFab
 {
     class CallRequestContainerBase;
-    typedef std::shared_ptr<void> SharedVoidPointer;
     typedef void(*CallRequestContainerCallback)(int, std::string, CallRequestContainerBase&);
 
     /// <summary>
@@ -31,6 +30,10 @@ namespace PlayFab
         CallRequestContainerBase(const CallRequestContainerBase& reqContainer);
         const CallRequestContainerBase& operator=(const CallRequestContainerBase& reqContainer);
 
+        // Prevent move construction and assignment operations
+        CallRequestContainerBase(CallRequestContainerBase&&) = delete;
+        CallRequestContainerBase& operator=(CallRequestContainerBase&&) = delete;
+
         virtual ~CallRequestContainerBase();
 
         std::string getUrl() const;
@@ -51,6 +54,6 @@ namespace PlayFab
         CallRequestContainerCallback mCallback;
 
         // I never own this, I can never destroy it
-        void* mCustomData;
+        void* mCustomData; // optional user data (relayed to callback). This gives users the flexibility to tag each request with some data that can be accessed in callback.
     };
 }

--- a/targets/XPlatCppSdk/source/cppsdk/include/playfab/PlayFabHttp.h
+++ b/targets/XPlatCppSdk/source/cppsdk/include/playfab/PlayFabHttp.h
@@ -25,7 +25,7 @@ namespace PlayFab
     public:
         static IPlayFabHttp& Get();
 
-        virtual ~IPlayFabHttp();
+        virtual ~IPlayFabHttp() = 0;
 
         virtual size_t Update() = 0;
 

--- a/targets/XPlatCppSdk/source/cppsdk/include/playfab/PlayFabHttp.h
+++ b/targets/XPlatCppSdk/source/cppsdk/include/playfab/PlayFabHttp.h
@@ -29,7 +29,7 @@ namespace PlayFab
 
         virtual size_t Update() = 0;
 
-        virtual void MakePostRequest(const CallRequestContainerBase&) override { };
+        virtual void MakePostRequest(const CallRequestContainerBase&) = 0;
 
     protected:
         static std::unique_ptr<IPlayFabHttp> httpInstance;
@@ -65,8 +65,8 @@ namespace PlayFab
         std::mutex httpRequestMutex;
         bool threadRunning;
         int activeRequestCount;
-        std::vector<CallRequestContainer*> pendingRequests;
-        std::vector<CallRequestContainer*> pendingResults;
+        std::vector<CallRequestContainerBase*> pendingRequests;
+        std::vector<CallRequestContainerBase*> pendingResults;
     };
 }
 

--- a/targets/XPlatCppSdk/source/cppsdk/include/playfab/PlayFabHttp.h
+++ b/targets/XPlatCppSdk/source/cppsdk/include/playfab/PlayFabHttp.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <playfab/PlayFabCallRequestContainer.h>
+#include <playfab/PlayFabPluginManager.h>
 #include <playfab/PlayFabError.h>
 #include <functional>
 #include <memory>
@@ -19,15 +20,17 @@ namespace PlayFab
     /// <summary>
     /// Provides an interface and a static instance for https implementations
     /// </summary>
-    class IPlayFabHttp
+    class IPlayFabHttp : public IPlayFabHttpPlugin
     {
     public:
         static IPlayFabHttp& Get();
 
         virtual ~IPlayFabHttp();
 
-        virtual void AddRequest(const std::string& urlPath, const std::string& authKey, const std::string& authValue, const Json::Value& requestBody, RequestCompleteCallback internalCallback, SharedVoidPointer successCallback, ErrorCallback errorCallback, void* customData) = 0;
         virtual size_t Update() = 0;
+
+        virtual void MakePostRequest(const CallRequestContainerBase&) override { };
+
     protected:
         static std::unique_ptr<IPlayFabHttp> httpInstance;
     };
@@ -41,11 +44,16 @@ namespace PlayFab
         static void MakeInstance();
         ~PlayFabHttp() override;
 
-        void AddRequest(const std::string& urlPath, const std::string& authKey, const std::string& authValue, const Json::Value& requestBody, RequestCompleteCallback internalCallback, SharedVoidPointer successCallback, ErrorCallback errorCallback, void* customData) override;
+        virtual void MakePostRequest(const CallRequestContainerBase&) override;
+
         size_t Update() override;
+
     private:
         PlayFabHttp(); // Private constructor, to enforce singleton instance
         PlayFabHttp(const PlayFabHttp& other); // Private copy-constructor, to enforce singleton instance
+
+        PlayFabHttp(PlayFabHttp&& other) = delete;
+        PlayFabHttp& operator=(PlayFabHttp&& other) = delete;
 
         static size_t CurlReceiveData(char* buffer, size_t blockSize, size_t blockCount, void* userData);
         static void ExecuteRequest(CallRequestContainer& reqContainer);
@@ -61,3 +69,4 @@ namespace PlayFab
         std::vector<CallRequestContainer*> pendingResults;
     };
 }
+

--- a/targets/XPlatCppSdk/source/cppsdk/include/playfab/PlayFabPluginManager.h
+++ b/targets/XPlatCppSdk/source/cppsdk/include/playfab/PlayFabPluginManager.h
@@ -27,10 +27,16 @@ namespace PlayFab
 
     /// <summary>
     /// Interface of any transport SDK plugin.
+    /// All functions execute asynchronously
     /// </summary>
     class IPlayFabHttpPlugin : public IPlayFabPlugin
     {
-        virtual void AddRequest(std::string url, std::unordered_map<std::string, std::string> headers, SharedVoidPointer callback, ErrorCallback errorCallback = nullptr, void* extrabuffer = nullptr);
+    public:
+        /// <summary>
+        /// starts the process of making a post request.
+        /// A user is expected to supply their own CallRequestContainerBase
+        /// </summary>
+        virtual void MakePostRequest(const CallRequestContainerBase&) = 0;
     };
 
     /// <summary>

--- a/targets/XPlatCppSdk/source/cppsdk/source/playfab/PlayFabCallRequestContainer.cpp
+++ b/targets/XPlatCppSdk/source/cppsdk/source/playfab/PlayFabCallRequestContainer.cpp
@@ -12,30 +12,30 @@
 
 namespace PlayFab
 {
-    CallRequestContainer::CallRequestContainer(const CallRequestContainerBase& base) :
-        CallRequestContainerBase(base),
+    CallRequestContainer::CallRequestContainer(const CallRequestContainerBase& reqContainer) :
+        CallRequestContainerBase(reqContainer),
         curlHandle(nullptr),
         curlHttpHeaders(nullptr),
         finished(false),
         responseString(""),
         responseJson(Json::Value::null),
         errorWrapper(),
-        internalCallback(nullptr),
-        successCallback(nullptr)
+        successCallback(nullptr),
+        errorCallback(nullptr)
     {
-        errorWrapper.UrlPath = base.getUrl();
+        errorWrapper.UrlPath = reqContainer.getUrl();
 
-        Json::Value root;
+        Json::Value request;
         Json::Reader reader;
-        bool parsingSuccessful = reader.parse(base.getRequestBody().c_str(), root);
+        bool parsingSuccessful = reader.parse(reqContainer.getRequestBody(), request);
 
-        if(parsingSuccessful)
+        if (parsingSuccessful)
         {
-            errorWrapper.Request = base.getRequestBody();
+            errorWrapper.Request = request;
         }
         else
         {
-            throw new std::invalid_argument("The requestBody string was not in a valid Json format during MakePostRequest.");
+            throw new std::invalid_argument("The requestBody string is not in a valid Json format.");
         }
     }
 

--- a/targets/XPlatCppSdk/source/cppsdk/source/playfab/PlayFabCallRequestContainer.cpp
+++ b/targets/XPlatCppSdk/source/cppsdk/source/playfab/PlayFabCallRequestContainer.cpp
@@ -2,18 +2,14 @@
 
 #include <playfab/PlayFabCallRequestContainer.h>
 
-#ifndef _WIN32
-#include <jsoncpp/json/reader.h>
-#endif
-#ifdef _WIN32
-#include <json/reader.h>
-#endif
-
-
 namespace PlayFab
 {
-    CallRequestContainer::CallRequestContainer(const CallRequestContainerBase& reqContainer) :
-        CallRequestContainerBase(reqContainer),
+    CallRequestContainer::CallRequestContainer(std::string url,
+        const std::unordered_map<std::string, std::string>& headers,
+        std::string requestBody,
+        CallRequestContainerCallback callback,
+        void* customData) :
+        CallRequestContainerBase(url, headers, requestBody, callback, customData),
         curlHandle(nullptr),
         curlHttpHeaders(nullptr),
         finished(false),
@@ -23,19 +19,15 @@ namespace PlayFab
         successCallback(nullptr),
         errorCallback(nullptr)
     {
-        errorWrapper.UrlPath = reqContainer.getUrl();
+        errorWrapper.UrlPath = url;
 
         Json::Value request;
         Json::Reader reader;
-        bool parsingSuccessful = reader.parse(reqContainer.getRequestBody(), request);
+        bool parsingSuccessful = reader.parse(requestBody, request);
 
         if (parsingSuccessful)
         {
             errorWrapper.Request = request;
-        }
-        else
-        {
-            throw new std::invalid_argument("The requestBody string is not in a valid Json format.");
         }
     }
 

--- a/targets/XPlatCppSdk/source/cppsdk/source/playfab/PlayFabCallRequestContainer.cpp
+++ b/targets/XPlatCppSdk/source/cppsdk/source/playfab/PlayFabCallRequestContainer.cpp
@@ -2,20 +2,41 @@
 
 #include <playfab/PlayFabCallRequestContainer.h>
 
+#ifndef _WIN32
+#include <jsoncpp/json/reader.h>
+#endif
+#ifdef _WIN32
+#include <json/reader.h>
+#endif
+
+
 namespace PlayFab
 {
-    CallRequestContainer::CallRequestContainer() :
+    CallRequestContainer::CallRequestContainer(const CallRequestContainerBase& base) :
+        CallRequestContainerBase(base),
         curlHandle(nullptr),
         curlHttpHeaders(nullptr),
-        customData(nullptr),
         finished(false),
         responseString(""),
         responseJson(Json::Value::null),
         errorWrapper(),
         internalCallback(nullptr),
-        successCallback(nullptr),
-        errorCallback(nullptr)
+        successCallback(nullptr)
     {
+        errorWrapper.UrlPath = base.getUrl();
+
+        Json::Value root;
+        Json::Reader reader;
+        bool parsingSuccessful = reader.parse(base.getRequestBody().c_str(), root);
+
+        if(parsingSuccessful)
+        {
+            errorWrapper.Request = base.getRequestBody();
+        }
+        else
+        {
+            throw new std::invalid_argument("The requestBody string was not in a valid Json format during MakePostRequest.");
+        }
     }
 
     CallRequestContainer::~CallRequestContainer()

--- a/targets/XPlatCppSdk/source/cppsdk/source/playfab/PlayFabCallRequestContainerBase.cpp
+++ b/targets/XPlatCppSdk/source/cppsdk/source/playfab/PlayFabCallRequestContainerBase.cpp
@@ -1,0 +1,85 @@
+#include <stdafx.h>
+
+#include <playfab/PlayFabCallRequestContainer.h>
+
+namespace PlayFab
+{
+    CallRequestContainerBase::CallRequestContainerBase(
+            std::string url,
+            const std::unordered_map<std::string, std::string>& headers,
+            std::string requestBody,
+            CallRequestContainerCallback callback,
+            SharedVoidPointer externalCallback,
+            ErrorCallback errorCallback, 
+            void* customContext) :
+            mUrl(url),
+            mHeaders(headers),
+            mRequestBody(requestBody),
+            mCallback(callback),
+            mSuccessCallback(externalCallback),
+            mErrorCallback(errorCallback),
+            mCustomContext(customContext)
+    {
+    }
+
+    CallRequestContainerBase::CallRequestContainerBase(const CallRequestContainerBase& otherContainer)
+    {
+        *this = otherContainer;
+    }
+
+    const CallRequestContainerBase& CallRequestContainerBase::operator=(const CallRequestContainerBase& otherContainer)
+    {
+        if(this != &otherContainer)
+        {
+            this->mUrl = otherContainer.mUrl;
+            this->mHeaders = otherContainer.mHeaders;
+            this->mRequestBody = otherContainer.mRequestBody;
+            this->mCallback = otherContainer.mCallback;
+            this->mCustomContext = otherContainer.mCustomContext;
+            this->mSuccessCallback = otherContainer.mSuccessCallback;
+            this->mErrorCallback = otherContainer.mErrorCallback;
+            this->mCustomContext = otherContainer.mCustomContext;
+        }
+
+        return *this;
+    }
+
+    CallRequestContainerBase::~CallRequestContainerBase()
+    {
+    }
+
+    std::string CallRequestContainerBase::getUrl() const
+    {
+        return mUrl;
+    }
+
+    std::unordered_map<std::string, std::string> CallRequestContainerBase::getHeaders() const
+    {
+        return mHeaders;
+    }
+
+    std::string CallRequestContainerBase::getRequestBody() const
+    {
+        return mRequestBody;
+    }
+
+    CallRequestContainerCallback CallRequestContainerBase::getCallback() const
+    {
+        return mCallback;
+    }
+
+    void* CallRequestContainerBase::getCustomContext() const
+    {
+        return mCustomContext;
+    }
+
+    ErrorCallback CallRequestContainerBase::getErrorCallback() const
+    {
+        return mErrorCallback;
+    }
+
+    SharedVoidPointer* CallRequestContainerBase::getAPICallback()
+    {
+        return &mSuccessCallback;
+    }
+}

--- a/targets/XPlatCppSdk/source/cppsdk/source/playfab/PlayFabCallRequestContainerBase.cpp
+++ b/targets/XPlatCppSdk/source/cppsdk/source/playfab/PlayFabCallRequestContainerBase.cpp
@@ -5,20 +5,16 @@
 namespace PlayFab
 {
     CallRequestContainerBase::CallRequestContainerBase(
-            std::string url,
-            const std::unordered_map<std::string, std::string>& headers,
-            std::string requestBody,
-            CallRequestContainerCallback callback,
-            SharedVoidPointer externalCallback,
-            ErrorCallback errorCallback, 
-            void* customContext) :
-            mUrl(url),
-            mHeaders(headers),
-            mRequestBody(requestBody),
-            mCallback(callback),
-            mSuccessCallback(externalCallback),
-            mErrorCallback(errorCallback),
-            mCustomContext(customContext)
+        std::string url,
+        const std::unordered_map<std::string, std::string>& headers,
+        std::string requestBody,
+        CallRequestContainerCallback callback,
+        void* customData) :
+        mUrl(url),
+        mHeaders(headers),
+        mRequestBody(requestBody),
+        mCallback(callback),
+        mCustomData(customData)
     {
     }
 
@@ -29,16 +25,13 @@ namespace PlayFab
 
     const CallRequestContainerBase& CallRequestContainerBase::operator=(const CallRequestContainerBase& otherContainer)
     {
-        if(this != &otherContainer)
+        if (this != &otherContainer)
         {
             this->mUrl = otherContainer.mUrl;
             this->mHeaders = otherContainer.mHeaders;
             this->mRequestBody = otherContainer.mRequestBody;
             this->mCallback = otherContainer.mCallback;
-            this->mCustomContext = otherContainer.mCustomContext;
-            this->mSuccessCallback = otherContainer.mSuccessCallback;
-            this->mErrorCallback = otherContainer.mErrorCallback;
-            this->mCustomContext = otherContainer.mCustomContext;
+            this->mCustomData = otherContainer.mCustomData;
         }
 
         return *this;
@@ -68,18 +61,8 @@ namespace PlayFab
         return mCallback;
     }
 
-    void* CallRequestContainerBase::getCustomContext() const
+    void* CallRequestContainerBase::getCustomData() const
     {
-        return mCustomContext;
-    }
-
-    ErrorCallback CallRequestContainerBase::getErrorCallback() const
-    {
-        return mErrorCallback;
-    }
-
-    SharedVoidPointer* CallRequestContainerBase::getAPICallback()
-    {
-        return &mSuccessCallback;
+        return mCustomData;
     }
 }

--- a/targets/XPlatCppSdk/source/cppsdk/source/playfab/PlayFabHttp.cpp
+++ b/targets/XPlatCppSdk/source/cppsdk/source/playfab/PlayFabHttp.cpp
@@ -6,6 +6,8 @@
 // Intellisense-only includes
 #include <curl/curl.h>
 
+#include <stdexcept>
+
 namespace PlayFab
 {
     std::unique_ptr<IPlayFabHttp> IPlayFabHttp::httpInstance = nullptr;
@@ -14,7 +16,9 @@ namespace PlayFab
     {
         // In the future we could make it easier to override this instance with a sub-type, for now it defaults to the only one we have
         if (httpInstance == nullptr)
+        {
             PlayFabHttp::MakeInstance();
+        }
         return *httpInstance.get();
     }
 
@@ -30,11 +34,19 @@ namespace PlayFab
         threadRunning = false;
         pfHttpWorkerThread.join();
         for (size_t i = 0; i < pendingRequests.size(); ++i)
+        {
             delete pendingRequests[i];
+        }
+
         pendingRequests.clear();
+
         for (size_t i = 0; i < pendingResults.size(); ++i)
+        {
             delete pendingResults[i];
+        }
+
         pendingResults.clear();
+
         activeRequestCount = 0;
     }
 
@@ -78,7 +90,9 @@ namespace PlayFab
             }
 
             if (reqContainer != nullptr)
+            {
                 ExecuteRequest(*reqContainer);
+            }
         }
     }
 
@@ -86,11 +100,13 @@ namespace PlayFab
     {
         reqContainer.finished = true;
         if (PlayFabSettings::threadedCallbacks)
+        {
             HandleResults(reqContainer);
+        }
 
-        PlayFabHttp& instance = static_cast<PlayFabHttp&>(Get());
         if (!PlayFabSettings::threadedCallbacks)
         {
+            PlayFabHttp& instance = static_cast<PlayFabHttp&>(Get());
             { // LOCK httpRequestMutex
                 std::unique_lock<std::mutex> lock(instance.httpRequestMutex);
                 instance.pendingResults.push_back(&reqContainer);
@@ -106,17 +122,9 @@ namespace PlayFab
         return (blockSize * blockCount);
     }
 
-    void PlayFabHttp::AddRequest(const std::string& urlPath, const std::string& authKey, const std::string& authValue, const Json::Value& requestBody, RequestCompleteCallback internalCallback, SharedVoidPointer successCallback, ErrorCallback errorCallback, void* customData)
+    void PlayFabHttp::MakePostRequest(const CallRequestContainerBase& requestContainer)
     {
-        CallRequestContainer* reqContainer = new CallRequestContainer();
-        reqContainer->errorWrapper.UrlPath = urlPath;
-        reqContainer->authKey = authKey;
-        reqContainer->authValue = authValue;
-        reqContainer->errorWrapper.Request = requestBody;
-        reqContainer->internalCallback = internalCallback;
-        reqContainer->successCallback = successCallback;
-        reqContainer->errorCallback = errorCallback;
-        reqContainer->customData = customData;
+        CallRequestContainer* reqContainer = new CallRequestContainer(requestContainer);
 
         { // LOCK httpRequestMutex
             std::unique_lock<std::mutex> lock(httpRequestMutex);
@@ -138,8 +146,18 @@ namespace PlayFab
         reqContainer.curlHttpHeaders = curl_slist_append(reqContainer.curlHttpHeaders, "Content-Type: application/json; charset=utf-8");
         reqContainer.curlHttpHeaders = curl_slist_append(reqContainer.curlHttpHeaders, ("X-PlayFabSDK: " + PlayFabSettings::versionString).c_str());
         reqContainer.curlHttpHeaders = curl_slist_append(reqContainer.curlHttpHeaders, "X-ReportErrorAsSuccess: true");
-        if (reqContainer.authKey.length() != 0 && reqContainer.authValue.length() != 0)
-            reqContainer.curlHttpHeaders = curl_slist_append(reqContainer.curlHttpHeaders, (reqContainer.authKey + ": " + reqContainer.authValue).c_str());
+
+        auto headers = reqContainer.getHeaders();
+
+        if (headers.size() > 0)
+        {
+            for (auto const &obj : headers)
+            {
+                std::string header = obj.first + ": " + obj.second;
+                reqContainer.curlHttpHeaders = curl_slist_append(reqContainer.curlHttpHeaders, header.c_str());
+            }
+        }
+
         curl_easy_setopt(reqContainer.curlHandle, CURLOPT_HTTPHEADER, reqContainer.curlHttpHeaders);
 
         // Set up post & payload
@@ -197,30 +215,29 @@ namespace PlayFab
 
     void PlayFabHttp::HandleResults(CallRequestContainer& reqContainer)
     {
-        // The success case must be handled by a function which is aware of the ResultType
-        if (reqContainer.errorWrapper.HttpCode == 200)
+        if (reqContainer.getCallback() != nullptr)
         {
-            reqContainer.internalCallback(reqContainer); // Unpacks the result as ResultType and invokes successCallback according to that type
-        }
-        else // Process the error case
-        {
-            if (PlayFabSettings::globalErrorHandler != nullptr)
-                PlayFabSettings::globalErrorHandler(reqContainer.errorWrapper, reqContainer.customData);
-            if (reqContainer.errorCallback != nullptr)
-                reqContainer.errorCallback(reqContainer.errorWrapper, reqContainer.customData);
+            reqContainer.getCallback()(
+                reqContainer.responseJson.get("code", Json::Value::null).asInt(),
+                reqContainer.responseString.c_str(),
+                static_cast<void*>(&reqContainer));
         }
     }
 
     size_t PlayFabHttp::Update()
     {
         if (PlayFabSettings::threadedCallbacks)
+        {
             throw std::runtime_error("You should not call Update() when PlayFabSettings::threadedCallbacks == true");
+        }
 
         CallRequestContainer* reqContainer;
         { // LOCK httpRequestMutex
             std::unique_lock<std::mutex> lock(httpRequestMutex);
             if (pendingResults.empty())
+            {
                 return activeRequestCount;
+            }
 
             reqContainer = pendingResults[pendingResults.size() - 1];
             pendingResults.pop_back();

--- a/targets/XPlatCppSdk/source/cppsdk/source/playfab/PlayFabPluginManager.cpp
+++ b/targets/XPlatCppSdk/source/cppsdk/source/playfab/PlayFabPluginManager.cpp
@@ -68,7 +68,7 @@ namespace PlayFab
 
     IPlayFabPlugin* PlayFabPluginManager::CreatePlayFabTransportPlugin()
     {
-        // TODO: this should make a real HttpPlugin, not an interface
-        return new IPlayFabHttpPlugin;
+        IPlayFabHttp& http = IPlayFabHttp::Get();
+        return &http;
     }
 }

--- a/targets/XPlatCppSdk/templates/PlayFab_API.h.ejs
+++ b/targets/XPlatCppSdk/templates/PlayFab_API.h.ejs
@@ -31,7 +31,7 @@ namespace PlayFab
 
         // ------------ Generated result handlers
 <% for (var callIdx = 0; callIdx < api.calls.length; callIdx++) { var apiCall = api.calls[callIdx];
-%>        static void On<%- apiCall.name %>Result(CallRequestContainerBase& request);
+%>        static void On<%- apiCall.name %>Result(int httpCode, std::string result, void* customContext);
 <% } %>
 <% if (hasClientOptions) { %>
         // Private, Client-Specific

--- a/targets/XPlatCppSdk/templates/PlayFab_API.h.ejs
+++ b/targets/XPlatCppSdk/templates/PlayFab_API.h.ejs
@@ -31,12 +31,13 @@ namespace PlayFab
 
         // ------------ Generated result handlers
 <% for (var callIdx = 0; callIdx < api.calls.length; callIdx++) { var apiCall = api.calls[callIdx];
-%>        static void On<%- apiCall.name %>Result(int httpCode, std::string result, void* customContext);
+%>        static void On<%- apiCall.name %>Result(int httpCode, std::string result, CallRequestContainerBase& reqContainer);
 <% } %>
 <% if (hasClientOptions) { %>
         // Private, Client-Specific
         static void MultiStepClientLogin(bool needsAttribution);
-<% } %>    };
+<% } %>    static bool IsSuccessfulResult(PlayFabResultCommon& resultCommon, CallRequestContainer& container);
+    };
 }
 
 #endif

--- a/targets/XPlatCppSdk/templates/PlayFab_Api.cpp.ejs
+++ b/targets/XPlatCppSdk/templates/PlayFab_Api.cpp.ejs
@@ -40,14 +40,14 @@ namespace PlayFab
         std::unordered_map<std::string, std::string> headers;
         headers.emplace(<%- getAuthParams(apiCall) %>);
 
-        CallRequestContainer* reqContainer = new CallRequestContainer(CallRequestContainerBase(
+        CallRequestContainer* reqContainer = new CallRequestContainer(
             "<%- apiCall.url %>",
             headers,
             jsonAsString,
             On<%- apiCall.name %>Result,
-            customData));
+            customData);
 
-        reqContainer->successCallback = SharedVoidPointer((callback == nullptr) ? nullptr : new ProcessApiCallback<<%- apiCall.result %>>(callback));
+        reqContainer->successCallback = std::shared_ptr<void>((callback == nullptr) ? nullptr : new ProcessApiCallback<<%- apiCall.result %>>(callback));
         reqContainer->errorCallback = errorCallback;
 
         http.MakePostRequest(*reqContainer);
@@ -57,11 +57,10 @@ namespace PlayFab
     {
         CallRequestContainer& container = static_cast<CallRequestContainer&>(reqContainer);
 
-        // Unpacks the result as ResultType and invokes successCallback according to that type
         <%- apiCall.result %> outResult;
         if (IsSuccessfulResult(outResult, container))
         {
-    <%- getResultActions("        ", apiCall) %>
+<%- getResultActions("            ", apiCall) %>
             const auto internalPtr = container.successCallback.get();
             if (internalPtr != nullptr)
             {
@@ -72,7 +71,6 @@ namespace PlayFab
 
         delete &container;
     }
-
 <% } %><% if (hasClientOptions) { %>
     // Private PlayFabClientAPI specific
     bool PlayFabClientAPI::IsClientLoggedIn()
@@ -94,7 +92,8 @@ namespace PlayFab
             AttributeInstall(request, nullptr, nullptr);
         }
     }
-<% } %>    bool PlayFab<%- api.name %>API::IsSuccessfulResult(PlayFabResultCommon& resultCommon, CallRequestContainer& container)
+<% } %>
+    bool PlayFab<%- api.name %>API::IsSuccessfulResult(PlayFabResultCommon& resultCommon, CallRequestContainer& container)
     {
         if (container.errorWrapper.HttpCode == 200)
         {

--- a/targets/XPlatCppSdk/templates/PlayFab_Api.cpp.ejs
+++ b/targets/XPlatCppSdk/templates/PlayFab_Api.cpp.ejs
@@ -5,6 +5,15 @@
 #include <playfab/PlayFab<%- api.name %>Api.h>
 #include <playfab/PlayFabHttp.h>
 #include <playfab/PlayFabSettings.h>
+#include <playfab/PlayFabError.h>
+
+
+#ifndef _WIN32
+#include <jsoncpp/json/writer.h>
+#endif
+#ifdef _WIN32
+#include <json/writer.h>
+#endif
 
 namespace PlayFab
 {
@@ -32,23 +41,70 @@ namespace PlayFab
 <%- getRequestActions("        ", apiCall) %>
         IPlayFabHttp& http = IPlayFabHttp::Get();
         const auto requestJson = request.ToJson();
-        http.AddRequest("<%- apiCall.url %>", <%- getAuthParams(apiCall) %>, requestJson, On<%- apiCall.name %>Result, SharedVoidPointer((callback == nullptr) ? nullptr : new ProcessApiCallback<<%- apiCall.result %>>(callback)), errorCallback, customData);
+
+        Json::FastWriter writer;
+        std::string jsonAsString = writer.write(requestJson);
+
+        std::unordered_map<std::string, std::string> headers;
+        headers.emplace(<%- getAuthParams(apiCall) %>);
+
+        CallRequestContainerBase crc = CallRequestContainerBase(
+            "<%- apiCall.url %>",
+            headers,
+            jsonAsString,
+            On<%- apiCall.name %>Result,
+            SharedVoidPointer((callback == nullptr) ? nullptr : new ProcessApiCallback<<%- apiCall.result %>>(callback)),
+            errorCallback,
+            customData);
+
+        http.MakePostRequest(crc);
     }
 
-    void PlayFab<%- api.name %>API::On<%- apiCall.name %>Result(CallRequestContainerBase& pRequest)
+    void PlayFab<%- api.name %>API::On<%- apiCall.name %>Result(int httpCode, std::string result, void* customContext)
     {
-        CallRequestContainer request = static_cast<CallRequestContainer&>(pRequest);
-        <%- apiCall.result %> outResult;
-        outResult.FromJson(request.errorWrapper.Data);
-        outResult.Request = request.errorWrapper.Request;
-<%- getResultActions("        ", apiCall) %>
-        const auto internalPtr = request.successCallback.get();
-        if (internalPtr != nullptr)
+        Json::Value root;
+        Json::Reader reader;
+
+        bool parsingSuccessful = reader.parse(result.c_str(), root);
+
+        if(parsingSuccessful)
         {
-            const auto callback = (*static_cast<ProcessApiCallback<<%- apiCall.result %>> *>(internalPtr));
-            callback(outResult, request.customData);
+            <%- apiCall.result %> outResult;
+
+            outResult.FromJson(root);
+
+            // TODO: consider the following: (do we need this errorWrapper request?)
+            //outResult.Request = request.errorWrapper.Request;
+
+            CallRequestContainerBase* crc = static_cast<CallRequestContainerBase*>(customContext);
+
+            if(httpCode == 200 && crc->getAPICallback() != nullptr)
+            {
+                // TODO: cast the function correctly.
+                // const auto callback = (*static_cast<ProcessApiCallback<<%- apiCall.result %>> *>(crc->getAPICallback()));
+                // callback(outResult, crc->getCustomContext());
+            }
+            else // Process the error case
+            {
+                // TODO: how is this supposed to fail gracefully?
+                // TODO: consider the objects we are using, does the base class need an errorWrapper?
+                if (PlayFabSettings::globalErrorHandler != nullptr)
+                {
+                    PlayFabSettings::globalErrorHandler(request.errorWrapper, customData);
+                }
+
+                if (crc->getErrorCallback() != nullptr)
+                {
+                    //outResult->getErrorCallback()(request.errorWrapper, customData);
+                }
+            }
+        }
+        else
+        {
+            throw new std::invalid_argument("The returned result body was not in a valid Json format during On<%- apiCall.name %>Result.");
         }
     }
+
 <% } %><% if (hasClientOptions) { %>
     // Private PlayFabClientAPI specific
     bool PlayFabClientAPI::IsClientLoggedIn()

--- a/targets/XPlatCppSdk/templates/PlayFab_Api.cpp.ejs
+++ b/targets/XPlatCppSdk/templates/PlayFab_Api.cpp.ejs
@@ -7,14 +7,6 @@
 #include <playfab/PlayFabSettings.h>
 #include <playfab/PlayFabError.h>
 
-
-#ifndef _WIN32
-#include <jsoncpp/json/writer.h>
-#endif
-#ifdef _WIN32
-#include <json/writer.h>
-#endif
-
 namespace PlayFab
 {
     using namespace <%- api.name %>Models;
@@ -48,61 +40,37 @@ namespace PlayFab
         std::unordered_map<std::string, std::string> headers;
         headers.emplace(<%- getAuthParams(apiCall) %>);
 
-        CallRequestContainerBase crc = CallRequestContainerBase(
+        CallRequestContainer* reqContainer = new CallRequestContainer(CallRequestContainerBase(
             "<%- apiCall.url %>",
             headers,
             jsonAsString,
             On<%- apiCall.name %>Result,
-            SharedVoidPointer((callback == nullptr) ? nullptr : new ProcessApiCallback<<%- apiCall.result %>>(callback)),
-            errorCallback,
-            customData);
+            customData));
 
-        http.MakePostRequest(crc);
+        reqContainer->successCallback = SharedVoidPointer((callback == nullptr) ? nullptr : new ProcessApiCallback<<%- apiCall.result %>>(callback));
+        reqContainer->errorCallback = errorCallback;
+
+        http.MakePostRequest(*reqContainer);
     }
 
-    void PlayFab<%- api.name %>API::On<%- apiCall.name %>Result(int httpCode, std::string result, void* customContext)
+    void PlayFab<%- api.name %>API::On<%- apiCall.name %>Result(int httpCode, std::string result, CallRequestContainerBase& reqContainer)
     {
-        Json::Value root;
-        Json::Reader reader;
+        CallRequestContainer& container = static_cast<CallRequestContainer&>(reqContainer);
 
-        bool parsingSuccessful = reader.parse(result.c_str(), root);
-
-        if(parsingSuccessful)
+        // Unpacks the result as ResultType and invokes successCallback according to that type
+        <%- apiCall.result %> outResult;
+        if (IsSuccessfulResult(outResult, container))
         {
-            <%- apiCall.result %> outResult;
-
-            outResult.FromJson(root);
-
-            // TODO: consider the following: (do we need this errorWrapper request?)
-            //outResult.Request = request.errorWrapper.Request;
-
-            CallRequestContainerBase* crc = static_cast<CallRequestContainerBase*>(customContext);
-
-            if(httpCode == 200 && crc->getAPICallback() != nullptr)
+    <%- getResultActions("        ", apiCall) %>
+            const auto internalPtr = container.successCallback.get();
+            if (internalPtr != nullptr)
             {
-                // TODO: cast the function correctly.
-                // const auto callback = (*static_cast<ProcessApiCallback<<%- apiCall.result %>> *>(crc->getAPICallback()));
-                // callback(outResult, crc->getCustomContext());
-            }
-            else // Process the error case
-            {
-                // TODO: how is this supposed to fail gracefully?
-                // TODO: consider the objects we are using, does the base class need an errorWrapper?
-                if (PlayFabSettings::globalErrorHandler != nullptr)
-                {
-                    PlayFabSettings::globalErrorHandler(request.errorWrapper, customData);
-                }
-
-                if (crc->getErrorCallback() != nullptr)
-                {
-                    //outResult->getErrorCallback()(request.errorWrapper, customData);
-                }
+                const auto callback = (*static_cast<ProcessApiCallback<<%- apiCall.result %>> *>(internalPtr));
+                callback(outResult, container.getCustomData());
             }
         }
-        else
-        {
-            throw new std::invalid_argument("The returned result body was not in a valid Json format during On<%- apiCall.name %>Result.");
-        }
+
+        delete &container;
     }
 
 <% } %><% if (hasClientOptions) { %>
@@ -126,6 +94,23 @@ namespace PlayFab
             AttributeInstall(request, nullptr, nullptr);
         }
     }
-<% } %>}
+<% } %>    bool PlayFab<%- api.name %>API::IsSuccessfulResult(PlayFabResultCommon& resultCommon, CallRequestContainer& container)
+    {
+        if (container.errorWrapper.HttpCode == 200)
+        {
+            resultCommon.FromJson(container.errorWrapper.Data);
+            resultCommon.Request = container.errorWrapper.Request;
+            return true;
+        }
+        else // Process the error case
+        {
+            if (PlayFabSettings::globalErrorHandler != nullptr)
+                PlayFabSettings::globalErrorHandler(container.errorWrapper, container.getCustomData());
+            if (container.errorCallback != nullptr)
+                container.errorCallback(container.errorWrapper, container.getCustomData());
+            return false;
+        }
+    }
+}
 
 #endif


### PR DESCRIPTION
* Tests pass (the app)

* The initial work was done by Todd (credits!). I wrapped it up with some fixes and refactoring.

* The public HTTP transport is using CallRequestContainerBase with zero-knowledge about PlayFab (that was the main goal)

* Fixed major issue with memory heap leak (allocated CallRequestContainers were never deleted from the heap)

* A few minor optimizations (we were making additional copies of CallRequestContainers on the stack in internal callbacks)

* Not all bugs and issues discovered in the original Todd's PR were addressed: we maintain a list of those bugs that will be addressed as Xplat C++ evolves in the next sprints

* Threading model/mutexes remain the same for now and will be addressed in specialized PRs
