### PR TITLE
Change EditorUserBuildSettings in Tests

### DIFF
--- a/targets/unity-v2/Testing/Editor/PlayFabPackager.cs
+++ b/targets/unity-v2/Testing/Editor/PlayFabPackager.cs
@@ -165,7 +165,7 @@ namespace PlayFab.Internal
         {
             Setup();
 #if UNITY_2017_1_OR_NEWER
-            EditorUserBuildSettings.wsaBuildAndRunDeployTarget = WSABuildAndRunDeployTarget.LocalMachine;
+            EditorUserBuildSettings.wsaBuildAndRunDeployTarget = WSABuildAndRunDeployTarget.WindowsPhone;
             EditorUserBuildSettings.wsaSubtarget = WSASubtarget.AnyDevice;
             EditorUserBuildSettings.wsaGenerateReferenceProjects = true;
             PlayerSettings.WSA.SetCapability(PlayerSettings.WSACapability.InternetClient, true);

--- a/targets/unity-v2/Testing/Editor/PlayFabPackager.cs
+++ b/targets/unity-v2/Testing/Editor/PlayFabPackager.cs
@@ -165,7 +165,7 @@ namespace PlayFab.Internal
         {
             Setup();
 #if UNITY_2017_1_OR_NEWER
-            EditorUserBuildSettings.wsaBuildAndRunDeployTarget = WSABuildAndRunDeployTarget.LocalMachineAndWindowsPhone;
+            EditorUserBuildSettings.wsaBuildAndRunDeployTarget = WSABuildAndRunDeployTarget.LocalMachine;
             EditorUserBuildSettings.wsaSubtarget = WSASubtarget.AnyDevice;
             EditorUserBuildSettings.wsaGenerateReferenceProjects = true;
             PlayerSettings.WSA.SetCapability(PlayerSettings.WSACapability.InternetClient, true);


### PR DESCRIPTION
Changes EditorUserBuildSettings for windows builds to be the local machine rather than both a local machine and windows phone (no longer a valid Enum, have to pick one or the other).