### PR TITLE
Implemented WinHTTP plugins for PF and OneDS

### DIFF
--- a/SDKGenerator.njsproj
+++ b/SDKGenerator.njsproj
@@ -659,6 +659,7 @@
     <Content Include="targets\XPlatCppSdk\source\code\include\playfab\OneDSEventsDataModels.h" />
     <Content Include="targets\XPlatCppSdk\source\code\include\playfab\OneDSHttpPlugin.h" />
     <Content Include="targets\XPlatCppSdk\source\code\include\playfab\OneDSIXHR2Plugin.h" />
+    <Content Include="targets\XPlatCppSdk\source\code\include\playfab\OneDSWinHttpPlugin.h" />
     <Content Include="targets\XPlatCppSdk\source\code\include\playfab\PlayFabBaseModel.h" />
     <Content Include="targets\XPlatCppSdk\source\code\include\playfab\PlayFabCallRequestContainer.h" />
     <Content Include="targets\XPlatCppSdk\source\code\include\playfab\PlayFabCallRequestContainerBase.h" />
@@ -677,6 +678,7 @@
     <Content Include="targets\XPlatCppSdk\source\code\include\playfab\PlayFabSettings.h" />
     <Content Include="targets\XPlatCppSdk\source\code\include\playfab\PlayFabSpinLock.h" />
     <Content Include="targets\XPlatCppSdk\source\code\include\playfab\PlayFabTransportHeaders.h" />
+    <Content Include="targets\XPlatCppSdk\source\code\include\playfab\PlayFabWinHttpPlugin.h" />
     <Content Include="targets\XPlatCppSdk\source\code\include\playfab\QoS\DataCenterResult.h" />
     <Content Include="targets\XPlatCppSdk\source\code\include\playfab\QoS\PingResult.h" />
     <Content Include="targets\XPlatCppSdk\source\code\include\playfab\QoS\PlayFabQoSApi.h" />
@@ -688,6 +690,7 @@
     <Content Include="targets\XPlatCppSdk\source\code\source\playfab\OneDSEventsApi.cpp" />
     <Content Include="targets\XPlatCppSdk\source\code\source\playfab\OneDSHttpPlugin.cpp" />
     <Content Include="targets\XPlatCppSdk\source\code\source\playfab\OneDSIXHR2Plugin.cpp" />
+    <Content Include="targets\XPlatCppSdk\source\code\source\playfab\OneDSWinHttpPlugin.cpp" />
     <Content Include="targets\XPlatCppSdk\source\code\source\playfab\PlayFabCallRequestContainer.cpp" />
     <Content Include="targets\XPlatCppSdk\source\code\source\playfab\PlayFabCallRequestContainerBase.cpp" />
     <Content Include="targets\XPlatCppSdk\source\code\source\playfab\PlayFabError.cpp" />
@@ -702,6 +705,7 @@
     <Content Include="targets\XPlatCppSdk\source\code\source\playfab\PlayFabPluginManager.cpp" />
     <Content Include="targets\XPlatCppSdk\source\code\source\playfab\PlayFabSettings.cpp.ejs" />
     <Content Include="targets\XPlatCppSdk\source\code\source\playfab\PlayFabSpinLock.cpp" />
+    <Content Include="targets\XPlatCppSdk\source\code\source\playfab\PlayFabWinHttpPlugin.cpp" />
     <Content Include="targets\XPlatCppSdk\source\code\source\playfab\QoS\DataCenterResult.cpp" />
     <Content Include="targets\XPlatCppSdk\source\code\source\playfab\QoS\PlayFabQoSApi.cpp" />
     <Content Include="targets\XPlatCppSdk\source\code\source\playfab\QoS\QoSSocket.cpp" />

--- a/targets/XPlatCppSdk/source/build/Windows/XPlatCppWindows.vcxproj.ejs
+++ b/targets/XPlatCppSdk/source/build/Windows/XPlatCppWindows.vcxproj.ejs
@@ -79,7 +79,7 @@
     <ProjectReference />
     <ProjectReference />
     <Lib>
-      <AdditionalDependencies>ws2_32.lib;lib_json.lib;zlib.lib;libssl.lib;libcrypto.lib;wldap32.lib;crypt32.lib;normaliz.lib;libcurl_a_debug.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>ws2_32.lib;lib_json.lib;winhttp.lib;zlib.lib;libssl.lib;libcrypto.lib;wldap32.lib;crypt32.lib;normaliz.lib;libcurl_a_debug.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <AdditionalLibraryDirectories>$(ExternalDir)\deps-$(Configuration)\lib</AdditionalLibraryDirectories>
     </Lib>
   </ItemDefinitionGroup>
@@ -106,13 +106,14 @@
     <ProjectReference />
     <ProjectReference />
     <Lib>
-      <AdditionalDependencies>ws2_32.lib;lib_json.lib;zlib.lib;libssl.lib;libcrypto.lib;wldap32.lib;crypt32.lib;normaliz.lib;libcurl_a.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>ws2_32.lib;lib_json.lib;winhttp.lib;zlib.lib;libssl.lib;libcrypto.lib;wldap32.lib;crypt32.lib;normaliz.lib;libcurl_a.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <AdditionalLibraryDirectories>$(ExternalDir)\deps-$(Configuration)\lib</AdditionalLibraryDirectories>
     </Lib>
   </ItemDefinitionGroup>
   <ItemGroup>
     <ClInclude Include="$(SdkSourceDir)\include\playfab\PlayFabPlatformMacros.h" />
     <ClInclude Include="$(SdkSourceDir)\include\playfab\OneDSHttpPlugin.h" />
+    <ClInclude Include="$(SdkSourceDir)\include\playfab\OneDSWinHttpPlugin.h" />
     <ClInclude Include="$(SdkSourceDir)\include\playfab\OneDSEventsApi.h" />
     <ClInclude Include="$(SdkSourceDir)\include\playfab\OneDSEventPipeline.h" />
     <ClInclude Include="$(SdkSourceDir)\include\playfab\PlayFabBaseModel.h" />
@@ -127,6 +128,7 @@
     <ClInclude Include="$(SdkSourceDir)\include\playfab\PlayFabEventRouter.h" />
     <ClInclude Include="$(SdkSourceDir)\include\playfab\PlayFabError.h" />
     <ClInclude Include="$(SdkSourceDir)\include\playfab\PlayFabHttp.h" />
+    <ClInclude Include="$(SdkSourceDir)\include\playfab\PlayFabWinHttpPlugin.h" />
     <ClInclude Include="$(SdkSourceDir)\include\playfab\PlayFabSettings.h" />
     <ClInclude Include="$(SdkSourceDir)\include\playfab\PlayFabCallRequestContainer.h" />
     <ClInclude Include="$(SdkSourceDir)\include\playfab\PlayFabCallRequestContainerBase.h" />
