### PR TITLE
Add index typescript declaration for NodeJS SDK

### DIFF
--- a/SDKGenerator.njsproj
+++ b/SDKGenerator.njsproj
@@ -136,6 +136,9 @@
     <Compile Include="targets\java\source_androidStudio\src\main\java\com\playfab\androidstudioexample\PlayFabExampleActivity.java" />
     <Compile Include="targets\java\source_androidStudio\src\main\java\com\playfab\PlayFabGetAdvertId.java" />
     <Compile Include="targets\js-node\make.js" />
+    <Compile Include="targets\js-node\source\index.d.ts.ejs">
+      <SubType>Code</SubType>
+    </Compile>
     <Compile Include="targets\js-node\source\test\reporter.js" />
     <Compile Include="targets\LuaSdk\make.js" />
     <Compile Include="targets\newTarget\make.js" />

--- a/SDKGenerator.njsproj
+++ b/SDKGenerator.njsproj
@@ -136,9 +136,7 @@
     <Compile Include="targets\java\source_androidStudio\src\main\java\com\playfab\androidstudioexample\PlayFabExampleActivity.java" />
     <Compile Include="targets\java\source_androidStudio\src\main\java\com\playfab\PlayFabGetAdvertId.java" />
     <Compile Include="targets\js-node\make.js" />
-    <Compile Include="targets\js-node\source\index.d.ts.ejs">
-      <SubType>Code</SubType>
-    </Compile>
+    <Compile Include="targets\js-node\source\index.d.ts.ejs" />
     <Compile Include="targets\js-node\source\test\reporter.js" />
     <Compile Include="targets\LuaSdk\make.js" />
     <Compile Include="targets\newTarget\make.js" />

--- a/targets/js-node/source/index.d.ts.ejs
+++ b/targets/js-node/source/index.d.ts.ejs
@@ -1,0 +1,8 @@
+﻿/// <reference path="Scripts/typings/PlayFab/PlayFab.d.ts" />
+<% for(var i = 0; i < apis.length; i++) { var api = apis[i]; %>/// <reference path="Scripts/typings/PlayFab/PlayFab<%- api.name %>.d.ts" />
+<% } %>
+export const PlayFab: PlayFabModule.IPlayFab;
+export function settings(): PlayFabModule.IPlayFabSettings;
+export function settings(value): void;
+<% for(var i = 0; i < apis.length; i++) { var api = apis[i]; %>export const PlayFab<%= api.name %>: PlayFab<%- api.name %>Module.IPlayFab<%- api.name %>;
+<% } %>

--- a/targets/js-node/source/package.json.ejs
+++ b/targets/js-node/source/package.json.ejs
@@ -11,6 +11,7 @@
   "scripts": {
     "test": ".\\test\\run.bat"
   },
+  "types":  "./index.d.ts",
   "repository": {
     "type": "git",
     "url": "https://github.com/playfab/NodeSDK"

--- a/targets/js-node/source/tsconfig.json.ejs
+++ b/targets/js-node/source/tsconfig.json.ejs
@@ -3,6 +3,7 @@
         "module": "commonjs"
     },
     "files": [
+        "index.d.ts",
         "Scripts/typings/PlayFab/PlayFab.d.ts",
 <% for(var i = 0; i < apis.length; i++) { var api = apis[i];
 %>        "Scripts/typings/PlayFab/PlayFab<%- api.name %>.d.ts",


### PR DESCRIPTION
When I was using the playfab-sdk npm package while using visual studio code, I wasn't able to use the typing from the file structure as it wasn't in the standard typing locations that IDEs look for.

This change allows developers to call `import { PlayFabAdmin, PlayFabClient } from "playfab-sdk";` and it will just work, as the IDE and typescript can infer that the `index.js` file's typings are in `index.d.ts`.

This could be expanded for the other files such as `Scripts/PlayFab/PlayFab<api.name>.js`. But I wanted to go for the simplest fix first that doesn't have too many duplicate or huge changes.