### PR TITLE
Fix unreal engine build issue

### DIFF
--- a/targets/UnrealMarketplacePlugin/makeBp.js
+++ b/targets/UnrealMarketplacePlugin/makeBp.js
@@ -17,7 +17,7 @@ function makeApiIntermal(apis, copyright, sourceDir, apiOutputDir, libName, ueTa
         apis: apis,
         copyright: copyright,
         buildIdentifier: buildIdentifier,
-        
+
         generateApiSummary: generateApiSummary,
         getDataTypeSafeName: getDataTypeSafeName,
         hasClientOptions: authMechanisms.includes("SessionTicket"),
@@ -28,8 +28,16 @@ function makeApiIntermal(apis, copyright, sourceDir, apiOutputDir, libName, ueTa
     };
 
     // Make the variable api files
-    for (var a = 0; a < apis.length; a++)
-        makeApiFiles(apis[a], copyright, apiOutputDir, sourceDir, libName);
+    for (var a = 0; a < apis.length; a++) {
+        if (apis[a].calls.length > 0) {
+            // If there are any calls specified for this api, call makeApi
+            makeApiFiles(apis[a], copyright, apiOutputDir, sourceDir, libName);
+        }
+        else {
+            // Else remove it from the apis list as we do not need it
+            apis.splice(a, 1);
+        }
+    }
 }
 
 // Create Models, .h and .cpp files

--- a/targets/UnrealMarketplacePlugin/makeCpp.js
+++ b/targets/UnrealMarketplacePlugin/makeCpp.js
@@ -25,9 +25,18 @@ exports.makeCppCombinedAPI = function (apis, copyright, sourceDir, baseApiOutput
         var outputCodeDir = path.resolve(apiOutputDir, "PlayFab/Source/PlayFabCpp");
 
         console.log("Generating UE4 C++ Module from " + sourceDir + " to " + apiOutputDir);
+        
+        for (var a = 0; a < apis.length; a++) {
+            if (apis[a].calls.length > 0) {
+                // If there are any calls specified for this api, call makeApi
+                makeApi(apis[a], copyright, sourceDir, outputCodeDir, "Core/");
+            }
+            else {
+                // Else remove it from the apis list as we do not need it
+                apis.splice(a, 1);
+            }
+        }
 
-        for (var a = 0; a < apis.length; a++)
-            makeApi(apis[a], copyright, sourceDir, outputCodeDir, "Core/");
         generateModels(apis, copyright, sourceDir, outputCodeDir, "All", "Core/");
     }
 }


### PR DESCRIPTION
The UE build for Beta and PlayStation SDK is failing.
Issue : The LeaderboardAPI class is getting generated with no actual apis. This leads to an empty UE class.
Assuming that UE does not allow building empty classes, we need to remove them.
Quick Fix : Update UE specific make.js to remove not generate apis who do not have any calls.

The actual fix would come in later. Discuss with Paul and fix why emtpy APIs are getting generated.