### PR TITLE
Copy paste error in Jenkins led to a handful of failures

### DIFF
--- a/JenkinsConsoleUtility/JenkinsScripts/listencsJCU.sh
+++ b/JenkinsConsoleUtility/JenkinsScripts/listencsJCU.sh
@@ -1,0 +1,6 @@
+echo === Execute $SdkName UnitTests ===
+cd "$WORKSPACE\SDKGenerator\JenkinsConsoleUtility\bin\Debug"
+./JenkinsConsoleUtility.exe --listencs -buildIdentifier JBuild_${SdkName}_${VerticalName}_${NODE_NAME}_${EXECUTOR_NUMBER} -workspacePath "$WORKSPACE" -timeout 60 -verbose true
+if [ ! -z "$killTaskName" ]; then
+    ./JenkinsConsoleUtility.exe --kill -taskname $killTaskName
+fi


### PR DESCRIPTION
Move this script into GitHub, and only do the kill-task option when it's required.