### PR TITLE
Addressed missed feedback from previous PR, naming convention, warnings

### DIFF
--- a/targets/XPlatCppSdk/source/cppsdk/include/playfab/PlayFabBaseModel.h
+++ b/targets/XPlatCppSdk/source/cppsdk/include/playfab/PlayFabBaseModel.h
@@ -40,20 +40,20 @@ namespace PlayFab
     class Boxed
     {
     public:
-        Boxed() : mValue(), mIsSet(false) {}
-        Boxed(BoxedType value) : mValue(value), mIsSet(true) {}
+        Boxed() : boxedValue(), isSet(false) {}
+        Boxed(BoxedType value) : boxedValue(value), isSet(true) {}
 
-        inline Boxed& operator=(BoxedType value) { mValue = value; mIsSet = true; return *this; }
+        inline Boxed& operator=(BoxedType value) { boxedValue = value; isSet = true; return *this; }
         inline operator const BoxedType& () const { assert(notNull()); return *operator->(); }
-        inline BoxedType* operator->() { return mIsSet ? &mValue : nullptr; }
-        inline const BoxedType* operator->() const { return mIsSet ? &mValue : nullptr; }
+        inline BoxedType* operator->() { return isSet ? &boxedValue : nullptr; }
+        inline const BoxedType* operator->() const { return isSet ? &boxedValue : nullptr; }
 
-        inline void setNull() { mIsSet = false; }
-        inline bool notNull() const { return mIsSet; }
-        inline bool isNull() const { return !mIsSet; }
+        inline void setNull() { isSet = false; }
+        inline bool notNull() const { return isSet; }
+        inline bool isNull() const { return !isSet; }
     private:
-        BoxedType mValue;
-        bool mIsSet;
+        BoxedType boxedValue;
+        bool isSet;
     };
 
     template<typename ResType> using ProcessApiCallback = std::function<void(const ResType& result, void* customData)>;

--- a/targets/XPlatCppSdk/source/cppsdk/include/playfab/PlayFabCallRequestContainerBase.h
+++ b/targets/XPlatCppSdk/source/cppsdk/include/playfab/PlayFabCallRequestContainerBase.h
@@ -36,24 +36,24 @@ namespace PlayFab
 
         virtual ~CallRequestContainerBase();
 
-        std::string getUrl() const;
-        std::unordered_map<std::string, std::string> getHeaders() const;
-        std::string getRequestBody() const;
+        std::string GetUrl() const;
+        std::unordered_map<std::string, std::string> GetHeaders() const;
+        std::string GetRequestBody() const;
 
         /// <summary>
         /// This function is meant to handle logic of calling the error callback or success
         /// </summary>
-        CallRequestContainerCallback getCallback() const;
+        CallRequestContainerCallback GetCallback() const;
 
-        void* getCustomData() const;
+        void* GetCustomData() const;
 
     private:
-        std::string mUrl;
-        std::unordered_map<std::string, std::string> mHeaders;
-        std::string mRequestBody;
-        CallRequestContainerCallback mCallback;
+        std::string url;
+        std::unordered_map<std::string, std::string> headers;
+        std::string requestBody;
+        CallRequestContainerCallback callback;
 
         // I never own this, I can never destroy it
-        void* mCustomData; // optional user data (relayed to callback). This gives users the flexibility to tag each request with some data that can be accessed in callback.
+        void* customData; // optional user data (relayed to callback). This gives users the flexibility to tag each request with some data that can be accessed in callback.
     };
 }

--- a/targets/XPlatCppSdk/source/cppsdk/include/playfab/PlayFabPluginManager.h
+++ b/targets/XPlatCppSdk/source/cppsdk/include/playfab/PlayFabPluginManager.h
@@ -52,7 +52,7 @@ namespace PlayFab
     class PlayFabPluginManager
     {
     public:
-        static PlayFabPluginManager& instance(); // The singleton instance of plugin manager
+        static PlayFabPluginManager& Instance(); // The singleton instance of plugin manager
 
         // Prevent copy/move construction
         PlayFabPluginManager(const PlayFabPluginManager&) = delete;
@@ -67,7 +67,7 @@ namespace PlayFab
         template <typename T>
         static T& GetPlugin(const PlayFabPluginContract& contract, const std::string& instanceName = "")
         {
-            return (T&)(instance().GetPluginInternal(contract, instanceName));
+            return (T&)(Instance().GetPluginInternal(contract, instanceName));
         }
 
         // Sets a custom plugin.

--- a/targets/XPlatCppSdk/source/cppsdk/source/playfab/PlayFabCallRequestContainerBase.cpp
+++ b/targets/XPlatCppSdk/source/cppsdk/source/playfab/PlayFabCallRequestContainerBase.cpp
@@ -10,11 +10,11 @@ namespace PlayFab
         std::string requestBody,
         CallRequestContainerCallback callback,
         void* customData) :
