### PR TITLE
Fixed PluginManager, Unit Tests

### DIFF
--- a/targets/XPlatCppSdk/source/LibUnitTest/LibUnitTest.vcxproj.ejs
+++ b/targets/XPlatCppSdk/source/LibUnitTest/LibUnitTest.vcxproj.ejs
@@ -94,8 +94,12 @@
   </ItemDefinitionGroup>
   <ItemGroup>
     <ClInclude Include="stdafx.h" />
+    <ClInclude Include="targetver.h" />
   </ItemGroup>
   <ItemGroup>
+    <ClCompile Include="PlayFabClientTest.cpp" />
+    <ClCompile Include="PlayFabEntityTest.cpp" />
+    <ClCompile Include="PlayFabServerTest.cpp" />
     <ClCompile Include="stdafx.cpp">
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">Create</PrecompiledHeader>
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release|x64'">Create</PrecompiledHeader>
@@ -121,6 +125,13 @@
     <Import Project="..\packages\libssh2.1.4.3.3\build\native\libssh2.targets" Condition="Exists('..\packages\libssh2.1.4.3.3\build\native\libssh2.targets')" />
     <Import Project="..\packages\curl.7.30.0.2\build\native\curl.targets" Condition="Exists('..\packages\curl.7.30.0.2\build\native\curl.targets')" />
   </ImportGroup>
+  <Target Name="CopyDependencies" AfterTargets="AfterBuild"> 
+    <ItemGroup> 
+      <Dependency Include="$(TFS_BinariesDirectory)\$(Configuration)\$(Platform)\XPlatCppWindows\*.dll" />
+      <Dependency Include="$(SolutionDir)$(Platform)\$(Configuration)\XPlatCppWindows\*.dll" />
+    </ItemGroup>
+    <Copy SourceFiles="@(Dependency)" DestinationFolder="$(OutDir)" SkipUnchangedFiles="true" />
+  </Target>
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>

--- a/targets/XPlatCppSdk/source/LibUnitTest/LibUnitTest.vcxproj.filters
+++ b/targets/XPlatCppSdk/source/LibUnitTest/LibUnitTest.vcxproj.filters
@@ -18,10 +18,22 @@
     <ClInclude Include="stdafx.h">
       <Filter>Header Files</Filter>
     </ClInclude>
+    <ClInclude Include="targetver.h"> 
+      <Filter>Header Files</Filter>    
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="stdafx.cpp">
       <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="PlayFabClientTest.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="PlayFabEntityTest.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="PlayFabServerTest.cpp">
+      <Filter>Source Files</Filter> 
     </ClCompile>
   </ItemGroup>
   <ItemGroup>