@@ -145,6 +147,7 @@
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="$(SdkSourceDir)\source\playfab\OneDSHttpPlugin.cpp" />
+    <ClCompile Include="$(SdkSourceDir)\source\playfab\OneDSWinHttpPlugin.cpp" />
     <ClCompile Include="$(SdkSourceDir)\source\playfab\OneDSEventsApi.cpp" />
     <ClCompile Include="$(SdkSourceDir)\source\playfab\OneDSEventPipeline.cpp" />
 <% for(var i in apis) { var api = apis[i];%>
@@ -156,6 +159,7 @@
     <ClCompile Include="$(SdkSourceDir)\source\playfab\PlayFabEventRouter.cpp" />
     <ClCompile Include="$(SdkSourceDir)\source\playfab\PlayFabError.cpp" />
     <ClCompile Include="$(SdkSourceDir)\source\playfab\PlayFabHttp.cpp" />
+    <ClCompile Include="$(SdkSourceDir)\source\playfab\PlayFabWinHttpPlugin.cpp" />
     <ClCompile Include="$(SdkSourceDir)\source\playfab\PlayFabSettings.cpp" />
     <ClCompile Include="$(SdkSourceDir)\source\playfab\PlayFabCallRequestContainerBase.cpp" />
     <ClCompile Include="$(SdkSourceDir)\source\playfab\PlayFabCallRequestContainer.cpp" />

--- a/targets/XPlatCppSdk/source/build/Windows/XPlatCppWindows.vcxproj.filters.ejs
+++ b/targets/XPlatCppSdk/source/build/Windows/XPlatCppWindows.vcxproj.filters.ejs
@@ -29,6 +29,9 @@
     <ClInclude Include="$(SdkSourceDir)\include\playfab\OneDSHttpPlugin.h">
       <Filter>Header Files\playfab</Filter>
     </ClInclude>
+    <ClInclude Include="$(SdkSourceDir)\include\playfab\OneDSWinHttpPlugin.h">
+      <Filter>Header Files\playfab</Filter>
+    </ClInclude>
     <ClInclude Include="$(SdkSourceDir)\include\playfab\OneDSEventsApi.h">
       <Filter>Header Files\playfab</Filter>
     </ClInclude>
@@ -46,6 +49,9 @@
       <Filter>Header Files\playfab</Filter>
     </ClInclude>
 <% } %>    <ClInclude Include="$(SdkSourceDir)\include\playfab\PlayFabHttp.h">
+      <Filter>Header Files\playfab</Filter>
+    </ClInclude>
+    <ClInclude Include="$(SdkSourceDir)\include\playfab\PlayFabWinHttpPlugin.h">
       <Filter>Header Files\playfab</Filter>
     </ClInclude>
     <ClInclude Include="$(SdkSourceDir)\include\playfab\PlayFabSettings.h">
@@ -119,6 +125,9 @@
     <ClCompile Include="$(SdkSourceDir)\source\playfab\OneDSHttpPlugin.cpp">
       <Filter>Source Files\playfab</Filter>
     </ClCompile>
+    <ClCompile Include="$(SdkSourceDir)\source\playfab\OneDSWinHttpPlugin.cpp">
+      <Filter>Source Files\playfab</Filter>
+    </ClCompile>
     <ClCompile Include="$(SdkSourceDir)\source\playfab\OneDSEventsApi.cpp">
       <Filter>Source Files\playfab</Filter>
     </ClCompile>
@@ -136,6 +145,9 @@
       <Filter>Source Files\playfab</Filter>
     </ClCompile>
     <ClCompile Include="$(SdkSourceDir)\source\playfab\PlayFabHttp.cpp">
+      <Filter>Source Files\playfab</Filter>
+    </ClCompile>
+    <ClCompile Include="$(SdkSourceDir)\source\playfab\PlayFabWinHttpPlugin.cpp">
       <Filter>Source Files\playfab</Filter>
     </ClCompile>
     <ClCompile Include="$(SdkSourceDir)\source\playfab\PlayFabSettings.cpp">

