### PR TITLE
Adding a synchronous Send() when we lose focus.

### DIFF
--- a/targets/unity-v2/source/Entity/ScreenTimeTracker.cs
+++ b/targets/unity-v2/source/Entity/ScreenTimeTracker.cs
@@ -141,6 +141,14 @@ namespace PlayFab.Public
             eventsRequests.Enqueue(eventInfo);
 
             initialFocus = false;
+
+            if(!isFocused)
+            {
+                // Force the eventsRequests queue to empty.
+                // If we are losing focus we should make an attempt to push out a focus lost event ASAP
+                Send();
+            }
+
         }
 
         /// <summary>


### PR DESCRIPTION
Small fix ensures if we receive an OnApplicationFocus(false) event, we will force the HTTP call immediately.