### PR TITLE
Optimization for pf-main

### DIFF
--- a/JenkinsConsoleUtility/JenkinsScripts/testInit.sh
+++ b/JenkinsConsoleUtility/JenkinsScripts/testInit.sh
@@ -42,18 +42,19 @@ DoNugetWork (){
     pushd "$WORKSPACE/SDKGenerator/JenkinsConsoleUtility"
     cmd <<< "nuget restore JenkinsConsoleUtility.sln"
     popd
-    pushd "$WORKSPACE/pf-main/Server"
-    cmd <<< "nuget restore Server.sln"
-    popd
+    # None of the SDKs need pf-main directly
+    # pushd "$WORKSPACE/pf-main/Server"
+    # cmd <<< "nuget restore Server.sln"
+    # popd
 }
 
-# USAGE: MainScript
-MainScript () {
-    echo == MainScript $PWD, $@ ==
+# USAGE: DoWork
+DoWork () {
+    echo == DoWork $PWD, $@ ==
 
     # These are always shared, never modified directly, and never arc-patched
     SyncGitHubRepo "$SHARED_WORKSPACE" "API_Specs"
-    SyncGitHubRepo "$SHARED_WORKSPACE" "pf-main"
+    # SyncGitHubRepo "$SHARED_WORKSPACE" "pf-main" # None of the SDKs need pf-main directly
     SyncGitHubRepo "$SHARED_WORKSPACE" "SDKGenerator"
     SyncGitHubRepo "$SHARED_WORKSPACE/sdks" "$SdkName"
 
@@ -61,11 +62,7 @@ MainScript () {
     # TEMPORARY: API_Specs might already exist, without being a git repo because of previous script versions
     rm -rf "$WORKSPACE/API_Specs"
     SyncWorkspaceRepo "$SHARED_WORKSPACE" "$WORKSPACE" "API_Specs"
-    if [ -z "$quickTest" ]; then
-        SyncWorkspaceRepo "$SHARED_WORKSPACE" "$WORKSPACE" "pf-main"
-    else
-        echo SKIP: SyncWorkspaceRepo pf-main 
-    fi
+    # SyncWorkspaceRepo "$SHARED_WORKSPACE" "$WORKSPACE" "pf-main" # None of the SDKs need pf-main directly
     SyncWorkspaceRepo "$SHARED_WORKSPACE" "$WORKSPACE" "SDKGenerator"
     ForcePushD "$SHARED_WORKSPACE/sdks"
     SyncWorkspaceRepo "$SHARED_WORKSPACE/sdks" "$WORKSPACE/sdks" "$SdkName"
@@ -84,4 +81,4 @@ MainScript () {
     # ApplyArcPatch
 }
 
-MainScript "$@"
+DoWork "$@"


### PR DESCRIPTION
Most of the SDK tests don't need to sync or run pf-main.
It's wasting time and space to keep it in every build.