--- a/targets/XPlatCppSdk/source/LibUnitTest/PlayFabClientTest.cpp
+++ b/targets/XPlatCppSdk/source/LibUnitTest/PlayFabClientTest.cpp
@@ -1,0 +1,572 @@
+#include <stdafx.h>
+
+#ifndef DISABLE_PLAYFABCLIENT_API
+
+#include <fstream>
+#include <CppUnitTest.h>
+#include <cstdlib> // _dupenv_s
+#include <Windows.h> // Sleep()
+
+#include <json/reader.h>
+
+#include <playfab/PlayFabClientDataModels.h>
+#include <playfab/PlayFabClientApi.h>
+#include <playfab/PlayFabSettings.h>
+
+using namespace Microsoft::VisualStudio::CppUnitTestFramework;
+using namespace std;
+using namespace PlayFab;
+using namespace ClientModels;
+
+namespace UnittestRunner
+{
+    TEST_CLASS(PlayFabClientTest)
+    {
+        // Functional
+        static bool TITLE_INFO_SET;
+
+        // Fixed values provided from testInputs
+        static string USER_EMAIL;
+
+        // Information fetched by appropriate API calls
+        static string playFabId;
+
+        static const int TEST_STAT_BASE;
+        static const string TEST_STAT_NAME;
+        static string TEST_TITLE_DATA_LOC;
+        static const string TEST_DATA_KEY_1;
+        static const string TEST_DATA_KEY_2;
+
+        // Variables for specific tests
+        static string testMessageReturn;
+        static Int32 testMessageInt1;
+        static Int32 testMessageInt2;
+        static time_t testMessageTime;
+        static bool testMessageBool;
+
+    public:
+        /// <summary>
+        /// PlayFab Title cannot be created from SDK tests, so you must provide your titleId to run unit tests.
+        /// (Also, we don't want lots of excess unused titles)
+        /// </summary>
+        static void SetTitleInfo(Json::Value titleData)
+        {
+            // Parse all the inputs
+            PlayFab::PlayFabSettings::threadedCallbacks = false;
+            PlayFabSettings::titleId = titleData["titleId"].asString();
+            USER_EMAIL = titleData["userEmail"].asString();
+
+            // Verify all the inputs won't cause crashes in the tests
+            TITLE_INFO_SET = true;
+        }
+
+        TEST_CLASS_INITIALIZE(ClassInitialize)
+        {
+            if (TITLE_INFO_SET)
+                return;
+
+            // Prefer to load path from environment variable, if present
+            char* envPath = nullptr;
+            size_t envPathStrLen;
+            const errno_t err = _dupenv_s(&envPath, &envPathStrLen, "PF_TEST_TITLE_DATA_JSON");
+            if (err == 0 && envPath != nullptr)
+                TEST_TITLE_DATA_LOC = envPath;
+            if (envPath != nullptr)
+                free(envPath);
+
+            ifstream titleInput;
+            if (TEST_TITLE_DATA_LOC.length() > 0)
+                titleInput.open(TEST_TITLE_DATA_LOC, ios::binary | ios::in);
+            if (titleInput)
+            {
+                const auto begin = titleInput.tellg();
+                titleInput.seekg(0, ios::end);
+                const auto end = titleInput.tellg();
+                const int size = static_cast<int>(end - begin);
+                char* titleJson = new char[size + 1];
+                titleInput.seekg(0, ios::beg);
+                titleInput.read(titleJson, size);
+                titleJson[size] = '\0';
+
+                Json::CharReaderBuilder jsonReaderFactory;
+                Json::CharReader* jsonReader(jsonReaderFactory.newCharReader());
+                JSONCPP_STRING jsonParseErrors;
+                Json::Value titleData;
+                const bool parsedSuccessfully = jsonReader->parse(titleJson, titleJson + size + 1, &titleData, &jsonParseErrors);
+                if (parsedSuccessfully)
+                    SetTitleInfo(titleData);
+
+                delete[] titleJson;
+            }
+            else
+            {
+                // TODO: POPULATE THIS SECTION WITH REAL INFORMATION (or set up a testTitleData file, and set your PF_TEST_TITLE_DATA_JSON to the path for that file)
+                PlayFabSettings::titleId = ""; // The titleId for your title, found in the "Settings" section of PlayFab Game Manager
+                USER_EMAIL = ""; // This is the email for a valid user (test tries to log into it with an invalid password, and verifies error result)
+            }
+        }
+        TEST_CLASS_CLEANUP(ClassCleanup)
+        {
+            PlayFabClientAPI::ForgetAllCredentials();
+        }
+
+        static void PlayFabApiWait()
+        {
+            testMessageReturn = "pending";
+            size_t count = 1, sleepCount = 0;
+            while (count != 0)
+            {
+                count = PlayFabClientAPI::Update();
+                sleepCount++;
+                Sleep(1);
+            }
+            // Assert::IsTrue(sleepCount < 20); // The API call shouldn't take too long
+        }
+
+        // A shared failure function for all calls (That don't expect failure)
+        static void SharedFailedCallback(const PlayFabError& error, void* = nullptr)
+        {
+            testMessageReturn.clear();
+            testMessageReturn.reserve(1024);
+            testMessageReturn = "API_Call_Failed for: ";
+            testMessageReturn += error.UrlPath;
+            testMessageReturn += "\n";
+            testMessageReturn += error.GenerateErrorReport();
+            testMessageReturn += "\n";
+            testMessageReturn += error.Request.toStyledString();
+        }
+
+        /// <summary>
+        /// CLIENT API
+        /// Try to deliberately log in with an inappropriate password,
+        ///   and verify that the error displays as expected.
+        /// </summary>
+        TEST_METHOD(InvalidLogin)
+        {
+            LoginWithEmailAddressRequest request;
+            request.Email = USER_EMAIL;
+            request.Password = "INVALID";
+
+            PlayFabClientAPI::LoginWithEmailAddress(request, LoginCallback, LoginFailedCallback);
+            PlayFabApiWait();
+
+            Assert::IsTrue(testMessageReturn.compare("InvalidLogin - Password correctly reported") == 0, U(testMessageReturn).c_str()); // This call is supposed to return as an error
+        }
+        static void LoginCallback(const LoginResult& result, void*)
+        {
+            testMessageReturn = "Login_Success";
+            playFabId = result.PlayFabId; // Successful login tracks playFabId
+        }
+        static void LoginFailedCallback(const PlayFabError& error, void*)
+        {
+            if (error.ErrorMessage.find("password") != string::npos)
+                testMessageReturn = "InvalidLogin - Password correctly reported";
+            else
+                SharedFailedCallback(error);
+        }
+
+        /// <summary>
+        /// CLIENT API
+        /// Test that a lambda error callback can be successfully invoked
+        /// </summary>
+        TEST_METHOD(InvalidLoginLambda)
+        {
+            LoginWithEmailAddressRequest request;
+            request.Email = USER_EMAIL;
+            request.Password = "INVALID";
+
+            PlayFabClientAPI::LoginWithEmailAddress(request, LoginCallback, [](const PlayFabError&, void*) { testMessageReturn = "Lambda failure success"; });
+            PlayFabApiWait();
+
+            Assert::IsTrue(testMessageReturn.compare("Lambda failure success") == 0, U(testMessageReturn).c_str()); // This call is supposed to return as an error
+        }
+
+        /// <summary>
+        /// CLIENT API
+        /// Try to deliberately register a user with an invalid email and password
+        ///   Verify that errorDetails are populated correctly.
+        /// </summary>
+        TEST_METHOD(InvalidRegistration)
+        {
+            RegisterPlayFabUserRequest request;
+            request.Username = "x";
+            request.Email = "x";
+            request.Password = "x";
+            PlayFabClientAPI::RegisterPlayFabUser(request, InvalidRegistrationSuccess, InvalidRegistrationFail);
+            PlayFabApiWait();
+
+            Assert::IsTrue(testMessageReturn.compare("InvalidRegistration - errorDetails correctly reported") == 0, U(testMessageReturn).c_str()); // This call is supposed to return as an error
+        }
+        static void InvalidRegistrationSuccess(const RegisterPlayFabUserResult&, void*)
+        {
+            testMessageReturn = "InvalidRegistration was expected to fail";
+        }
+        static void InvalidRegistrationFail(const PlayFabError& error, void*)
+        {
+            bool foundEmailMsg, foundPasswordMsg;
+            string expectedEmailMsg = "Email address is not valid.";
+            string expectedPasswordMsg = "Password must be between";
+            string errorConcat = error.GenerateErrorReport();
+            foundEmailMsg = (errorConcat.find(expectedEmailMsg) != -1);
+            foundPasswordMsg = (errorConcat.find(expectedPasswordMsg) != -1);
+
+            if (foundEmailMsg && foundPasswordMsg)
+                testMessageReturn = "InvalidRegistration - errorDetails correctly reported";
+            else
+                SharedFailedCallback(error);
+        }
+
+        /// <summary>
+        /// CLIENT API
+        /// Log in or create a user, track their PlayFabId
+        /// </summary>
+        TEST_METHOD(LoginOrRegister)
+        {
+            if (PlayFabClientAPI::IsClientLoggedIn())
+                return; // This test has to have passed at least once for this case to happen
+
+            LoginWithCustomIDRequest loginRequest;
+            loginRequest.CustomId = PlayFabSettings::buildIdentifier;
+            loginRequest.CreateAccount = true;
+
+            PlayFabClientAPI::LoginWithCustomID(loginRequest, LoginCallback, LoginFailedCallback);
+            PlayFabApiWait();
+            Assert::IsTrue(PlayFabClientAPI::IsClientLoggedIn(), U(testMessageReturn).c_str());
+        }
+
+        /// <summary>
+        /// CLIENT API
+        /// Test that the login call sequence sends the AdvertisingId when set
+        /// </summary>
+        TEST_METHOD(LoginWithAdvertisingId)
+        {
+            PlayFabSettings::advertisingIdType = PlayFabSettings::AD_TYPE_ANDROID_ID;
+            PlayFabSettings::advertisingIdValue = "PlayFabTestId";
+
+            LoginWithCustomIDRequest loginRequest;
+            loginRequest.CustomId = PlayFabSettings::buildIdentifier;
+            loginRequest.CreateAccount = true;
+
+            PlayFabClientAPI::LoginWithCustomID(loginRequest, LoginCallback, LoginFailedCallback);
+            PlayFabApiWait();
+
+            auto targetValue = PlayFabSettings::AD_TYPE_ANDROID_ID + "_Successful";
+            auto actualValue = PlayFabSettings::advertisingIdType;
+            Assert::IsTrue(actualValue.compare(targetValue) == 0, L"Check that advertisingId was sent.");
+        }
+
+        /// <summary>
+        /// CLIENT API
+        /// Test a sequence of calls that modifies saved data,
+        ///   and verifies that the next sequential API call contains updated data.
+        /// Verify that the data is correctly modified on the next call.
+        /// Parameter types tested: string, map<string, UserDataRecord>, DateTime
+        /// </summary>
+        TEST_METHOD(UserDataApi)
+        {
+            LoginOrRegister(); // C++ Environment is nicely secluded, but also means that we have to manually handle sequential requirements
+
+                               // Define some of the containers we use in this test
+            GetUserDataRequest getRequest;
+            UpdateUserDataRequest updateRequest1, updateRequest2;
+            int testCounterValueActual;
+
+            PlayFabClientAPI::GetUserData(getRequest, GetDataCallback, SharedFailedCallback);
+            PlayFabApiWait();
+            Assert::IsTrue(testMessageReturn.compare("GetData_Success") == 0, L"Check that GetUserData was successful");
+            int testCounterValueExpected = (testMessageInt1 + 1) % 100; // This test is about the expected value changing - but not testing more complicated issues like bounds
+
+            updateRequest1.Data[TEST_DATA_KEY_1] = to_string(testCounterValueExpected);
+            updateRequest1.Data[TEST_DATA_KEY_2] = string("This is trash");
+            PlayFabClientAPI::UpdateUserData(updateRequest1, UpdateDataCallback, SharedFailedCallback);
+            PlayFabApiWait();
+            Assert::IsTrue(testMessageReturn.compare("UpdateData_Success") == 0, L"Check that UpdateUserData was successful");
+
+            PlayFabClientAPI::GetUserData(getRequest, GetDataCallback, SharedFailedCallback);
+            PlayFabApiWait();
+            Assert::IsTrue(testMessageReturn.compare("GetData_Success") == 0, L"Check that GetUserData was successful");
+            testCounterValueActual = testMessageInt1;
+            Assert::AreEqual(testCounterValueExpected, testCounterValueActual, L"Check that the userData counter was incremented as expected");
+            Assert::IsTrue(testMessageBool, L"Check if TEST_DATA_KEY_2 exists");
+
+            // Check for, and remove TEST_DATA_KEY_2
+            updateRequest2.KeysToRemove.emplace_back(TEST_DATA_KEY_2);
+            PlayFabClientAPI::UpdateUserData(updateRequest2, UpdateDataCallback, SharedFailedCallback);
+            PlayFabApiWait();
+            Assert::IsTrue(testMessageReturn.compare("UpdateData_Success") == 0, L"Check that UpdateUserData was successful");
+
+            PlayFabClientAPI::GetUserData(getRequest, GetDataCallback, SharedFailedCallback);
+            PlayFabApiWait();
+            Assert::IsTrue(testMessageReturn.compare("GetData_Success") == 0, L"Check that GetUserData was successful");
+            Assert::IsFalse(testMessageBool, L"Check if TEST_DATA_KEY_2 is removed"); // TEST_DATA_KEY_2 is removed
+
+            time_t now = time(nullptr);
+            tm timeInfo;
+            gmtime_s(&timeInfo, &now);
+            now = mktime(&timeInfo);
+            time_t minTime = now - (60 * 5);
+            time_t maxTime = now + (60 * 5);
+            Assert::IsTrue(minTime <= testMessageTime && testMessageTime <= maxTime, L"Timestamps don't match");
+        }
+        static void GetDataCallback(const GetUserDataResult& result, void*)
+        {
+            testMessageReturn = "GetData_Success";
+            const auto it1 = result.Data.find(TEST_DATA_KEY_1);
+            if (it1 != result.Data.end())
+            {
+                testMessageInt1 = atoi(it1->second.Value.c_str());
+                testMessageTime = it1->second.LastUpdated;
+            }
+            const auto it2 = result.Data.find(TEST_DATA_KEY_2);
+            testMessageBool = (it2 != result.Data.end());
+        }
+        static void UpdateDataCallback(const UpdateUserDataResult&, void*)
+        {
+            // The update result doesn't contain anything interesting.  It's better to just re-call GetUserData again to verify the update
+            testMessageReturn = "UpdateData_Success";
+        }
+
+        /// <summary>
+        /// CLIENT API
+        /// Test a sequence of calls that modifies saved data,
+        ///   and verifies that the next sequential API call contains updated data.
+        /// Verify that the data is saved correctly, and that specific types are tested
+        /// Parameter types tested: map<string, Int32>
+        /// </summary>
+        TEST_METHOD(PlayerStatisticsApi)
+        {
+            LoginOrRegister(); // C++ Environment is nicely secluded, but also means that we have to manually handle sequential requirements
+
+            testMessageInt1 = 0;
+            GetPlayerStatisticsRequest getRequest;
+            PlayFabClientAPI::GetPlayerStatistics(getRequest, GetStatsCallback, SharedFailedCallback);
+            PlayFabApiWait();
+            const Int32 testStatValueExpected = (testMessageInt1 + 5) % 100;
+
+            UpdatePlayerStatisticsRequest updateRequest;
+            StatisticUpdate statUpdate;
+            statUpdate.StatisticName = TEST_STAT_NAME;
+            statUpdate.Value = testStatValueExpected;
+            updateRequest.Statistics.insert(updateRequest.Statistics.begin(), statUpdate);
+            PlayFabClientAPI::UpdatePlayerStatistics(updateRequest, UpdateStatsCallback, SharedFailedCallback);
+            PlayFabApiWait();
+            Assert::IsTrue(testMessageReturn.compare("UpdateStats_Success") == 0, U(testMessageReturn).c_str());
+
+            testMessageInt1 = -1000;
+            PlayFabClientAPI::GetPlayerStatistics(getRequest, GetStatsCallback, SharedFailedCallback);
+            PlayFabApiWait();
+            Assert::IsTrue(testMessageReturn.compare("GetStats_Success") == 0, U(testMessageReturn).c_str());
+            const Int32 testStatValueActual = testMessageInt1;
+
+            Assert::AreEqual(testStatValueExpected, testStatValueActual);
+        }
+        static void GetStatsCallback(const GetPlayerStatisticsResult& result, void*)
+        {
+            bool success = false;
+            for (auto it = result.Statistics.begin(); it != result.Statistics.end(); ++it)
+            {
+                if (it->StatisticName == TEST_STAT_NAME)
+                {
+                    testMessageInt1 = it->Value;
+                    success = true;
+                }
+            }
+            if (success)
+                testMessageReturn = "GetStats_Success";
+            else
+                testMessageReturn = "Target statistic not found";
+        }
+        static void UpdateStatsCallback(const UpdatePlayerStatisticsResult&, void*)
+        {
+            // The update result doesn't contain anything interesting.  It's better to just re-call GetUserData again to verify the update
+            testMessageReturn = "UpdateStats_Success";
+        }
+
+        /// <summary>
+        /// CLIENT API
+        /// Get characters is no longer very useful
+        /// </summary>
+        TEST_METHOD(UserCharacter)
+        {
+            LoginOrRegister(); // C++ Environment is nicely secluded, but also means that we have to manually handle sequential requirements
+
+            ListUsersCharactersRequest request;
+            PlayFabClientAPI::GetAllUsersCharacters(request, GetCharsCallback, SharedFailedCallback);
+            PlayFabApiWait();
+            Assert::IsTrue(testMessageReturn.compare("GetChars_Success") == 0, U(testMessageReturn).c_str());
+        }
+        static void GetCharsCallback(const ListUsersCharactersResult&, void*)
+        {
+            testMessageReturn = "GetChars_Success";
+        }
+
+        /// <summary>
+        /// CLIENT API
+        /// Test that leaderboard results can be requested
+        /// Parameter types tested: List of contained-classes
+        /// </summary>
+        TEST_METHOD(LeaderBoard)
+        {
+            // C++ Environment is nicely secluded, but also means that we have to manually handle sequential requirements
+            LoginOrRegister();
+            PlayerStatisticsApi();
+
+            GetLeaderboardRequest clientRequest;
+            clientRequest.MaxResultsCount = 3;
+            clientRequest.StatisticName = TEST_STAT_NAME;
+            PlayFabClientAPI::GetLeaderboard(clientRequest, ClientLeaderboardCallback, SharedFailedCallback);
+            PlayFabApiWait();
+            Assert::IsTrue(testMessageReturn.compare("GetClientLB_Success") == 0, U(testMessageReturn).c_str());
+            Assert::IsTrue(testMessageInt1 != 0, L"There should be at least 1 leaderboard entry");
+            Assert::IsTrue(testMessageInt2 == clientRequest.MaxResultsCount, L"result.request.MaxResultsCount did not match expected value");
+        }
+        static void ClientLeaderboardCallback(const GetLeaderboardResult& result, void*)
+        {
+            testMessageReturn = "GetClientLB_Success";
+            testMessageInt1 = static_cast<Int32>(result.Leaderboard.size());
+            // Verifies that the request comes through as expected
+            testMessageInt2 = result.Request["MaxResultsCount"].asInt();
+        }
+
+        /// <summary>
+        /// CLIENT API
+        /// Test that AccountInfo can be requested
+        /// Parameter types tested: List of enum-as-strings converted to list of enums
+        /// </summary>
+        TEST_METHOD(AccountInfo)
+        {
+            LoginOrRegister();
+
+            GetAccountInfoRequest request;
+            request.PlayFabId = playFabId;
+            PlayFabClientAPI::GetAccountInfo(request, AcctInfoCallback, SharedFailedCallback);
+            PlayFabApiWait();
+            Assert::IsTrue(testMessageReturn.compare("Enums tested") == 0, U(testMessageReturn).c_str());
+        }
+        static void AcctInfoCallback(const GetAccountInfoResult& result, void*)
+        {
+            if (result.AccountInfo.isNull() || result.AccountInfo->TitleInfo.isNull() || result.AccountInfo->TitleInfo->Origination.isNull())
+            {
+                testMessageReturn = "Enums not properly tested";
+                return;
+            }
+
+            testMessageReturn = "Enums tested";
+        }
+
+        /// <summary>
+        /// CLIENT API
+        /// Test that CloudScript can be properly set up and invoked
+        /// </summary>
+        TEST_METHOD(CloudScript)
+        {
+            LoginOrRegister();
+
+            ExecuteCloudScriptRequest hwRequest;
+            hwRequest.FunctionName = "helloWorld";
+            PlayFabClientAPI::ExecuteCloudScript(hwRequest, CloudHelloWorldCallback, SharedFailedCallback);
+            PlayFabApiWait();
+
+            const bool success = testMessageReturn.find("Hello " + playFabId + "!") != -1;
+            Assert::IsTrue(success, U(testMessageReturn).c_str());
+        }
+        static void CloudHelloWorldCallback(const ExecuteCloudScriptResult& constResult, void* = nullptr)
+        {
+            ExecuteCloudScriptResult result = constResult; // Some Json::Value syntax is unavailable for const objects, and there's just no way around it
+            if (result.FunctionResult.isNull())
+                testMessageReturn = "Cloud Decode Failure";
+            else if (!result.Error.isNull())
+                testMessageReturn = result.Error->Message;
+            else
+                testMessageReturn = result.FunctionResult["messageValue"].asString();
+        }
+
+        /// <summary>
+        /// CLIENT API
+        /// Test that a lambda success callback can be successfully invoked
+        /// </summary>
+        TEST_METHOD(CloudScriptLambda)
+        {
+            LoginOrRegister();
+
+            ExecuteCloudScriptRequest hwRequest;
+            hwRequest.FunctionName = "helloWorld";
+            PlayFabClientAPI::ExecuteCloudScript(hwRequest, [](const ExecuteCloudScriptResult& constResult, void*) { CloudHelloWorldCallback(constResult); }, SharedFailedCallback);
+            PlayFabApiWait();
+
+            const bool success = testMessageReturn.find("Hello " + playFabId + "!") != -1;
+            Assert::IsTrue(success, U(testMessageReturn).c_str());
+        }
+
+        /// <summary>
+        /// CLIENT API
+        /// Test that CloudScript errors can be deciphered
+        /// </summary>
+        TEST_METHOD(CloudScriptError)
+        {
+            LoginOrRegister();
+
+            ExecuteCloudScriptRequest errRequest;
+            errRequest.FunctionName = "throwError";
+            PlayFabClientAPI::ExecuteCloudScript(errRequest, CloudErrorCallback, SharedFailedCallback);
+            PlayFabApiWait();
+
+            Assert::IsTrue(testMessageReturn.find("JavascriptException") == 0, U(testMessageReturn).c_str());
+        }
+        static void CloudErrorCallback(const ExecuteCloudScriptResult& result, void*)
+        {
+            testMessageReturn = "";
+            if (!result.FunctionResult.isNull())
+                testMessageReturn = "FunctionResult was unexpectedly defined.";
+            else if (result.Error.isNull())
+                testMessageReturn = "Cloud Script error not found.";
+            else
+                testMessageReturn = result.Error->Error;
+        }
+
+        /// <summary>
+        /// CLIENT API
+        /// Test that the client can publish custom PlayStream events
+        /// </summary>
+        TEST_METHOD(WriteEvent)
+        {
+            LoginOrRegister();
+
+            WriteClientPlayerEventRequest request;
+            request.EventName = "ForumPostEvent";
+            request.Timestamp = time(nullptr);
+            request.Body["Subject"] = "My First Post";
+            request.Body["Body"] = "My awesome post.";
+            PlayFabClientAPI::WritePlayerEvent(request, OnWritePlayerEvent, SharedFailedCallback);
+            PlayFabApiWait();
+            Assert::IsTrue(testMessageReturn.compare("WriteEvent tested") == 0, U(testMessageReturn).c_str());
+        }
+        static void OnWritePlayerEvent(const WriteEventResponse&, void*)
+        {
+            testMessageReturn = "WriteEvent tested";
+        }
+    };
+
+    bool PlayFabClientTest::TITLE_INFO_SET = false;
+
+    // Fixed values provided from testInputs
+    string PlayFabClientTest::USER_EMAIL;
+
+    // Information fetched by appropriate API calls
+    string PlayFabClientTest::playFabId;
+
+    const int PlayFabClientTest::TEST_STAT_BASE = 10;
+    const string PlayFabClientTest::TEST_STAT_NAME = "str";
+    string PlayFabClientTest::TEST_TITLE_DATA_LOC = "testTitleData.json"; // default to local file if PF_TEST_TITLE_DATA_JSON env-var does not exist
+    const string PlayFabClientTest::TEST_DATA_KEY_1 = "testCounter";
+    const string PlayFabClientTest::TEST_DATA_KEY_2 = "deleteCounter";
+
+    // Variables for specific tests
+    string PlayFabClientTest::testMessageReturn;
+    Int32 PlayFabClientTest::testMessageInt1;
+    Int32 PlayFabClientTest::testMessageInt2;
+    time_t PlayFabClientTest::testMessageTime;
+    bool PlayFabClientTest::testMessageBool;
+}
+
+#endif

