### PR TITLE
Adding publishToS3.sh

### DIFF
--- a/JenkinsConsoleUtility/JenkinsScripts/gitFinalize.sh
+++ b/JenkinsConsoleUtility/JenkinsScripts/gitFinalize.sh
@@ -1,9 +1,8 @@
 #!/bin/bash
 
-. $SHARED_WORKSPACE/SDKGenerator/JenkinsConsoleUtility/JenkinsScripts/util.sh
-. $SHARED_WORKSPACE/SDKGenerator/JenkinsConsoleUtility/JenkinsScripts/sdkUtil.sh
+. $WORKSPACE/SDKGenerator/JenkinsConsoleUtility/JenkinsScripts/util.sh || . ./util.sh
+. $WORKSPACE/SDKGenerator/JenkinsConsoleUtility/JenkinsScripts/sdkUtil.sh || . ./sdkUtil.sh
 
-CheckDefault SHARED_WORKSPACE C:/depot
 CheckDefault PublishToGit false
 
 DoWork() {

--- a/JenkinsConsoleUtility/JenkinsScripts/gitInitNuke.sh
+++ b/JenkinsConsoleUtility/JenkinsScripts/gitInitNuke.sh
@@ -1,13 +1,8 @@
 #!/bin/bash
 # USAGE: testInit.sh
 
-. $SHARED_WORKSPACE/SDKGenerator/JenkinsConsoleUtility/JenkinsScripts/util.sh
-. $SHARED_WORKSPACE/SDKGenerator/JenkinsConsoleUtility/JenkinsScripts/sdkUtil.sh
-
-# Defaults for some variables
-# CheckDefault SdkName UnitySDK
-CheckDefault SHARED_WORKSPACE C:/depot
-# CheckDefault WORKSPACE C:/proj
+. $WORKSPACE/SDKGenerator/JenkinsConsoleUtility/JenkinsScripts/util.sh || . ./util.sh
+. $WORKSPACE/SDKGenerator/JenkinsConsoleUtility/JenkinsScripts/sdkUtil.sh || . ./sdkUtil.sh
 
 # USAGE: ResetRepo
 ResetRepo (){

--- a/JenkinsConsoleUtility/JenkinsScripts/publishSquashAndMerge.sh
+++ b/JenkinsConsoleUtility/JenkinsScripts/publishSquashAndMerge.sh
@@ -3,7 +3,7 @@
 # Squash and Merge from "automated-publish"->"master"->"versioned"
 #   If versioned exists: master->versioned, and then tag and notate the release in GitHub
 
-. ./util.sh
+. $WORKSPACE/SDKGenerator/JenkinsConsoleUtility/JenkinsScripts/util.sh || . ./util.sh
 
 CheckDefault GitSrcBranch "automated-publish"
 

--- a/JenkinsConsoleUtility/JenkinsScripts/publishToS3.sh
+++ b/JenkinsConsoleUtility/JenkinsScripts/publishToS3.sh
@@ -1,0 +1,3 @@
+echo "This file will contain the Publish To S3 logic which zips and writes a repo to S3."
+echo "It is currently a placeholder, so that Jenkins can start calling it, but doesn't actually do anything yet"
+

--- a/JenkinsConsoleUtility/JenkinsScripts/testInit.sh
+++ b/JenkinsConsoleUtility/JenkinsScripts/testInit.sh
@@ -1,10 +1,9 @@
 #!/bin/bash
 # USAGE: testInit.sh
 
-. $SHARED_WORKSPACE/SDKGenerator/JenkinsConsoleUtility/JenkinsScripts/util.sh || . util.sh
+. $SHARED_WORKSPACE/SDKGenerator/JenkinsConsoleUtility/JenkinsScripts/util.sh || . ./util.sh
 
 # Defaults for some variables
-CheckDefault SdkName UnitySDK
 CheckDefault SHARED_WORKSPACE C:/depot
 CheckDefault WORKSPACE C:/proj
 

--- a/JenkinsConsoleUtility/JenkinsScripts/util.sh
+++ b/JenkinsConsoleUtility/JenkinsScripts/util.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# USAGE: . util.sh
+# USAGE: . ./util.sh
 # Includes a bunch of functions shared by other scripts
 
 # USAGE: CheckDefault <variable> <new value if unset>


### PR DESCRIPTION
Converting some calls to use the local WORKSPACE instead of the SHARED_WORKSPACE, which improves test separation
Removing some unsafe defaults
Adding some redundancy in the util.sh imports (improves debugability on local machines)
Jenkins import syntax is slightly more strict than regular bash, so I'm updating several imports to be good for Jenkins