### PR TITLE
Added a better fix for JSON reader leak based on Scotts request

### DIFF
--- a/targets/XPlatCppSdk/source/cppsdk/source/playfab/PlayFabHttp.cpp
+++ b/targets/XPlatCppSdk/source/cppsdk/source/playfab/PlayFabHttp.cpp
@@ -188,10 +188,9 @@ namespace PlayFab
         else
         {
             Json::CharReaderBuilder jsonReaderFactory;
-            Json::CharReader* jsonReader(jsonReaderFactory.newCharReader());
+            std::unique_ptr<Json::CharReader> jsonReader(jsonReaderFactory.newCharReader());
             JSONCPP_STRING jsonParseErrors;
             const bool parsedSuccessfully = jsonReader->parse(reqContainer.responseString.c_str(), reqContainer.responseString.c_str() + reqContainer.responseString.length(), &reqContainer.responseJson, &jsonParseErrors);
-            delete jsonReader;
 
             if (parsedSuccessfully)
             {


### PR DESCRIPTION
- Scott Munro from Bumblelion team pointed out a better fix for JSON reader leak
- The fix looks more robust because it will allow to use JSON reader throughout the rest of the method without paying attention if it was deleted explicitly earlier or not
- Deleting manually is bad, we need to move away from it
- I verified that it works