--- a/targets/XPlatCppSdk/source/LibUnitTest/PlayFabEntityTest.cpp
+++ b/targets/XPlatCppSdk/source/LibUnitTest/PlayFabEntityTest.cpp
@@ -1,0 +1,251 @@
+#include <stdafx.h>
+
+#if defined(ENABLE_PLAYFABENTITY_API) && !defined(DISABLE_PLAYFABCLIENT_API)
+
+#include <fstream>
+#include <CppUnitTest.h>
+#include <stdlib.h> // _dupenv_s
+#include <Windows.h> // Sleep()
+
+#include <json/reader.h>
+
+#include <playfab/PlayFabClientDataModels.h>
+#include <playfab/PlayFabClientApi.h>
+#include <playfab/PlayFabEntityDataModels.h>
+#include <playfab/PlayFabEntityApi.h>
+#include <playfab/PlayFabSettings.h>
+
+using namespace Microsoft::VisualStudio::CppUnitTestFramework;
+using namespace std;
+using namespace PlayFab;
+using namespace ClientModels;
+using namespace EntityModels;
+
+namespace UnittestRunner
+{
+    TEST_CLASS(PlayFabEntityTest)
+    {
+        static bool TITLE_INFO_SET;
+        static string TEST_TITLE_DATA_LOC;
+        static int testMessageInt1;
+        static int testMessageInt2;
+        static string testMessageReturn;
+        static string entityToken;
+        static EntityModels::EntityKey entityKey;
+        static int testInteger;
+
+        static const string TEST_OBJ_NAME;
+
+    public:
+        /// <summary>
+        /// PlayFab Title cannot be created from SDK tests, so you must provide your titleId to run unit tests.
+        /// (Also, we don't want lots of excess unused titles)
+        /// </summary>
+        static void SetTitleInfo(Json::Value titleData)
+        {
+            TITLE_INFO_SET = true;
+
+            // Parse all the inputs
+            PlayFabSettings::titleId = titleData["titleId"].asString();
+            PlayFabSettings::developerSecretKey = titleData["developerSecretKey"].asString();
+
+            // Verify all the inputs won't cause crashes in the tests
+            TITLE_INFO_SET = true;
+        }
+
+        TEST_CLASS_INITIALIZE(ClassInitialize)
+        {
+            if (TITLE_INFO_SET)
+                return;
+
+            // Prefer to load path from environment variable, if present
+            char* envPath = nullptr;
+            size_t envPathStrLen;
+            errno_t err = _dupenv_s(&envPath, &envPathStrLen, "PF_TEST_TITLE_DATA_JSON");
+            if (err == 0 && envPath != nullptr)
+                TEST_TITLE_DATA_LOC = envPath;
+            if (envPath != nullptr)
+                free(envPath);
+
+            ifstream titleInput;
+            if (TEST_TITLE_DATA_LOC.length() > 0)
+                titleInput.open(TEST_TITLE_DATA_LOC, ios::binary | ios::in);
+            if (titleInput)
+            {
+                const auto begin = titleInput.tellg();
+                titleInput.seekg(0, ios::end);
+                const auto end = titleInput.tellg();
+                const int size = static_cast<int>(end - begin);
+                char* titleJson = new char[size + 1];
+                titleInput.seekg(0, ios::beg);
+                titleInput.read(titleJson, size);
+                titleJson[size] = '\0';
+
+                Json::CharReaderBuilder jsonReaderFactory;
+                Json::CharReader* jsonReader(jsonReaderFactory.newCharReader());
+                JSONCPP_STRING jsonParseErrors;
+                Json::Value titleData;
+                const bool parsedSuccessfully = jsonReader->parse(titleJson, titleJson + size + 1, &titleData, &jsonParseErrors);
+                if (parsedSuccessfully)
+                    SetTitleInfo(titleData);
+
+                delete[] titleJson;
+            }
+            else
+            {
+                // TODO: POPULATE THIS SECTION WITH REAL INFORMATION (or set up a testTitleData file, and set your PF_TEST_TITLE_DATA_JSON to the path for that file)
+                PlayFabSettings::titleId = ""; // The titleId for your title, found in the "Settings" section of PlayFab Game Manager
+            }
+        }
+        TEST_CLASS_CLEANUP(ClassCleanup)
+        {
+            PlayFabEntityAPI::ForgetAllCredentials();
+        }
+
+        static void PlayFabApiWait()
+        {
+            testMessageReturn = "pending";
+            size_t count = 1, sleepCount = 0;
+            while (count != 0)
+            {
+                count = PlayFabEntityAPI::Update();
+                sleepCount++;
+                Sleep(1);
+            }
+            // Assert::IsTrue(sleepCount < 20); // The API call shouldn't take too long
+        }
+
+        // A shared failure function for all calls (That don't expect failure)
+        static void SharedFailedCallback(const PlayFabError& error, void*)
+        {
+            testMessageReturn.clear();
+            testMessageReturn.reserve(1024);
+            testMessageReturn = "API_Call_Failed for: ";
+            testMessageReturn += error.UrlPath;
+            testMessageReturn += "\n";
+            testMessageReturn += error.GenerateReport();
+            testMessageReturn += "\n";
+            testMessageReturn += error.Request.toStyledString();
+        }
+
+        /// <summary>
+        /// CLIENT API
+        /// Log in or create a user, track their PlayFabId
+        /// </summary>
+        TEST_METHOD(LoginClient)
+        {
+            if (PlayFabClientAPI::IsClientLoggedIn())
+                return; // This test has to have passed at least once for this case to happen
+
+            LoginWithCustomIDRequest loginRequest;
+            loginRequest.CustomId = PlayFabSettings::buildIdentifier;
+            loginRequest.CreateAccount = true;
+
+            PlayFabClientAPI::LoginWithCustomID(loginRequest, nullptr, SharedFailedCallback, nullptr);
+            PlayFabApiWait();
+            Assert::IsTrue(PlayFabClientAPI::IsClientLoggedIn());
+        }
+
+        /// <summary>
+        /// ENTITY API
+        /// Verify that a client login can be converted into an entity token
+        /// </summary>
+        TEST_METHOD(GetEntityToken)
+        {
+            LoginClient();
+
+            GetEntityTokenRequest request;
+            PlayFabEntityAPI::GetEntityToken(request, GetEntityTokenCallback, SharedFailedCallback, nullptr);
+            PlayFabApiWait();
+
+            Assert::IsTrue(testMessageReturn.compare("Entity Token Received") == 0, U(testMessageReturn).c_str()); // We got the entity token
+            Assert::IsTrue(entityKey.TypeString.compare("title_player_account") == 0, U("EntityType: " + entityKey.TypeString).c_str()); // We got the entity token for the type we expected
+            Assert::IsTrue(entityToken.length() > 0, U("Title-Player Entity Token not retrieved from GetEntityToken").c_str());
+            Assert::IsTrue(entityKey.Id.length() > 0, U("Title-Player EntityId not retrieved from GetEntityToken").c_str());
+        }
+        static void GetEntityTokenCallback(const GetEntityTokenResponse& result, void*)
+        {
+            testMessageReturn = "Entity Token Received";
+            entityToken = result.EntityToken;
+
+            // It's unfortunate that we have to specify the internal structure of EntityType here...
+            entityKey.Id = result.Entity->Id;
+            entityKey.Type = result.Entity->Type;
+            entityKey.TypeString = result.Entity->TypeString;
+        }
+
+        /// <summary>
+        /// ENTITY API
+        /// Test a sequence of calls that modifies entity objects,
+        ///   and verifies that the next sequential API call contains updated information.
+        /// Verify that the object is correctly modified on the next call.
+        /// </summary>
+        TEST_METHOD(ObjectApi)
+        {
+            GetEntityToken();
+
+            GetObjectsRequest getRequest;
+            getRequest.Entity = entityKey;
+            PlayFabEntityAPI::GetObjects(getRequest, GetObjectsCallback1, SharedFailedCallback, nullptr);
+            PlayFabApiWait();
+            Assert::IsTrue(testMessageReturn.compare("GetObj1 Success") == 0, U(testMessageReturn).c_str());
+
+            SetObjectsRequest setRequest;
+            setRequest.Entity = entityKey;
+            SetObject setObj;
+            setObj.DataObject = testMessageInt1;
+            setObj.ObjectName = TEST_OBJ_NAME;
+            setRequest.Objects.push_back(setObj);
+            PlayFabEntityAPI::SetObjects(setRequest, SetObjectsCallback, SharedFailedCallback, nullptr);
+            PlayFabApiWait();
+            Assert::IsTrue(testMessageReturn.compare("UpdateObj Success") == 0, U(testMessageReturn).c_str());
+
+            PlayFabEntityAPI::GetObjects(getRequest, GetObjectsCallback2, SharedFailedCallback, nullptr);
+            PlayFabApiWait();
+            Assert::IsTrue(testMessageReturn.compare("GetObj2 Success") == 0, U(testMessageReturn).c_str());
+
+            Assert::IsTrue(testMessageInt1 == testMessageInt2);
+        }
+        static void GetObjectsCallback1(const GetObjectsResponse& result, void*)
+        {
+            testMessageInt1 = 0; // Expected Value
+            for (auto it = result.Objects.begin(); it != result.Objects.end(); ++it)
+                if (it->first.compare(TEST_OBJ_NAME) == 0)
+                    testMessageInt1 = atoi(it->second.EscapedDataObject.c_str());
+            testMessageReturn = "GetObj1 Success";
+        }
+        static void SetObjectsCallback(const SetObjectsResponse& /* result */, void*)
+        {
+            testMessageReturn = "UpdateObj Success";
+        }
+        static void GetObjectsCallback2(const GetObjectsResponse& result, void*)
+        {
+            testMessageInt2 = -1000; // Actual Value
+            testMessageReturn = "GetObj2 Failed";
+            for (auto it = result.Objects.begin(); it != result.Objects.end(); ++it)
+            {
+                if (it->first.compare(TEST_OBJ_NAME) == 0)
+                {
+                    testMessageInt2 = atoi(it->second.EscapedDataObject.c_str());
+                    testMessageReturn = "GetObj2 Success";
+                }
+            }
+        }
+    };
+
+    bool PlayFabEntityTest::TITLE_INFO_SET = false;
+
+    // default to local file if PF_TEST_TITLE_DATA_JSON env-var does not exist
+    string PlayFabEntityTest::TEST_TITLE_DATA_LOC = "testTitleData.json";
+
+    // Variables for specific tests
+    int PlayFabEntityTest::testMessageInt1;
+    int PlayFabEntityTest::testMessageInt2;
+    string PlayFabEntityTest::testMessageReturn;
+    string PlayFabEntityTest::entityToken;
+    EntityModels::EntityKey PlayFabEntityTest::entityKey;
+
+    const string PlayFabEntityTest::TEST_OBJ_NAME = "testCounter";
+}
+
+#endif