-        mUrl(url),
-        mHeaders(headers),
-        mRequestBody(requestBody),
-        mCallback(callback),
-        mCustomData(customData)
+        url(url),
+        headers(headers),
+        requestBody(requestBody),
+        callback(callback),
+        customData(customData)
     {
     }
 
@@ -27,11 +27,11 @@ namespace PlayFab
     {
         if (this != &otherContainer)
         {
-            this->mUrl = otherContainer.mUrl;
-            this->mHeaders = otherContainer.mHeaders;
-            this->mRequestBody = otherContainer.mRequestBody;
-            this->mCallback = otherContainer.mCallback;
-            this->mCustomData = otherContainer.mCustomData;
+            this->url = otherContainer.url;
+            this->headers = otherContainer.headers;
+            this->requestBody = otherContainer.requestBody;
+            this->callback = otherContainer.callback;
+            this->customData = otherContainer.customData;
         }
 
         return *this;
@@ -41,28 +41,28 @@ namespace PlayFab
     {
     }
 
-    std::string CallRequestContainerBase::getUrl() const
+    std::string CallRequestContainerBase::GetUrl() const
     {
-        return mUrl;
+        return url;
     }
 
-    std::unordered_map<std::string, std::string> CallRequestContainerBase::getHeaders() const
+    std::unordered_map<std::string, std::string> CallRequestContainerBase::GetHeaders() const
     {
-        return mHeaders;
+        return headers;
     }
 
-    std::string CallRequestContainerBase::getRequestBody() const
+    std::string CallRequestContainerBase::GetRequestBody() const
     {
-        return mRequestBody;
+        return requestBody;
     }
 
-    CallRequestContainerCallback CallRequestContainerBase::getCallback() const
+    CallRequestContainerCallback CallRequestContainerBase::GetCallback() const
     {
-        return mCallback;
+        return callback;
     }
 
-    void* CallRequestContainerBase::getCustomData() const
+    void* CallRequestContainerBase::GetCustomData() const
     {
-        return mCustomData;
+        return customData;
     }
 }

--- a/targets/XPlatCppSdk/source/cppsdk/source/playfab/PlayFabHttp.cpp
+++ b/targets/XPlatCppSdk/source/cppsdk/source/playfab/PlayFabHttp.cpp
@@ -136,7 +136,7 @@ namespace PlayFab
         // Set up curl handle
         reqContainer.curlHandle = curl_easy_init();
         curl_easy_reset(reqContainer.curlHandle);
-        curl_easy_setopt(reqContainer.curlHandle, CURLOPT_URL, PlayFabSettings::GetUrl(reqContainer.getUrl(), PlayFabSettings::requestGetParams).c_str());
+        curl_easy_setopt(reqContainer.curlHandle, CURLOPT_URL, PlayFabSettings::GetUrl(reqContainer.GetUrl(), PlayFabSettings::requestGetParams).c_str());
 
         // Set up headers
         reqContainer.curlHttpHeaders = nullptr;
@@ -145,7 +145,7 @@ namespace PlayFab
         reqContainer.curlHttpHeaders = curl_slist_append(reqContainer.curlHttpHeaders, ("X-PlayFabSDK: " + PlayFabSettings::versionString).c_str());
         reqContainer.curlHttpHeaders = curl_slist_append(reqContainer.curlHttpHeaders, "X-ReportErrorAsSuccess: true");
 
