### PR TITLE
Update the git-branch destination to the new field

### DIFF
--- a/JenkinsConsoleUtility/JenkinsScripts/gitFinalize.sh
+++ b/JenkinsConsoleUtility/JenkinsScripts/gitFinalize.sh
@@ -2,10 +2,7 @@
 
 . $SHARED_WORKSPACE/SDKGenerator/JenkinsConsoleUtility/JenkinsScripts/util.sh
 
-CheckDefault gitTarget $AUTOMATED_GIT_BRANCH
-# CheckDefault WORKSPACE C:/proj
 CheckDefault SHARED_WORKSPACE C:/depot
-# CheckDefault SdkName UnitySDK
 CheckDefault PublishToGit false
 
 ForcePushD "$WORKSPACE/sdks/$SdkName"
@@ -15,7 +12,7 @@ if [ $PublishToGit=="true" ]; then
     git fetch --progress origin
     git add -A
     git commit --allow-empty -m "$commitMessage"
-    git push origin $gitTarget -f -u || (git fetch --progress origin && git push origin $gitTarget -f -u)
+    git push origin $GitDestBranch -f -u || (git fetch --progress origin && git push origin $GitDestBranch -f -u)
 fi
 
 popd

--- a/JenkinsConsoleUtility/JenkinsScripts/gitInitNuke.sh
+++ b/JenkinsConsoleUtility/JenkinsScripts/gitInitNuke.sh
@@ -4,8 +4,6 @@
 . $SHARED_WORKSPACE/SDKGenerator/JenkinsConsoleUtility/JenkinsScripts/util.sh
 
 # Defaults for some variables
-CheckDefault AUTOMATED_GIT_BRANCH automated
-CheckDefault gitTarget $AUTOMATED_GIT_BRANCH
 CheckDefault SdkName UnitySDK
 CheckDefault SHARED_WORKSPACE C:/depot
 CheckDefault WORKSPACE C:/proj
@@ -18,14 +16,14 @@ ResetRepo (){
     git checkout master || git checkout -b master || CleanCurrentRepo
     git pull origin master
 
-    if [ "$gitTarget"!="master" ]; then
+    if [ "$GitDestBranch"!="master" ]; then
         git fetch --progress origin
         if [ "$PublishToGit"!="true" ]; then
-            git branch -D $gitTarget || true
-            git checkout -b $gitTarget
+            git branch -D $GitDestBranch || true
+            git checkout -b $GitDestBranch
         else
-            git checkout -b $gitTarget
-            git checkout $gitTarget
+            git checkout -b $GitDestBranch
+            git checkout $GitDestBranch
         fi
     fi
 }

--- a/JenkinsConsoleUtility/JenkinsScripts/publishSquashAndMerge.sh
+++ b/JenkinsConsoleUtility/JenkinsScripts/publishSquashAndMerge.sh
@@ -1,21 +1,23 @@
 #!/bin/bash
 
-# Squash and Merge from automated->master
+# Squash and Merge from "automated-publish"->"master"->"versioned"
 #   If versioned exists: master->versioned, and then tag and notate the release in GitHub
+
+CheckDefault GitSrcBranch "automated-publish"
 
 cd "$WORKSPACE/sdks/$SdkName"
 
 git fetch --progress origin
 
-echo === Sync $AUTOMATED_GIT_BRANCH ===
-git checkout $AUTOMATED_GIT_BRANCH || git checkout -b $AUTOMATED_GIT_BRANCH
-git reset --hard origin/$AUTOMATED_GIT_BRANCH
+echo === Sync $GitSrcBranch ===
+git checkout $GitSrcBranch || git checkout -b $GitSrcBranch
+git reset --hard origin/$GitSrcBranch
 echo === Sync master ===
 git checkout master || git checkout -b master
 git reset --hard origin/master
 
 echo === Squash-Merge to master ===
-git merge --no-commit --squash origin/$AUTOMATED_GIT_BRANCH
+git merge --no-commit --squash origin/$GitSrcBranch
 git commit -m "https://api.playfab.com/releaseNotes/#$sdkDate"
 git push origin master
 


### PR DESCRIPTION
Setting up GitDestBranch as the variable branch output instead of the more or less constant AUTOMATED_GIT_BRANCH and gitTarget, which really could only be "automated", or generally converted to a single other constant value, but was never able to be variable job-to-job.