--- a/targets/XPlatCppSdk/source/code/include/playfab/OneDSHttpPlugin.h
+++ b/targets/XPlatCppSdk/source/code/include/playfab/OneDSHttpPlugin.h
@@ -11,7 +11,7 @@
 namespace PlayFab
 {
     /// <summary>
-    /// OneDSHttpPlugin is the default https implementation to interact with OneDS (One Data Collector) services using curl.
+    /// OneDSHttpPlugin is an https implementation to interact with OneDS (One Data Collector) services using curl.
     /// </summary>
     class OneDSHttpPlugin : public PlayFabHttp
     {

--- a/targets/XPlatCppSdk/source/code/include/playfab/OneDSWinHttpPlugin.h
+++ b/targets/XPlatCppSdk/source/code/include/playfab/OneDSWinHttpPlugin.h
@@ -1,0 +1,32 @@
+#pragma once
+
+#ifndef DISABLE_ONEDS_API
+
+#include <playfab/PlayFabCallRequestContainer.h>
+#include <playfab/PlayFabPluginManager.h>
+#include <playfab/PlayFabWinHttpPlugin.h>
+
+namespace PlayFab
+{
+    /// <summary>
+    /// OneDSWinHttpPlugin is an https implementation to interact with OneDS (One Data Collector) services using WinHTTP.
+    /// </summary>
+    class OneDSWinHttpPlugin : public PlayFabWinHttpPlugin
+    {
+    public:
+        OneDSWinHttpPlugin() {}
+        OneDSWinHttpPlugin(const OneDSWinHttpPlugin& other) = delete;
+        OneDSWinHttpPlugin& operator=(const OneDSWinHttpPlugin&) = delete;
+        OneDSWinHttpPlugin(OneDSWinHttpPlugin&& other) = delete;
+        OneDSWinHttpPlugin& operator=(OneDSWinHttpPlugin&& other) = delete;
+        virtual ~OneDSWinHttpPlugin() override {}
+
+    protected:
+        virtual std::string GetUrl(CallRequestContainer& requestContainer) const;
+        virtual void SetPredefinedHeaders(CallRequestContainer& requestContainer, HINTERNET hRequest);
+        virtual bool GetBinaryPayload(CallRequestContainer& requestContainer, LPVOID& payload, DWORD& payloadSize) const;
+        virtual void ProcessResponse(CallRequestContainer& requestContainer, const int httpCode);
+    };
+}
+
+#endif

--- a/targets/XPlatCppSdk/source/code/include/playfab/PlayFabHttp.h
+++ b/targets/XPlatCppSdk/source/code/include/playfab/PlayFabHttp.h
@@ -8,6 +8,7 @@
 #include <memory>
 #include <thread>
 #include <mutex>
+#include <atomic>
 
 #include <playfab/PlayFabJsonHeaders.h>
 
@@ -37,7 +38,7 @@ namespace PlayFab
 
         std::thread workerThread;
         std::mutex httpRequestMutex;
-        bool threadRunning;
+        std::atomic<bool> threadRunning;
         int activeRequestCount;
         std::deque<std::unique_ptr<CallRequestContainerBase>> pendingRequests;
         std::deque<std::unique_ptr<CallRequestContainerBase>> pendingResults;

--- a/targets/XPlatCppSdk/source/code/include/playfab/PlayFabHttp.h
+++ b/targets/XPlatCppSdk/source/code/include/playfab/PlayFabHttp.h
@@ -14,7 +14,7 @@
 namespace PlayFab
 {
     /// <summary>
-    /// PlayFabHttp is the default https implementation to interact with PlayFab services using curl.
+    /// PlayFabHttp is an https implementation to interact with PlayFab services using curl.
     /// </summary>
     class PlayFabHttp : public IPlayFabHttpPlugin
     {

--- a/targets/XPlatCppSdk/source/code/include/playfab/PlayFabIXHR2HttpPlugin.h
+++ b/targets/XPlatCppSdk/source/code/include/playfab/PlayFabIXHR2HttpPlugin.h
@@ -8,6 +8,7 @@
 #include <memory>
 #include <thread>
 #include <mutex>
+#include <atomic>
 
 #include <json/value.h>
 #include <playfab/PlayFabIXHR2HttpRequest.h>
@@ -38,7 +39,7 @@ namespace PlayFab
 
         std::thread workerThread;
         std::mutex httpRequestMutex;
-        bool threadRunning;
+        std::atomic<bool> threadRunning;
         int activeRequestCount;
         std::deque<std::unique_ptr<CallRequestContainerBase>> pendingRequests;
         std::deque<std::unique_ptr<CallRequestContainerBase>> pendingResults;

--- a/targets/XPlatCppSdk/source/code/include/playfab/PlayFabJsonHeaders.h
+++ b/targets/XPlatCppSdk/source/code/include/playfab/PlayFabJsonHeaders.h
@@ -1,3 +1,7 @@
+// Copyright (C) Microsoft Corporation. All rights reserved.
+// 
+// This header file is used to include platform-specific headers of JsonCpp library.
+
 #pragma once
 
 #include <playfab/PlayFabPlatformMacros.h>

--- a/targets/XPlatCppSdk/source/code/include/playfab/PlayFabTransportHeaders.h
+++ b/targets/XPlatCppSdk/source/code/include/playfab/PlayFabTransportHeaders.h
@@ -1,12 +1,24 @@
+// Copyright (C) Microsoft Corporation. All rights reserved.
+// 
+// This header file is used to include headers of transport plugins supported on each platform.
+
 #pragma once
 
 #include <playfab/PlayFabPlatformMacros.h>
 
 #ifdef PLAYFAB_PLATFORM_XBOX
 #include <playfab/PlayFabIXHR2HttpPlugin.h>
+#include <playfab/OneDSIXHR2HttpPlugin.h>
 #endif // PLAYFAB_PLATFORM_XBOX
 
-#if defined(PLAYFAB_PLATFORM_WINDOWS) || defined(PLAYFAB_PLATFORM_LINUX) 
-#include <curl/curl.h>
+#ifdef PLAYFAB_PLATFORM_WINDOWS
+#include <playfab/PlayFabWinHttpPlugin.h>
 #include <playfab/PlayFabHttp.h>
-#endif // PLAYFAB_PLATFORM_WINDOWS || PLAYFAB_PLATFORM_LINUX
+#include <playfab/OneDSWinHttpPlugin.h>
+#include <playfab/OneDSHttpPlugin.h>
+#endif // PLAYFAB_PLATFORM_WINDOWS
+
+#ifdef PLAYFAB_PLATFORM_LINUX
+#include <playfab/PlayFabHttp.h>
+#include <playfab/OneDSHttpPlugin.h>
+#endif // PLAYFAB_PLATFORM_LINUX

--- a/targets/XPlatCppSdk/source/code/include/playfab/PlayFabWinHttpPlugin.h
+++ b/targets/XPlatCppSdk/source/code/include/playfab/PlayFabWinHttpPlugin.h
@@ -4,6 +4,7 @@
 #include <playfab/PlayFabPluginManager.h>
 #include <thread>
 #include <mutex>
+#include <atomic>
 #include <windows.h>
 #include <winhttp.h>
 
@@ -37,7 +38,7 @@ namespace PlayFab
 
         std::thread workerThread;
         std::mutex httpRequestMutex;
-        bool threadRunning;
+        std::atomic<bool> threadRunning;
         int activeRequestCount;
         std::deque<std::unique_ptr<CallRequestContainerBase>> pendingRequests;
         std::deque<std::unique_ptr<CallRequestContainerBase>> pendingResults;

--- a/targets/XPlatCppSdk/source/code/include/playfab/PlayFabWinHttpPlugin.h
+++ b/targets/XPlatCppSdk/source/code/include/playfab/PlayFabWinHttpPlugin.h
@@ -1,0 +1,45 @@
+#pragma once
+
+#include <playfab/PlayFabCallRequestContainer.h>
+#include <playfab/PlayFabPluginManager.h>
+#include <thread>
+#include <mutex>
+#include <windows.h>
+#include <winhttp.h>
+
+namespace PlayFab
+{
+    /// <summary>
+    /// PlayFabWinHttpPlugin is an https implementation to interact with PlayFab services using WinHTTP.
+    /// </summary>
+    class PlayFabWinHttpPlugin : public IPlayFabHttpPlugin
+    {
+    public:
+        PlayFabWinHttpPlugin();
+        PlayFabWinHttpPlugin(const PlayFabWinHttpPlugin& other) = delete;
+        PlayFabWinHttpPlugin(PlayFabWinHttpPlugin&& other) = delete;
+        PlayFabWinHttpPlugin& operator=(PlayFabWinHttpPlugin&& other) = delete;
+        virtual ~PlayFabWinHttpPlugin();
+
+        virtual void MakePostRequest(std::unique_ptr<CallRequestContainerBase> requestContainer) override;
+        virtual size_t Update() override;
+
+    protected:
+        virtual void ExecuteRequest(std::unique_ptr<CallRequestContainer> requestContainer);
+        virtual std::string GetUrl(CallRequestContainer& requestContainer) const;
+        virtual void SetPredefinedHeaders(CallRequestContainer& requestContainer, HINTERNET hRequest);
+        virtual bool GetBinaryPayload(CallRequestContainer& requestContainer, LPVOID& payload, DWORD& payloadSize) const;
+        virtual void ProcessResponse(CallRequestContainer& requestContainer, const int httpCode);
+        void WorkerThread();
+        void HandleCallback(std::unique_ptr<CallRequestContainer> requestContainer);
+        void HandleResults(std::unique_ptr<CallRequestContainer> requestContainer);
+        void SetErrorInfo(CallRequestContainer& requestContainer, const std::string& errorMessage, const int httpCode = 0) const;
+
+        std::thread workerThread;
+        std::mutex httpRequestMutex;
+        bool threadRunning;
+        int activeRequestCount;
+        std::deque<std::unique_ptr<CallRequestContainerBase>> pendingRequests;
+        std::deque<std::unique_ptr<CallRequestContainerBase>> pendingResults;
+    };
+}

--- a/targets/XPlatCppSdk/source/code/source/playfab/OneDSHttpPlugin.cpp
+++ b/targets/XPlatCppSdk/source/code/source/playfab/OneDSHttpPlugin.cpp
@@ -3,8 +3,7 @@
 #ifndef DISABLE_ONEDS_API
 
 #include <playfab/OneDSHttpPlugin.h>
-
-#include <playfab/PlayFabTransportHeaders.h>
+#include <curl/curl.h>
 
 namespace PlayFab
 {

--- a/targets/XPlatCppSdk/source/code/source/playfab/OneDSWinHttpPlugin.cpp
+++ b/targets/XPlatCppSdk/source/code/source/playfab/OneDSWinHttpPlugin.cpp
@@ -11,9 +11,11 @@
 
 namespace PlayFab
 {
+    constexpr auto ONEDS_SERVICE_URL = "https://self.events.data.microsoft.com/OneCollector/1.0/";
+
     std::string OneDSWinHttpPlugin::GetUrl(CallRequestContainer& requestContainer) const
     {
-        return std::string("https://self.events.data.microsoft.com/OneCollector/1.0/");
+        return std::string(ONEDS_SERVICE_URL);
     }
 
     void OneDSWinHttpPlugin::SetPredefinedHeaders(CallRequestContainer& requestContainer, HINTERNET hRequest)
@@ -35,7 +37,7 @@ namespace PlayFab
     bool OneDSWinHttpPlugin::GetBinaryPayload(CallRequestContainer& requestContainer, LPVOID& payload, DWORD& payloadSize) const
     {
         OneDSCallRequestContainer& reqContainer = (OneDSCallRequestContainer&)requestContainer;
-        payloadSize = (DWORD)reqContainer.requestBinaryBody.size();
+        payloadSize = static_cast<DWORD>(reqContainer.requestBinaryBody.size());
         payload = reqContainer.requestBinaryBody.data();
         return true;
     }

--- a/targets/XPlatCppSdk/source/code/source/playfab/OneDSWinHttpPlugin.cpp
+++ b/targets/XPlatCppSdk/source/code/source/playfab/OneDSWinHttpPlugin.cpp
@@ -1,0 +1,111 @@
+#include <stdafx.h>
+
+#ifndef DISABLE_ONEDS_API
+
+#include <playfab/OneDSWinHttpPlugin.h>
+#include <windows.h>
+#include <winhttp.h>
+
+#pragma warning (disable: 4100) // formal parameters are part of a public interface
+#pragma warning (disable: 4245) // Some DWORD arguments of WinHTTP API can accept -1, according to documentation
+
+namespace PlayFab
+{
+    std::string OneDSWinHttpPlugin::GetUrl(CallRequestContainer& requestContainer) const
+    {
+        return std::string("https://self.events.data.microsoft.com/OneCollector/1.0/");
+    }
+
+    void OneDSWinHttpPlugin::SetPredefinedHeaders(CallRequestContainer& requestContainer, HINTERNET hRequest)
+    {
+        OneDSCallRequestContainer& reqContainer = (OneDSCallRequestContainer&)requestContainer;
+
+        WinHttpAddRequestHeaders(hRequest, L"Accept: */*", -1, 0);
+        WinHttpAddRequestHeaders(hRequest, L"Client-Id: NO_AUTH", -1, 0);
+        WinHttpAddRequestHeaders(hRequest, L"Content-Type: application/bond-compact-binary", -1, 0);
+        WinHttpAddRequestHeaders(hRequest, L"Expect: 100-continue", -1, 0);
+        WinHttpAddRequestHeaders(hRequest, L"SDK-Version: EVT-PlayFab-XPlat-C++-No-3.0.275.1", -1, 0);
+        int64_t now = std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::system_clock::now().time_since_epoch()).count();
+        WinHttpAddRequestHeaders(hRequest, (L"Upload-Time: " + std::to_wstring(now)).c_str(), -1, 0);
+        WinHttpAddRequestHeaders(hRequest, (L"Content-Length: " + std::to_wstring(reqContainer.requestBinaryBody.size())).c_str(), -1, 0);
+        WinHttpAddRequestHeaders(hRequest, L"Connection: Keep-Alive", -1, 0);
+        WinHttpAddRequestHeaders(hRequest, L"Cache-Control: no-cache", -1, 0);
+    }
+
+    bool OneDSWinHttpPlugin::GetBinaryPayload(CallRequestContainer& requestContainer, LPVOID& payload, DWORD& payloadSize) const
+    {
+        OneDSCallRequestContainer& reqContainer = (OneDSCallRequestContainer&)requestContainer;
+        payloadSize = (DWORD)reqContainer.requestBinaryBody.size();
+        payload = reqContainer.requestBinaryBody.data();
+        return true;
+    }
+
+    void OneDSWinHttpPlugin::ProcessResponse(CallRequestContainer& reqContainer, const int httpCode)
+    {
+        if ((httpCode >= 200 && httpCode < 300) || httpCode == 0)
+        {
+            // following One-DS recommendations, HTTP response codes within [200, 300) are success
+            // (0 means HTTP code could not be determined and we attempt to parse response)
+            Json::CharReaderBuilder jsonReaderFactory;
+            std::unique_ptr<Json::CharReader> jsonReader(jsonReaderFactory.newCharReader());
+            JSONCPP_STRING jsonParseErrors;
+            const bool parsedSuccessfully = jsonReader->parse(reqContainer.responseString.c_str(), reqContainer.responseString.c_str() + reqContainer.responseString.length(), &reqContainer.responseJson, &jsonParseErrors);
+
+            if (parsedSuccessfully)
+            {
+                auto result = reqContainer.responseJson.get("acc", Json::Value::null).asInt();
+                if (result > 0)
+                {
+                    // fully successful response
+                    reqContainer.errorWrapper.HttpCode = httpCode != 0 ? httpCode : 200;
+                    reqContainer.errorWrapper.HttpStatus = "OK";
+                    reqContainer.errorWrapper.Data = reqContainer.responseJson;
+                    reqContainer.errorWrapper.ErrorName = "";
+                    reqContainer.errorWrapper.ErrorMessage = "";
+                }
+                else
+                {
+                    reqContainer.errorWrapper.HttpCode = httpCode != 0 ? httpCode : 200;
+                    reqContainer.errorWrapper.HttpStatus = reqContainer.responseString;
+                    reqContainer.errorWrapper.Data = reqContainer.responseJson;
+                    reqContainer.errorWrapper.ErrorCode = PlayFabErrorCode::PlayFabErrorPartialFailure;
+                    reqContainer.errorWrapper.ErrorName = "OneDS error";
+                    reqContainer.errorWrapper.ErrorMessage = reqContainer.responseJson.toStyledString();
+                }
+            }
+            else
+            {
+                reqContainer.errorWrapper.HttpCode = httpCode != 0 ? httpCode : 200;
+                reqContainer.errorWrapper.HttpStatus = reqContainer.responseString;
+                reqContainer.errorWrapper.ErrorCode = PlayFabErrorCode::PlayFabErrorPartialFailure;
+                reqContainer.errorWrapper.ErrorName = "Failed to parse OneDS response";
+                reqContainer.errorWrapper.ErrorMessage = jsonParseErrors;
+            }
+        }
+        else if ((httpCode >= 500 && httpCode != 501 && httpCode != 505)
+            || httpCode == 408 || httpCode == 429)
+        {
+            // following One-DS recommendations, HTTP response codes in this range (excluding and including specific codes)
+            // are eligible for retries
+
+            // TODO implement a retry policy
+            // As a placeholder, return an immediate error
+            reqContainer.errorWrapper.HttpCode = httpCode;
+            reqContainer.errorWrapper.HttpStatus = reqContainer.responseString;
+            reqContainer.errorWrapper.ErrorCode = PlayFabErrorCode::PlayFabErrorUnknownError;
+            reqContainer.errorWrapper.ErrorName = "OneDSError";
+            reqContainer.errorWrapper.ErrorMessage = "Failed to send a batch of events to OneDS";
+        }
+        else
+        {
+            // following One-DS recommendations, all other HTTP response codes are errors that should not be retried
+            reqContainer.errorWrapper.HttpCode = httpCode;
+            reqContainer.errorWrapper.HttpStatus = reqContainer.responseString;
+            reqContainer.errorWrapper.ErrorCode = PlayFabErrorCode::PlayFabErrorUnknownError;
+            reqContainer.errorWrapper.ErrorName = "OneDSError";
+            reqContainer.errorWrapper.ErrorMessage = "Failed to send a batch of events to OneDS";
+        }
+    }
+}
+
+#endif

--- a/targets/XPlatCppSdk/source/code/source/playfab/PlayFabHttp.cpp
+++ b/targets/XPlatCppSdk/source/code/source/playfab/PlayFabHttp.cpp
@@ -18,7 +18,13 @@ namespace PlayFab
     PlayFabHttp::~PlayFabHttp()
     {
         threadRunning = false;
-        workerThread.join();
+        try
+        {
+            workerThread.join();
+        }
+        catch (...)
+        {
+        }
     }
 
     void PlayFabHttp::WorkerThread()

--- a/targets/XPlatCppSdk/source/code/source/playfab/PlayFabHttp.cpp
+++ b/targets/XPlatCppSdk/source/code/source/playfab/PlayFabHttp.cpp
@@ -2,7 +2,7 @@
 
 #include <playfab/PlayFabHttp.h>
 #include <playfab/PlayFabSettings.h>
-#include <playfab/PlayFabTransportHeaders.h>
+#include <curl/curl.h>
 
 #include <stdexcept>
 

--- a/targets/XPlatCppSdk/source/code/source/playfab/PlayFabIXHR2HttpPlugin.cpp
+++ b/targets/XPlatCppSdk/source/code/source/playfab/PlayFabIXHR2HttpPlugin.cpp
@@ -17,7 +17,13 @@ namespace PlayFab
     PlayFabIXHR2HttpPlugin::~PlayFabIXHR2HttpPlugin()
     {
         threadRunning = false;
-        workerThread.join();
+        try
+        {
+            workerThread.join();
+        }
+        catch (...)
+        {
+        }
     }
 
     void PlayFabIXHR2HttpPlugin::WorkerThread()

--- a/targets/XPlatCppSdk/source/code/source/playfab/PlayFabPluginManager.cpp
+++ b/targets/XPlatCppSdk/source/code/source/playfab/PlayFabPluginManager.cpp
@@ -72,17 +72,17 @@ namespace PlayFab
 
     std::shared_ptr<IPlayFabPlugin> PlayFabPluginManager::CreatePlayFabSerializerPlugin()
     {
-        return std::shared_ptr<IPlayFabSerializerPlugin>(new IPlayFabSerializerPlugin());
+        return std::make_shared<IPlayFabSerializerPlugin>();
     }
 
     std::shared_ptr<IPlayFabPlugin> PlayFabPluginManager::CreatePlayFabTransportPlugin()
     {
 #ifdef PLAYFAB_PLATFORM_XBOX
-        return std::shared_ptr<PlayFabIXHR2HttpPlugin>(new PlayFabIXHR2HttpPlugin());
+        return std::make_shared<PlayFabIXHR2HttpPlugin>();
 #elif defined(PLAYFAB_PLATFORM_WINDOWS)
-        return std::shared_ptr<PlayFabWinHttpPlugin>(new PlayFabWinHttpPlugin());
+        return std::make_shared<PlayFabWinHttpPlugin>();
 #else
-        return std::shared_ptr<PlayFabHttp>(new PlayFabHttp());
+        return std::make_shared<PlayFabHttp>();
 #endif // PLAYFAB_PLATFORM_XBOX
     }
 }

--- a/targets/XPlatCppSdk/source/code/source/playfab/PlayFabPluginManager.cpp
+++ b/targets/XPlatCppSdk/source/code/source/playfab/PlayFabPluginManager.cpp
@@ -79,6 +79,8 @@ namespace PlayFab
     {
 #ifdef PLAYFAB_PLATFORM_XBOX
         return std::shared_ptr<PlayFabIXHR2HttpPlugin>(new PlayFabIXHR2HttpPlugin());
+#elif defined(PLAYFAB_PLATFORM_WINDOWS)
+        return std::shared_ptr<PlayFabWinHttpPlugin>(new PlayFabWinHttpPlugin());
 #else
         return std::shared_ptr<PlayFabHttp>(new PlayFabHttp());
 #endif // PLAYFAB_PLATFORM_XBOX

--- a/targets/XPlatCppSdk/source/code/source/playfab/PlayFabWinHttpPlugin.cpp
+++ b/targets/XPlatCppSdk/source/code/source/playfab/PlayFabWinHttpPlugin.cpp
@@ -21,7 +21,13 @@ namespace PlayFab
     PlayFabWinHttpPlugin::~PlayFabWinHttpPlugin()
     {
         threadRunning = false;
-        workerThread.join();
+        try
+        {
+            workerThread.join();
+        }
+        catch (...)
+        {
+        }
     }
 
     void PlayFabWinHttpPlugin::WorkerThread()

--- a/targets/XPlatCppSdk/source/code/source/playfab/PlayFabWinHttpPlugin.cpp
+++ b/targets/XPlatCppSdk/source/code/source/playfab/PlayFabWinHttpPlugin.cpp
@@ -1,0 +1,378 @@
+#include <stdafx.h>
+
+#include <playfab/PlayFabWinHttpPlugin.h>
+#include <playfab/PlayFabSettings.h>
+#include <stdexcept>
+#include <vector>
+#include <windows.h>
+
+#pragma warning (disable: 4100) // formal parameters are part of a public interface
+#pragma warning (disable: 4245) // Some DWORD arguments of WinHTTP API can accept -1, according to documentation
+
+namespace PlayFab
+{
+    PlayFabWinHttpPlugin::PlayFabWinHttpPlugin()
+    {
+        activeRequestCount = 0;
+        threadRunning = true;
+        workerThread = std::thread(&PlayFabWinHttpPlugin::WorkerThread, this);
+    };
+
+    PlayFabWinHttpPlugin::~PlayFabWinHttpPlugin()
+    {
+        threadRunning = false;
+        workerThread.join();
+    }
+
+    void PlayFabWinHttpPlugin::WorkerThread()
+    {
+        size_t queueSize;
+
+        while (this->threadRunning)
+        {
+            std::unique_ptr<CallRequestContainerBase> requestContainer = nullptr;
+
+            { // LOCK httpRequestMutex
+                std::unique_lock<std::mutex> lock(this->httpRequestMutex);
+
+                queueSize = this->pendingRequests.size();
+                if (queueSize != 0)
+                {
+                    requestContainer = std::move(this->pendingRequests[0]);
+                    this->pendingRequests.pop_front();
+                }
+            } // UNLOCK httpRequestMutex
+
+            if (queueSize == 0)
+            {
+                std::this_thread::sleep_for(std::chrono::milliseconds(10));
+                continue;
+            }
+
+            if (requestContainer != nullptr)
+            {
+                CallRequestContainer* requestContainerPtr = dynamic_cast<CallRequestContainer*>(requestContainer.get());
+                if (requestContainerPtr != nullptr)
+                {
+                    requestContainer.release();
+                    ExecuteRequest(std::unique_ptr<CallRequestContainer>(requestContainerPtr));
+                }
+            }
+        }
+    }
+
+    void PlayFabWinHttpPlugin::HandleCallback(std::unique_ptr<CallRequestContainer> requestContainer)
+    {
+        CallRequestContainer& reqContainer = *requestContainer;
+        reqContainer.finished = true;
+        if (PlayFabSettings::threadedCallbacks)
+        {
+            HandleResults(std::move(requestContainer));
+        }
+
+        if (!PlayFabSettings::threadedCallbacks)
+        {
+            { // LOCK httpRequestMutex
+                std::unique_lock<std::mutex> lock(httpRequestMutex);
+                pendingResults.push_back(std::unique_ptr<CallRequestContainerBase>(static_cast<CallRequestContainerBase*>(requestContainer.release())));
+            } // UNLOCK httpRequestMutex
+        }
+    }
+
+    void PlayFabWinHttpPlugin::MakePostRequest(std::unique_ptr<CallRequestContainerBase> requestContainer)
+    {
+        { // LOCK httpRequestMutex
+            std::unique_lock<std::mutex> lock(httpRequestMutex);
+            pendingRequests.push_back(std::move(requestContainer));
+            activeRequestCount++;
+        } // UNLOCK httpRequestMutex
+    }
+
+    void PlayFabWinHttpPlugin::ExecuteRequest(std::unique_ptr<CallRequestContainer> requestContainer)
+    {
+        CallRequestContainer& reqContainer = *requestContainer;
+
+        // Set up variables
+        DWORD dwStatusCode = 0;
+        DWORD dwSize = 0;
+        DWORD dwDownloaded = 0;
+        BOOL bResults = FALSE;
+        HINTERNET hSession = NULL, hConnect = NULL, hRequest = NULL;
+        constexpr size_t MaxUrlLength = 2048;
+        constexpr size_t MaxSchemeLength = 6; // HTTP, HTTPS (plus zero terminator)
+
+        // WinHTTP requires HOST and PATH parts of URL separately, we need to crack it (there is special API to do it)
+        const std::string& urlStr = GetUrl(reqContainer);
+        std::wstring urlWideStr(urlStr.begin(), urlStr.end());
+        const wchar_t* url = urlWideStr.c_str();
+        wchar_t urlHost[MaxUrlLength]; // we need to reserve a buffer to store HOST. If it doesn't fit we simply get an error.
+        wchar_t urlScheme[MaxSchemeLength]; // we need to reserve a buffer to store SCHEME. If it doesn't fit we simply get an error.
+        DWORD winHttpOpenRequestFlags = NULL;
+
+        // please read docs on URL_COMPONENTS and WinHttpCrackUrl to understand these parameters:
+        URL_COMPONENTS urlComponents;
+        urlComponents.lpszExtraInfo = nullptr;
+        urlComponents.dwExtraInfoLength = 0;
+        urlComponents.lpszHostName = urlHost;
+        urlComponents.dwHostNameLength = MaxUrlLength;
+        urlComponents.lpszPassword = nullptr;
+        urlComponents.dwPasswordLength = 0;
+        urlComponents.lpszScheme = urlScheme;
+        urlComponents.dwSchemeLength = MaxSchemeLength;
+        urlComponents.lpszUrlPath = nullptr;
+        urlComponents.dwUrlPathLength = 1;
+        urlComponents.lpszUserName = nullptr;
+        urlComponents.dwUserNameLength = 0;
+        urlComponents.dwStructSize = sizeof(urlComponents);
+
+        bResults = WinHttpCrackUrl(url, 0, 0, &urlComponents); // parse the URL
+        if (!bResults)
+        {
+            SetErrorInfo(reqContainer, "Error in WinHttpCrackUrl, failed to parse the URL string");
+        }
+        else
+        {
+            if (urlComponents.nPort == INTERNET_DEFAULT_HTTPS_PORT)
+            {
+                winHttpOpenRequestFlags = WINHTTP_FLAG_SECURE;
+            }
+
+            // Use WinHttpOpen to obtain a session handle
+            hSession = WinHttpOpen(L"PlayFab Agent",
+                WINHTTP_ACCESS_TYPE_DEFAULT_PROXY,
+                WINHTTP_NO_PROXY_NAME,
+                WINHTTP_NO_PROXY_BYPASS, 0);
+            if (!hSession)
+            {
+                SetErrorInfo(reqContainer, "Error in WinHttpOpen, failed to open an HTTP session");
+            }
+            else
+            {
+                // Specify an HTTP server
+                hConnect = WinHttpConnect(hSession, urlComponents.lpszHostName, urlComponents.nPort, 0);
+                if (!hConnect)
+                {
+                    SetErrorInfo(reqContainer, "Error in WinHttpConnect, failed to connect to host");
+                }
+                else
+                {
+                    // Create an HTTP request handle
+                    hRequest = WinHttpOpenRequest(hConnect, L"POST", urlComponents.lpszUrlPath, NULL, WINHTTP_NO_REFERER, NULL, winHttpOpenRequestFlags);
+                    if (!hRequest)
+                    {
+                        SetErrorInfo(reqContainer, "Error in WinHttpOpenRequest, failed to open an HTTP request");
+                    }
+                    else
+                    {
+                        // Add HTTP headers
+                        SetPredefinedHeaders(reqContainer, hRequest);
+                        auto headers = reqContainer.GetHeaders();
+                        if (headers.size() > 0)
+                        {
+                            for (auto const &obj : headers)
+                            {
+                                if (obj.first.length() != 0 && obj.second.length() != 0) // no empty keys or values in headers
+                                {
+                                    std::string header = obj.first + ": " + obj.second;
+                                    WinHttpAddRequestHeaders(hRequest, std::wstring(header.begin(), header.end()).c_str(), -1, 0);
+                                }
+                            }
+                        }
+
+                        // Send a request
+                        DWORD payloadSize = 0;
+                        LPVOID payload = NULL;
+                        std::string requestBody;
+                        if (!GetBinaryPayload(reqContainer, payload, payloadSize))
+                        {
+                            // set string payload if binary wasn't provided
+                            requestBody = std::move(reqContainer.GetRequestBody());
+                            payloadSize = (DWORD)requestBody.size();
+                            payload = const_cast<char*>(requestBody.c_str());
+                        }
+
+                        bResults = WinHttpSendRequest(hRequest, WINHTTP_NO_ADDITIONAL_HEADERS, 0, payload, payloadSize, payloadSize, 0);
+                        if (!bResults)
+                        {
+                            SetErrorInfo(reqContainer, "Error in WinHttpSendRequest, failed to send an HTTP request");
+                        }
+                        else
+                        {
+                            // End the request
+                            bResults = WinHttpReceiveResponse(hRequest, NULL);
+                            if (!bResults)
+                            {
+                                SetErrorInfo(reqContainer, "Error in WinHttpReceiveResponse, failed to receive an HTTP response");
+                            }
+                            else
+                            {
+                                // Get HTTP response code
+                                dwSize = sizeof(dwStatusCode);
+                                bResults = WinHttpQueryHeaders(hRequest,
+                                    WINHTTP_QUERY_STATUS_CODE | WINHTTP_QUERY_FLAG_NUMBER,
+                                    WINHTTP_HEADER_NAME_BY_INDEX,
+                                    &dwStatusCode, &dwSize, WINHTTP_NO_HEADER_INDEX);
+                                if (!bResults)
+                                {
+                                    SetErrorInfo(reqContainer, "Error in WinHttpQueryHeaders, failed to read HTTP response code");
+                                }
+                                else
+                                {
+                                    // Keep checking for data until there is nothing left
+                                    do
+                                    {
+                                        // Check for available data block
+                                        dwSize = 0;
+                                        if (!WinHttpQueryDataAvailable(hRequest, &dwSize))
+                                        {
+                                            SetErrorInfo(reqContainer, "Error in WinHttpQueryDataAvailable, failed to check for an available data block in HTTP response");
+                                            bResults = FALSE;
+                                            break;
+                                        }
+
+                                        // Allocate space for the buffer
+                                        auto outBuffer = std::unique_ptr<char>(new char[dwSize + 1]);
+                                        if (!outBuffer)
+                                        {
+                                            SetErrorInfo(reqContainer, "Out of memory, failed to allocate a buffer to read a data block in HTTP response");
+                                            bResults = FALSE;
+                                            break;
+                                        }
+                                        else
+                                        {
+                                            // Read the data block
+                                            ZeroMemory(outBuffer.get(), dwSize + 1);
+                                            if (!WinHttpReadData(hRequest, (LPVOID)outBuffer.get(), dwSize, &dwDownloaded))
+                                            {
+                                                SetErrorInfo(reqContainer, "Error in WinHttpReadData, failed to read a data block in HTTP response");
+                                                bResults = FALSE;
+                                                break;
+                                            }
+                                            else
+                                            {
+                                                // successfully received a block of data
+                                                reqContainer.responseString.append(outBuffer.get());
+                                            }
+
+                                            // Free the memory allocated to the buffer
+                                            outBuffer = nullptr;
+                                        }
+
+                                    } while (dwSize > 0);
+
+                                    if (bResults)
+                                    {
+                                        ProcessResponse(reqContainer, dwStatusCode);
+                                    }
+                                } // WinHttpQueryHeaders
+                            } // WinHttpReceiveResponse
+                        } // WinHttpSendRequest
+                    } // WinHttpOpenRequest
+                } // WinHttpConnect
+            } // WinHttpOpen
+        } // WinHttpCrackUrl
+
+        HandleCallback(std::move(requestContainer));
+
+        // Close any open handles
+        if (hRequest) WinHttpCloseHandle(hRequest);
+        if (hConnect) WinHttpCloseHandle(hConnect);
+        if (hSession) WinHttpCloseHandle(hSession);
+    }
+
+    std::string PlayFabWinHttpPlugin::GetUrl(CallRequestContainer& reqContainer) const
+    {
+        return PlayFabSettings::GetUrl(reqContainer.GetUrl(), PlayFabSettings::requestGetParams);
+    }
+
+    void PlayFabWinHttpPlugin::SetPredefinedHeaders(CallRequestContainer& requestContainer, HINTERNET hRequest)
+    {
+        WinHttpAddRequestHeaders(hRequest, L"Accept: application/json", -1, 0);
+        WinHttpAddRequestHeaders(hRequest, L"Content-Type: application/json; charset=utf-8", -1, 0);
+        WinHttpAddRequestHeaders(hRequest, (L"X-PlayFabSDK: " + std::wstring(PlayFabSettings::versionString.begin(), PlayFabSettings::versionString.end())).c_str(), -1, 0);
+        WinHttpAddRequestHeaders(hRequest, L"X-ReportErrorAsSuccess: true", -1, 0);
+    }
+
+    bool PlayFabWinHttpPlugin::GetBinaryPayload(CallRequestContainer& reqContainer, LPVOID& payload, DWORD& payloadSize) const
+    {
+        return false;
+    }
+
+    void PlayFabWinHttpPlugin::ProcessResponse(CallRequestContainer& reqContainer, const int httpCode)
+    {
+        Json::CharReaderBuilder jsonReaderFactory;
+        std::unique_ptr<Json::CharReader> jsonReader(jsonReaderFactory.newCharReader());
+        JSONCPP_STRING jsonParseErrors;
+        const bool parsedSuccessfully = jsonReader->parse(reqContainer.responseString.c_str(), reqContainer.responseString.c_str() + reqContainer.responseString.length(), &reqContainer.responseJson, &jsonParseErrors);
+
+        if (parsedSuccessfully)
+        {
+            // fully successful response
+            reqContainer.errorWrapper.HttpCode = reqContainer.responseJson.get("code", Json::Value::null).asInt();
+            reqContainer.errorWrapper.HttpStatus = reqContainer.responseJson.get("status", Json::Value::null).asString();
+            reqContainer.errorWrapper.Data = reqContainer.responseJson.get("data", Json::Value::null);
+            reqContainer.errorWrapper.ErrorName = reqContainer.responseJson.get("error", Json::Value::null).asString();
+            reqContainer.errorWrapper.ErrorMessage = reqContainer.responseJson.get("errorMessage", Json::Value::null).asString();
+            reqContainer.errorWrapper.ErrorDetails = reqContainer.responseJson.get("errorDetails", Json::Value::null);
+        }
+        else
+        {
+            reqContainer.errorWrapper.HttpCode = httpCode;
+            reqContainer.errorWrapper.HttpStatus = reqContainer.responseString;
+            reqContainer.errorWrapper.ErrorCode = PlayFabErrorCode::PlayFabErrorPartialFailure;
+            reqContainer.errorWrapper.ErrorName = "Failed to parse PlayFab response";
+            reqContainer.errorWrapper.ErrorMessage = jsonParseErrors;
+        }
+    }
+
+    void PlayFabWinHttpPlugin::SetErrorInfo(CallRequestContainer& requestContainer, const std::string& errorMessage, const int httpCode) const
+    {
+        requestContainer.errorWrapper.HttpCode = httpCode;
+        requestContainer.errorWrapper.HttpStatus = errorMessage;
+        requestContainer.errorWrapper.ErrorCode = PlayFabErrorCode::PlayFabErrorUnknownError;
+        requestContainer.errorWrapper.ErrorName = errorMessage;
+        requestContainer.errorWrapper.ErrorMessage = "Error: " + std::to_string(GetLastError());
+    }
+
+    void PlayFabWinHttpPlugin::HandleResults(std::unique_ptr<CallRequestContainer> requestContainer)
+    {
+        CallRequestContainer& reqContainer = *requestContainer;
+        auto callback = reqContainer.GetCallback();
+        if (callback != nullptr)
+        {
+            callback(
+                reqContainer.responseJson.get("code", Json::Value::null).asInt(),
+                reqContainer.responseString,
+                std::unique_ptr<CallRequestContainerBase>(static_cast<CallRequestContainerBase*>(requestContainer.release())));
+        }
+    }
+
+    size_t PlayFabWinHttpPlugin::Update()
+    {
+        if (PlayFabSettings::threadedCallbacks)
+        {
+            throw std::runtime_error("You should not call Update() when PlayFabSettings::threadedCallbacks == true");
+        }
+
+        std::unique_ptr<CallRequestContainerBase> requestContainer = nullptr;
+        { // LOCK httpRequestMutex
+            std::unique_lock<std::mutex> lock(httpRequestMutex);
+            if (pendingResults.empty())
+            {
+                return activeRequestCount;
+            }
+
+            requestContainer = std::move(this->pendingResults[0]);
+            this->pendingResults.pop_front();
+            activeRequestCount--;
+        } // UNLOCK httpRequestMutex
+
+        HandleResults(std::unique_ptr<CallRequestContainer>(static_cast<CallRequestContainer*>(requestContainer.release())));
+
+        // activeRequestCount can be altered by HandleResults, so we have to re-lock and return an updated value
+        { // LOCK httpRequestMutex
+            std::unique_lock<std::mutex> lock(httpRequestMutex);
+            return activeRequestCount;
+        }
+    }
+}

--- a/targets/XPlatCppSdk/source/com.playfab.xplatcppsdk.v141.autopkg.ejs
+++ b/targets/XPlatCppSdk/source/com.playfab.xplatcppsdk.v141.autopkg.ejs
@@ -64,5 +64,6 @@ nuget {
         Libraries += wldap32.lib;
         Libraries += crypt32.lib;
         Libraries += normaliz.lib;
+        Libraries += winhttp.lib;
     }
 }

--- a/targets/XPlatCppSdk/source/test/TestApp/TestApp.cpp
+++ b/targets/XPlatCppSdk/source/test/TestApp/TestApp.cpp
@@ -17,7 +17,7 @@
 #include <playfab/PlayFabEventsDataModels.h>
 #include <playfab/PlayFabEventApi.h>
 #include <playfab/OneDSEventsApi.h>
-#include <playfab/OneDSHttpPlugin.h>
+#include <playfab/PlayFabTransportHeaders.h>
 
 #include <playfab/QoS/PlayFabQoSApi.h>
 
@@ -279,7 +279,11 @@ void TestOneDSEventsApi()
         return;
 
     // set OneDS HTTP plugin
+#ifdef PLAYFAB_PLATFORM_WINDOWS
+    auto oneDSHttpPlugin = std::shared_ptr<PlayFab::OneDSWinHttpPlugin>(new PlayFab::OneDSWinHttpPlugin());
+#elif defined(PLAYFAB_PLATFORM_LINUX)
     auto oneDSHttpPlugin = std::shared_ptr<PlayFab::OneDSHttpPlugin>(new PlayFab::OneDSHttpPlugin());
+#endif
     PlayFab::PlayFabPluginManager::SetPlugin(oneDSHttpPlugin, PlayFab::PlayFabPluginContract::PlayFab_Transport, PlayFab::PLUGIN_TRANSPORT_ONEDS);
 
     // create OneDS Events API instance


### PR DESCRIPTION
- WinHTTP plugins for PF and OneDS (default on Windows platform). This HTTP stack is built in Windows and doesn't require any dependencies, hence it's ideal for this platform.
- Curl-based plugins for Windows are not really needed anymore (we can remove them at any time now along with their dependencies and git submodules)
- All tests and test app pass
- Everything is verified and tested