### PR TITLE
Fixed HTTP interface, old bugs, removed singletons, manual deletes, improved inheritance

### DIFF
--- a/targets/XPlatCppSdk/source/cppsdk/include/playfab/PlayFabCallRequestContainerBase.h
+++ b/targets/XPlatCppSdk/source/cppsdk/include/playfab/PlayFabCallRequestContainerBase.h
@@ -5,7 +5,7 @@
 namespace PlayFab
 {
     class CallRequestContainerBase;
-    typedef void(*CallRequestContainerCallback)(int, std::string, CallRequestContainerBase&);
+    typedef void(*CallRequestContainerCallback)(int, std::string, std::unique_ptr<CallRequestContainerBase>);
 
     /// <summary>
     /// A base container meant for holding everything necessary to make a full HTTP request and return a response.

--- a/targets/XPlatCppSdk/source/cppsdk/include/playfab/PlayFabPluginManager.h
+++ b/targets/XPlatCppSdk/source/cppsdk/include/playfab/PlayFabPluginManager.h
@@ -36,7 +36,15 @@ namespace PlayFab
         /// starts the process of making a post request.
         /// A user is expected to supply their own CallRequestContainerBase
         /// </summary>
-        virtual void MakePostRequest(const CallRequestContainerBase&) = 0;
+        virtual void MakePostRequest(std::unique_ptr<CallRequestContainerBase>) = 0;
+
+        /// <summary>
+        /// updates the process of making post requests.
+        /// This method can be used when plugin is not using a working thread and instead should execute 
+        /// its long-running operations via polling using this method.
+        /// Returns number of currently pending post requests.
+        /// </summary>
+        virtual size_t Update() = 0;
     };
 
     /// <summary>

--- a/targets/XPlatCppSdk/source/cppsdk/source/playfab/PlayFabPluginManager.cpp
+++ b/targets/XPlatCppSdk/source/cppsdk/source/playfab/PlayFabPluginManager.cpp
@@ -77,6 +77,6 @@ namespace PlayFab
 
     std::shared_ptr<IPlayFabPlugin> PlayFabPluginManager::CreatePlayFabTransportPlugin()
     {
-        return IPlayFabHttp::GetPtr();
+        return std::make_shared<PlayFabHttp>();
     }
 }

--- a/targets/XPlatCppSdk/templates/PlayFab_API.h.ejs
+++ b/targets/XPlatCppSdk/templates/PlayFab_API.h.ejs
@@ -31,7 +31,7 @@ namespace PlayFab
 
         // ------------ Generated result handlers
 <% for (var callIdx = 0; callIdx < api.calls.length; callIdx++) { var apiCall = api.calls[callIdx];
-%>        static void On<%- apiCall.name %>Result(int httpCode, std::string result, CallRequestContainerBase& reqContainer);
+%>        static void On<%- apiCall.name %>Result(int httpCode, std::string result, std::unique_ptr<CallRequestContainerBase> reqContainer);
 <% } %>
 <% if (hasClientOptions) { %>
         // Private, Client-Specific

--- a/targets/XPlatCppSdk/templates/PlayFab_Api.cpp.ejs
+++ b/targets/XPlatCppSdk/templates/PlayFab_Api.cpp.ejs
@@ -15,7 +15,8 @@ namespace PlayFab
 
     size_t PlayFab<%- api.name %>API::Update()
     {
-        return PlayFabHttp::Get().Update();
+        IPlayFabHttpPlugin& http = *PlayFabPluginManager::GetPlugin<IPlayFabHttpPlugin>(PlayFabPluginContract::PlayFab_Transport);
+        return http.Update();
     }
 
     void PlayFab<%- api.name %>API::ForgetAllCredentials()
@@ -42,7 +43,7 @@ namespace PlayFab
         std::unordered_map<std::string, std::string> headers;
         headers.emplace(<%- getAuthParams(apiCall) %>);
 
-        CallRequestContainer* reqContainer = new CallRequestContainer(
+        auto reqContainer = std::make_unique<CallRequestContainer>(
             "<%- apiCall.url %>",
             headers,
             jsonAsString,
@@ -52,12 +53,12 @@ namespace PlayFab
         reqContainer->successCallback = std::shared_ptr<void>((callback == nullptr) ? nullptr : new ProcessApiCallback<<%- apiCall.result %>>(callback));
         reqContainer->errorCallback = errorCallback;
 
-        http.MakePostRequest(*reqContainer);
+        http.MakePostRequest(std::unique_ptr<CallRequestContainerBase>(static_cast<CallRequestContainerBase*>(reqContainer.release())));
     }
 
-    void PlayFab<%- api.name %>API::On<%- apiCall.name %>Result(int httpCode, std::string result, CallRequestContainerBase& reqContainer)
+    void PlayFab<%- api.name %>API::On<%- apiCall.name %>Result(int httpCode, std::string result, std::unique_ptr<CallRequestContainerBase> reqContainer)
     {
-        CallRequestContainer& container = static_cast<CallRequestContainer&>(reqContainer);
+        CallRequestContainer& container = static_cast<CallRequestContainer&>(*reqContainer);
 
         <%- apiCall.result %> outResult;
         if (ValidateResult(outResult, container))
@@ -70,8 +71,6 @@ namespace PlayFab
                 callback(outResult, container.GetCustomData());
             }
         }
-
-        delete &container;
     }
 <% } %><% if (hasClientOptions) { %>
     // Private PlayFabClientAPI specific


### PR DESCRIPTION
Lightweight events will require a new HTTP plugin. Some sanitation work needed to be done to our existing HTTP interface and PlayFab HTTP plugin to adhere to better standards we want to set going forward. That includes:
- Getting rid of a pattern where users have to own and maintain the lifecycle of request container objects (manual "new" in one method and "delete" in the other, hoping the delete will always be called). Replacing that with a pattern that uses unique_ptr instead to automate the lifecycle. That required some changes in HTTP plugin interface, but this is a way more reliable pattern that we want.
- Fixed a bug with API's Update method where PlayFab's HTTP plugin's Update method was always called instead of using a current plugin set by PluginManager
- Fixed a bug with wrong (reversed) pending requests consumption order in PlayFab HTTP plugin
- Removed unnecessary singleton pattern from PlayFab HTTP plugin (instance is managed by PluginManager instead). It allows to use inheritance in a proper way that will be used for 1DS HTTP plugin implementation.
- Replaced unnecessary static methods with instance methods in PlayFab HTTP plugin
- Removed some unnecessary code
- Verified that all tests succeed
- Verified that generated SDK build and runs on both Windows and Linux, and nothing is broken