--- a/targets/XPlatCppSdk/source/LibUnitTest/PlayFabServerTest.cpp
+++ b/targets/XPlatCppSdk/source/LibUnitTest/PlayFabServerTest.cpp
@@ -1,0 +1,157 @@
+#include <stdafx.h>
+
+#ifdef ENABLE_PLAYFABSERVER_API
+
+#include <fstream>
+#include <CppUnitTest.h>
+#include <stdlib.h> // _dupenv_s
+#include <Windows.h> // Sleep()
+
+#include <json/reader.h>
+
+#include <playfab/PlayFabServerDataModels.h>
+#include <playfab/PlayFabServerApi.h>
+#include <playfab/PlayFabSettings.h>
+
+using namespace Microsoft::VisualStudio::CppUnitTestFramework;
+using namespace std;
+using namespace PlayFab;
+using namespace ServerModels;
+
+namespace UnittestRunner
+{
+    TEST_CLASS(PlayFabServerTest)
+    {
+        static bool TITLE_INFO_SET;
+        static string TEST_TITLE_DATA_LOC;
+        static string testMessageReturn;
+
+    public:
+        /// <summary>
+        /// PlayFab Title cannot be created from SDK tests, so you must provide your titleId to run unit tests.
+        /// (Also, we don't want lots of excess unused titles)
+        /// </summary>
+        static void SetTitleInfo(Json::Value titleData)
+        {
+            TITLE_INFO_SET = true;
+
+            // Parse all the inputs
+            PlayFabSettings::titleId = titleData["titleId"].asString();
+            PlayFabSettings::developerSecretKey = titleData["developerSecretKey"].asString();
+
+            // Verify all the inputs won't cause crashes in the tests
+            TITLE_INFO_SET = true;
+        }
+
+        TEST_CLASS_INITIALIZE(ClassInitialize)
+        {
+            if (TITLE_INFO_SET)
+                return;
+
+            // Prefer to load path from environment variable, if present
+            char* envPath = nullptr;
+            size_t envPathStrLen;
+            errno_t err = _dupenv_s(&envPath, &envPathStrLen, "PF_TEST_TITLE_DATA_JSON");
+            if (err == 0 && envPath != nullptr)
+                TEST_TITLE_DATA_LOC = envPath;
+            if (envPath != nullptr)
+                free(envPath);
+
+            ifstream titleInput;
+            if (TEST_TITLE_DATA_LOC.length() > 0)
+                titleInput.open(TEST_TITLE_DATA_LOC, ios::binary | ios::in);
+            if (titleInput)
+            {
+                const auto begin = titleInput.tellg();
+                titleInput.seekg(0, ios::end);
+                const auto end = titleInput.tellg();
+                const int size = static_cast<int>(end - begin);
+                char* titleJson = new char[size + 1];
+                titleInput.seekg(0, ios::beg);
+                titleInput.read(titleJson, size);
+                titleJson[size] = '\0';
+
+                Json::CharReaderBuilder jsonReaderFactory;
+                Json::CharReader* jsonReader(jsonReaderFactory.newCharReader());
+                JSONCPP_STRING jsonParseErrors;
+                Json::Value titleData;
+                const bool parsedSuccessfully = jsonReader->parse(titleJson, titleJson + size + 1, &titleData, &jsonParseErrors);
+                if (parsedSuccessfully)
+                    SetTitleInfo(titleData);
+
+                delete[] titleJson;
+            }
+            else
+            {
+                // TODO: POPULATE THIS SECTION WITH REAL INFORMATION (or set up a testTitleData file, and set your PF_TEST_TITLE_DATA_JSON to the path for that file)
+                PlayFabSettings::titleId = ""; // The titleId for your title, found in the "Settings" section of PlayFab Game Manager
+            }
+        }
+        TEST_CLASS_CLEANUP(ClassCleanup)
+        {
+            PlayFabServerAPI::ForgetAllCredentials();
+        }
+
+        static void PlayFabApiWait()
+        {
+            testMessageReturn = "pending";
+            size_t count = 1, sleepCount = 0;
+            while (count != 0)
+            {
+                count = PlayFabServerAPI::Update();
+                sleepCount++;
+                Sleep(1);
+            }
+            // Assert::IsTrue(sleepCount < 20); // The API call shouldn't take too long
+        }
+
+        // A shared failure function for all calls (That don't expect failure)
+        static void SharedFailedCallback(const PlayFabError& error, void*)
+        {
+            testMessageReturn.clear();
+            testMessageReturn.reserve(1024);
+            testMessageReturn = "API_Call_Failed for: ";
+            testMessageReturn += error.UrlPath;
+            testMessageReturn += "\n";
+            testMessageReturn += error.GenerateErrorReport();
+            testMessageReturn += "\n";
+            testMessageReturn += error.Request.toStyledString();
+        }
+
+        /// <summary>
+        /// SERVER API
+        /// Test that CloudScript can be properly set up and invoked
+        /// </summary>
+        TEST_METHOD(ServerCloudScript)
+        {
+            ExecuteCloudScriptServerRequest hwRequest;
+            hwRequest.FunctionName = "helloWorld";
+            const string playFabId = hwRequest.PlayFabId = "1337D00D";
+            PlayFabServerAPI::ExecuteCloudScript(hwRequest, CloudHelloWorldCallback, SharedFailedCallback, nullptr);
+            PlayFabApiWait();
+
+            const bool success = (testMessageReturn.find("Hello " + playFabId + "!") != -1);
+            Assert::IsTrue(success, U(testMessageReturn).c_str());
+        }
+        static void CloudHelloWorldCallback(const ExecuteCloudScriptResult& constResult, void*)
+        {
+            ExecuteCloudScriptResult result = constResult; // Some Json::Value syntax is unavailable for const objects, and there's just no way around it
+            if (result.FunctionResult.isNull())
+                testMessageReturn = "Cloud Decode Failure";
+            else if (!result.Error.isNull())
+                testMessageReturn = result.Error->Message;
+            else
+                testMessageReturn = result.FunctionResult["messageValue"].asString();
+        }
+    };
+
+    bool PlayFabServerTest::TITLE_INFO_SET = false;
+
+    // default to local file if PF_TEST_TITLE_DATA_JSON env-var does not exist
+    string PlayFabServerTest::TEST_TITLE_DATA_LOC = "testTitleData.json";
+
+    // Variables for specific tests
+    string PlayFabServerTest::testMessageReturn;
+}
+
+#endif