-        auto headers = reqContainer.getHeaders();
+        auto headers = reqContainer.GetHeaders();
 
         if (headers.size() > 0)
         {
@@ -162,7 +162,7 @@ namespace PlayFab
         curl_easy_setopt(reqContainer.curlHandle, CURLOPT_HTTPHEADER, reqContainer.curlHttpHeaders);
 
         // Set up post & payload
-        std::string payload = reqContainer.getRequestBody();
+        std::string payload = reqContainer.GetRequestBody();
         curl_easy_setopt(reqContainer.curlHandle, CURLOPT_POST, nullptr);
         curl_easy_setopt(reqContainer.curlHandle, CURLOPT_POSTFIELDS, payload.c_str());
 
@@ -216,9 +216,9 @@ namespace PlayFab
 
     void PlayFabHttp::HandleResults(CallRequestContainer& reqContainer)
     {
-        if (reqContainer.getCallback() != nullptr)
+        if (reqContainer.GetCallback() != nullptr)
         {
-            reqContainer.getCallback()(
+            reqContainer.GetCallback()(
                 reqContainer.responseJson.get("code", Json::Value::null).asInt(),
                 reqContainer.responseString,
                 reqContainer);

--- a/targets/XPlatCppSdk/source/cppsdk/source/playfab/PlayFabHttp.cpp
+++ b/targets/XPlatCppSdk/source/cppsdk/source/playfab/PlayFabHttp.cpp
@@ -216,9 +216,10 @@ namespace PlayFab
 
     void PlayFabHttp::HandleResults(CallRequestContainer& reqContainer)
     {
-        if (reqContainer.GetCallback() != nullptr)
+        auto callback = reqContainer.GetCallback();
+        if (callback != nullptr)
         {
-            reqContainer.GetCallback()(
+            callback(
                 reqContainer.responseJson.get("code", Json::Value::null).asInt(),
                 reqContainer.responseString,
                 reqContainer);
@@ -245,8 +246,8 @@ namespace PlayFab
             activeRequestCount--;
         } // UNLOCK httpRequestMutex
 
+        // The callback called from HandleResults may delete the object pointed by reqContainer from the heap; do not use it after this call
         HandleResults(*static_cast<CallRequestContainer*>(reqContainer));
-        delete reqContainer;
 
         // activeRequestCount can be altered by HandleResults, so we have to re-lock and return an updated value
         { // LOCK httpRequestMutex

--- a/targets/XPlatCppSdk/source/cppsdk/source/playfab/PlayFabPluginManager.cpp
+++ b/targets/XPlatCppSdk/source/cppsdk/source/playfab/PlayFabPluginManager.cpp
@@ -5,7 +5,7 @@
 
 namespace PlayFab
 {
-    PlayFabPluginManager& PlayFabPluginManager::instance()
+    PlayFabPluginManager& PlayFabPluginManager::Instance()
     {
         static PlayFabPluginManager instance;
         return instance;
@@ -13,7 +13,7 @@ namespace PlayFab
 
     void PlayFabPluginManager::SetPlugin(IPlayFabPlugin& plugin, const PlayFabPluginContract& contract, const std::string& instanceName)
     {
-        instance().SetPluginInternal(plugin, contract, instanceName);
+        Instance().SetPluginInternal(plugin, contract, instanceName);
     }
 
     IPlayFabPlugin& PlayFabPluginManager::GetPluginInternal(const PlayFabPluginContract& contract, const std::string& instanceName)

--- a/targets/XPlatCppSdk/templates/PlayFab_API.h.ejs
+++ b/targets/XPlatCppSdk/templates/PlayFab_API.h.ejs
@@ -36,7 +36,7 @@ namespace PlayFab
 <% if (hasClientOptions) { %>
         // Private, Client-Specific
         static void MultiStepClientLogin(bool needsAttribution);
-<% } %>    static bool IsSuccessfulResult(PlayFabResultCommon& resultCommon, CallRequestContainer& container);
+<% } %>        static bool ValidateResult(PlayFabResultCommon& resultCommon, CallRequestContainer& container);
     };
 }
 

--- a/targets/XPlatCppSdk/templates/PlayFab_Api.cpp.ejs
+++ b/targets/XPlatCppSdk/templates/PlayFab_Api.cpp.ejs
@@ -7,6 +7,8 @@
 #include <playfab/PlayFabSettings.h>
 #include <playfab/PlayFabError.h>
 
+#pragma warning (disable: 4100) // formal parameters are part of a public interface
+
 namespace PlayFab
 {
     using namespace <%- api.name %>Models;
@@ -58,14 +60,14 @@ namespace PlayFab
         CallRequestContainer& container = static_cast<CallRequestContainer&>(reqContainer);
 
         <%- apiCall.result %> outResult;
-        if (IsSuccessfulResult(outResult, container))
+        if (ValidateResult(outResult, container))
         {
 <%- getResultActions("            ", apiCall) %>
             const auto internalPtr = container.successCallback.get();
             if (internalPtr != nullptr)
             {
                 const auto callback = (*static_cast<ProcessApiCallback<<%- apiCall.result %>> *>(internalPtr));
-                callback(outResult, container.getCustomData());
+                callback(outResult, container.GetCustomData());
             }
         }
 
@@ -93,7 +95,7 @@ namespace PlayFab
         }
     }
 <% } %>
-    bool PlayFab<%- api.name %>API::IsSuccessfulResult(PlayFabResultCommon& resultCommon, CallRequestContainer& container)
+    bool PlayFab<%- api.name %>API::ValidateResult(PlayFabResultCommon& resultCommon, CallRequestContainer& container)
     {
         if (container.errorWrapper.HttpCode == 200)
         {
@@ -104,9 +106,9 @@ namespace PlayFab
         else // Process the error case
         {
             if (PlayFabSettings::globalErrorHandler != nullptr)
-                PlayFabSettings::globalErrorHandler(container.errorWrapper, container.getCustomData());
+                PlayFabSettings::globalErrorHandler(container.errorWrapper, container.GetCustomData());
             if (container.errorCallback != nullptr)
-                container.errorCallback(container.errorWrapper, container.getCustomData());
+                container.errorCallback(container.errorWrapper, container.GetCustomData());
             return false;
         }
     }


### PR DESCRIPTION
- Addressed missed feedback for previous PR from Paul (about UpperCamelCasing for all method names, including getters, and a better name for IsSuccessfulResult(..))
- Addressed private field naming convention inconsistency
- Removed numerous warnings about unused parameters (httpCode) in callbacks since they are part of a formal interface (see typedef of CallRequestContainerCallback in PlayFabCallRequestContainerBase.h)