### PR TITLE
XplatCppSDK - fixed a memory leak when allocating a new json reader every time

### DIFF
--- a/targets/XPlatCppSdk/source/cppsdk/source/playfab/PlayFabHttp.cpp
+++ b/targets/XPlatCppSdk/source/cppsdk/source/playfab/PlayFabHttp.cpp
@@ -191,6 +191,7 @@ namespace PlayFab
             Json::CharReader* jsonReader(jsonReaderFactory.newCharReader());
             JSONCPP_STRING jsonParseErrors;
             const bool parsedSuccessfully = jsonReader->parse(reqContainer.responseString.c_str(), reqContainer.responseString.c_str() + reqContainer.responseString.length(), &reqContainer.responseJson, &jsonParseErrors);
+            delete jsonReader;
 
             if (parsedSuccessfully)
             {


### PR DESCRIPTION
There was a JSON reader allocation memory leak bug in our SDK. It was pointed out by a customer. Fixing this.