--- a/targets/XPlatCppSdk/source/cppsdk/include/playfab/PlayFabHttp.h
+++ b/targets/XPlatCppSdk/source/cppsdk/include/playfab/PlayFabHttp.h
@@ -24,6 +24,7 @@ namespace PlayFab
     {
     public:
         static IPlayFabHttp& Get();
+        static std::shared_ptr<IPlayFabHttp> GetPtr();
 
         virtual ~IPlayFabHttp() = 0;
 
@@ -32,7 +33,7 @@ namespace PlayFab
         virtual void MakePostRequest(const CallRequestContainerBase&) = 0;
 
     protected:
-        static std::unique_ptr<IPlayFabHttp> httpInstance;
+        static std::shared_ptr<IPlayFabHttp> httpInstance;
     };
 
     /// <summary>

--- a/targets/XPlatCppSdk/source/cppsdk/include/playfab/PlayFabPluginManager.h
+++ b/targets/XPlatCppSdk/source/cppsdk/include/playfab/PlayFabPluginManager.h
@@ -67,15 +67,7 @@ namespace PlayFab
         // Gets a plugin.
         // If a plugin with specified contract and optional instance name does not exist, it will create a new one.
         template <typename T>
-        static T& GetPlugin(const PlayFabPluginContract contract, const std::string& instanceName = "")
-        {
-            return *GetPlugin2<T>(contract, instanceName);
-        }
-
-        // Gets a plugin.
-        // If a plugin with specified contract and optional instance name does not exist, it will create a new one.
-        template <typename T>
-        static std::shared_ptr<T> GetPlugin2(const PlayFabPluginContract contract, const std::string& instanceName = "")
+        static std::shared_ptr<T> GetPlugin(const PlayFabPluginContract contract, const std::string& instanceName = "")
         {
             return std::static_pointer_cast<T>(GetInstance().GetPluginInternal(contract, instanceName));
         }

--- a/targets/XPlatCppSdk/source/cppsdk/source/playfab/PlayFabHttp.cpp
+++ b/targets/XPlatCppSdk/source/cppsdk/source/playfab/PlayFabHttp.cpp
@@ -10,16 +10,22 @@
 
 namespace PlayFab
 {
-    std::unique_ptr<IPlayFabHttp> IPlayFabHttp::httpInstance = nullptr;
+    std::shared_ptr<IPlayFabHttp> IPlayFabHttp::httpInstance = nullptr;
     IPlayFabHttp::~IPlayFabHttp() = default;
     IPlayFabHttp& IPlayFabHttp::Get()
+    {
+        return *GetPtr().get();
+    }
+
+    std::shared_ptr<IPlayFabHttp> IPlayFabHttp::GetPtr()
     {
         // In the future we could make it easier to override this instance with a sub-type, for now it defaults to the only one we have
         if (httpInstance == nullptr)
         {
             PlayFabHttp::MakeInstance();
         }
-        return *httpInstance.get();
+
+        return httpInstance;
     }
 
     PlayFabHttp::PlayFabHttp()
@@ -56,10 +62,10 @@ namespace PlayFab
         {
 #if __cplusplus > 201103L
             class _PlayFabHttp : public PlayFabHttp {}; // Hack to bypass private constructor on PlayFabHttp
-            httpInstance = std::make_unique<_PlayFabHttp>();
+            httpInstance = std::make_shared<_PlayFabHttp>();
 #else
 #pragma message("PlayFab SDK: C++11 support is not well tested. Please consider upgrading to the latest version of Visual Studio")
-            httpInstance = std::unique_ptr<PlayFabHttp>(new PlayFabHttp());
+            httpInstance = std::shared_ptr<PlayFabHttp>(new PlayFabHttp());
 #endif
         }
     }
@@ -188,7 +194,7 @@ namespace PlayFab
         else
         {
             Json::CharReaderBuilder jsonReaderFactory;
-            std::unique_ptr<Json::CharReader> jsonReader(jsonReaderFactory.newCharReader());
+            Json::CharReader* jsonReader(jsonReaderFactory.newCharReader());
             JSONCPP_STRING jsonParseErrors;
             const bool parsedSuccessfully = jsonReader->parse(reqContainer.responseString.c_str(), reqContainer.responseString.c_str() + reqContainer.responseString.length(), &reqContainer.responseJson, &jsonParseErrors);
 

--- a/targets/XPlatCppSdk/source/cppsdk/source/playfab/PlayFabHttp.cpp
+++ b/targets/XPlatCppSdk/source/cppsdk/source/playfab/PlayFabHttp.cpp
@@ -194,7 +194,7 @@ namespace PlayFab
         else
         {
             Json::CharReaderBuilder jsonReaderFactory;
-            Json::CharReader* jsonReader(jsonReaderFactory.newCharReader());
+            std::unique_ptr<Json::CharReader> jsonReader(jsonReaderFactory.newCharReader());
             JSONCPP_STRING jsonParseErrors;
             const bool parsedSuccessfully = jsonReader->parse(reqContainer.responseString.c_str(), reqContainer.responseString.c_str() + reqContainer.responseString.length(), &reqContainer.responseJson, &jsonParseErrors);
 

--- a/targets/XPlatCppSdk/source/testapps/cppLinuxTestApp/main.cpp
+++ b/targets/XPlatCppSdk/source/testapps/cppLinuxTestApp/main.cpp
@@ -1,7 +1,6 @@
 // Copyright (C) Microsoft Corporation. All rights reserved.
 
 #include <cstdio>
-#include <iostream>
 #include <memory>
 
 #include <playfab/PlayFabClientApi.h>
@@ -15,7 +14,7 @@ void OnPlayFabFail(const PlayFab::PlayFabError& error, void*)
 
 void OnProfile(const PlayFab::ClientModels::GetPlayerProfileResult& result, void*)
 {
-    printf(("========== PlayFab Profile Success: " + result.PlayerProfile->PublisherId + "\n").c_str());
+    printf(("========== PlayFab Profile Success: " + result.PlayerProfile->PlayerId + "\n").c_str());
 }
 
 void OnLoginSuccess(const PlayFab::ClientModels::LoginResult& result, void*)

--- a/targets/XPlatCppSdk/templates/PlayFab_Api.cpp.ejs
+++ b/targets/XPlatCppSdk/templates/PlayFab_Api.cpp.ejs
@@ -33,7 +33,7 @@ namespace PlayFab
     )
     {
 <%- getRequestActions("        ", apiCall) %>
-        IPlayFabHttpPlugin& http = PlayFabPluginManager::GetPlugin<IPlayFabHttpPlugin>(PlayFabPluginContract::PlayFab_Transport);
+        IPlayFabHttpPlugin& http = *PlayFabPluginManager::GetPlugin<IPlayFabHttpPlugin>(PlayFabPluginContract::PlayFab_Transport);
         const auto requestJson = request.ToJson();
 
         Json::FastWriter writer;


### PR DESCRIPTION
Important for the libHttpClient plugin story next week:

- Fixed PluginManager (moved from dangerous references to safe shared pointers)
- Added instanceability support (both singleton and instances of PluginManager are supported (request from a major customer, also a move towards much better memory management model)
- Restored unit tests and their infrastructure
- Generated SDK has been built and ran on Windows and Linux, verified along with unit tests 
