### PR TITLE
Implemented support for instance-able PlayFab API classes (multi-instance APIs) in XplatCppSDK

### DIFF
--- a/targets/XPlatCppSdk/source/build/Linux/makefile.ejs
+++ b/targets/XPlatCppSdk/source/build/Linux/makefile.ejs
@@ -21,23 +21,15 @@ LINK_TARGET = XPlatCppLinux
 
 # Here is a Make Macro that uses the backslash to extend to multiple lines.
 OBJS = stdafx.o \
-	PlayFabAdminApi.o \
-	PlayFabAuthenticationApi.o \
+	PlayFabAuthenticationContext.o \
+	PlayFabApiSettings.o \<% for(var i in apis) { var api = apis[i];%>
+	PlayFab<%- api.name %>Api.o \
+	PlayFab<%- api.name %>InstanceApi.o \<% } %>
 	PlayFabCallRequestContainer.o \
 	PlayFabCallRequestContainerBase.o \
-	PlayFabClientApi.o \
-	PlayFabCloudScriptApi.o \
-	PlayFabDataApi.o \
 	PlayFabError.o \
-	PlayFabEventsApi.o \
-	PlayFabGroupsApi.o \
 	PlayFabCurlHttpPlugin.o \
-	PlayFabLocalizationApi.o \
-	PlayFabMatchmakerApi.o \
-	PlayFabMultiplayerApi.o \
 	PlayFabPluginManager.o \
-	PlayFabProfilesApi.o \
-	PlayFabServerApi.o \
 	PlayFabSettings.o \
 	PlayFabEvent.o \
 	PlayFabEventApi.o \

--- a/targets/XPlatCppSdk/source/build/Windows/XPlatCppWindows.vcxproj.ejs
+++ b/targets/XPlatCppSdk/source/build/Windows/XPlatCppWindows.vcxproj.ejs
@@ -114,9 +114,11 @@
     <ClInclude Include="$(SdkSourceDir)\include\playfab\OneDSEventsApi.h" />
     <ClInclude Include="$(SdkSourceDir)\include\playfab\OneDSEventPipeline.h" />
     <ClInclude Include="$(SdkSourceDir)\include\playfab\PlayFabAuthenticationContext.h" />
+    <ClInclude Include="$(SdkSourceDir)\include\playfab\PlayFabApiSettings.h" />
     <ClInclude Include="$(SdkSourceDir)\include\playfab\PlayFabBaseModel.h" />
 <% for(var i in apis) { var api = apis[i];%>
     <ClInclude Include="$(SdkSourceDir)\include\playfab\PlayFab<%- api.name %>Api.h" />
+    <ClInclude Include="$(SdkSourceDir)\include\playfab\PlayFab<%- api.name %>InstanceApi.h" />
     <ClInclude Include="$(SdkSourceDir)\include\playfab\PlayFab<%- api.name %>DataModels.h" /><% } %>
     <ClInclude Include="$(SdkSourceDir)\include\playfab\OneDSEventsDataModels.h" />
     <ClInclude Include="$(SdkSourceDir)\include\playfab\PlayFabEvent.h" />
@@ -146,8 +148,11 @@
     <ClCompile Include="$(SdkSourceDir)\source\playfab\OneDSWinHttpPlugin.cpp" />
     <ClCompile Include="$(SdkSourceDir)\source\playfab\OneDSEventsApi.cpp" />
     <ClCompile Include="$(SdkSourceDir)\source\playfab\OneDSEventPipeline.cpp" />
+    <ClCompile Include="$(SdkSourceDir)\source\playfab\PlayFabAuthenticationContext.cpp" />
+    <ClCompile Include="$(SdkSourceDir)\source\playfab\PlayFabApiSettings.cpp" />
 <% for(var i in apis) { var api = apis[i];%>
-    <ClCompile Include="$(SdkSourceDir)\source\playfab\PlayFab<%- api.name %>Api.cpp" /><% } %>
+    <ClCompile Include="$(SdkSourceDir)\source\playfab\PlayFab<%- api.name %>Api.cpp" />
+    <ClCompile Include="$(SdkSourceDir)\source\playfab\PlayFab<%- api.name %>InstanceApi.cpp" /><% } %>
     <ClCompile Include="$(SdkSourceDir)\source\playfab\PlayFabEvent.cpp" />
     <ClCompile Include="$(SdkSourceDir)\source\playfab\PlayFabEventApi.cpp" />
     <ClCompile Include="$(SdkSourceDir)\source\playfab\PlayFabEventBuffer.cpp" />

--- a/targets/XPlatCppSdk/source/build/Windows/XPlatCppWindows.vcxproj.ejs
+++ b/targets/XPlatCppSdk/source/build/Windows/XPlatCppWindows.vcxproj.ejs
@@ -113,6 +113,7 @@
     <ClInclude Include="$(SdkSourceDir)\include\playfab\OneDSWinHttpPlugin.h" />
     <ClInclude Include="$(SdkSourceDir)\include\playfab\OneDSEventsApi.h" />
     <ClInclude Include="$(SdkSourceDir)\include\playfab\OneDSEventPipeline.h" />
+    <ClInclude Include="$(SdkSourceDir)\include\playfab\PlayFabAuthenticationContext.h" />
     <ClInclude Include="$(SdkSourceDir)\include\playfab\PlayFabBaseModel.h" />
 <% for(var i in apis) { var api = apis[i];%>
     <ClInclude Include="$(SdkSourceDir)\include\playfab\PlayFab<%- api.name %>Api.h" />

--- a/targets/XPlatCppSdk/source/build/Windows/XPlatCppWindows.vcxproj.filters.ejs
+++ b/targets/XPlatCppSdk/source/build/Windows/XPlatCppWindows.vcxproj.filters.ejs
@@ -38,11 +38,17 @@
     <ClInclude Include="$(SdkSourceDir)\include\playfab\PlayFabAuthenticationContext.h">
       <Filter>Header Files\playfab</Filter>
     </ClInclude>
+    <ClInclude Include="$(SdkSourceDir)\include\playfab\PlayFabApiSettings.h">
+      <Filter>Header Files\playfab</Filter>
+    </ClInclude>
     <ClInclude Include="$(SdkSourceDir)\include\playfab\PlayFabBaseModel.h">
       <Filter>Header Files\playfab</Filter>
     </ClInclude>
 <% for(var i in apis) { var api = apis[i];
 %>    <ClInclude Include="$(SdkSourceDir)\include\playfab\PlayFab<%- api.name %>API.h">
+      <Filter>Header Files\playfab</Filter>
+    </ClInclude>
+    <ClInclude Include="$(SdkSourceDir)\include\playfab\PlayFab<%- api.name %>InstanceAPI.h">
       <Filter>Header Files\playfab</Filter>
     </ClInclude>
     <ClInclude Include="$(SdkSourceDir)\include\playfab\PlayFab<%- api.name %>DataModels.h">
@@ -128,11 +134,20 @@
     <ClCompile Include="$(SdkSourceDir)\source\playfab\OneDSEventPipeline.cpp">
       <Filter>Source Files\playfab</Filter>
     </ClCompile>
+    <ClCompile Include="$(SdkSourceDir)\source\playfab\PlayFabAuthenticationContext.cpp">
+      <Filter>Source Files\playfab</Filter>
+    </ClCompile>
+    <ClCompile Include="$(SdkSourceDir)\source\playfab\PlayFabApiSettings.cpp">
+      <Filter>Source Files\playfab</Filter>
+    </ClCompile>
     <ClCompile Include="$(SdkSourceDir)\stdafx.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
 <% for(var i in apis) { var api = apis[i];
 %>    <ClCompile Include="$(SdkSourceDir)\source\playfab\PlayFab<%- api.name %>Api.cpp">
+      <Filter>Source Files\playfab</Filter>
+    </ClCompile>
+    <ClCompile Include="$(SdkSourceDir)\source\playfab\PlayFab<%- api.name %>InstanceAPI.cpp">
       <Filter>Source Files\playfab</Filter>
     </ClCompile>
 <% } %>    <ClCompile Include="$(SdkSourceDir)\source\playfab\PlayFabError.cpp">

--- a/targets/XPlatCppSdk/source/build/Windows/XPlatCppWindows.vcxproj.filters.ejs
+++ b/targets/XPlatCppSdk/source/build/Windows/XPlatCppWindows.vcxproj.filters.ejs
@@ -35,6 +35,9 @@
     <ClInclude Include="$(SdkSourceDir)\include\playfab\OneDSEventPipeline.h">
       <Filter>Header Files\playfab</Filter>
     </ClInclude>
+    <ClInclude Include="$(SdkSourceDir)\include\playfab\PlayFabAuthenticationContext.h">
+      <Filter>Header Files\playfab</Filter>
+    </ClInclude>
     <ClInclude Include="$(SdkSourceDir)\include\playfab\PlayFabBaseModel.h">
       <Filter>Header Files\playfab</Filter>
     </ClInclude>

--- a/targets/XPlatCppSdk/source/build/Xbox/XPlatXbox.vcxproj.ejs
+++ b/targets/XPlatCppSdk/source/build/Xbox/XPlatXbox.vcxproj.ejs
@@ -173,6 +173,7 @@
     <ClInclude Include="$(SdkSourceDir)\include\playfab\OneDSIXHR2Plugin.h" />
     <ClInclude Include="$(SdkSourceDir)\include\playfab\OneDSEventsApi.h" />
     <ClInclude Include="$(SdkSourceDir)\include\playfab\OneDSEventPipeline.h" />
+    <ClInclude Include="$(SdkSourceDir)\include\playfab\PlayFabAuthenticationContext.h" />
     <ClInclude Include="$(SdkSourceDir)\include\playfab\PlayFabBaseModel.h" />
 <% for(var i in apis) { var api = apis[i];%>
     <ClInclude Include="$(SdkSourceDir)\include\playfab\PlayFab<%- api.name %>Api.h" />

--- a/targets/XPlatCppSdk/source/build/Xbox/XPlatXbox.vcxproj.ejs
+++ b/targets/XPlatCppSdk/source/build/Xbox/XPlatXbox.vcxproj.ejs
@@ -174,9 +174,11 @@
     <ClInclude Include="$(SdkSourceDir)\include\playfab\OneDSEventsApi.h" />
     <ClInclude Include="$(SdkSourceDir)\include\playfab\OneDSEventPipeline.h" />
     <ClInclude Include="$(SdkSourceDir)\include\playfab\PlayFabAuthenticationContext.h" />
+    <ClInclude Include="$(SdkSourceDir)\include\playfab\PlayFabApiSettings.h" />
     <ClInclude Include="$(SdkSourceDir)\include\playfab\PlayFabBaseModel.h" />
 <% for(var i in apis) { var api = apis[i];%>
     <ClInclude Include="$(SdkSourceDir)\include\playfab\PlayFab<%- api.name %>Api.h" />
+    <ClInclude Include="$(SdkSourceDir)\include\playfab\PlayFab<%- api.name %>InstanceApi.h" />
     <ClInclude Include="$(SdkSourceDir)\include\playfab\PlayFab<%- api.name %>DataModels.h" /><% } %>
     <ClInclude Include="$(SdkSourceDir)\include\playfab\OneDSEventsDataModels.h" />
     <ClInclude Include="$(SdkSourceDir)\include\playfab\PlayFabEvent.h" />
@@ -207,8 +209,11 @@
     <ClCompile Include="$(SdkSourceDir)\source\playfab\OneDSIXHR2Plugin.cpp" />
     <ClCompile Include="$(SdkSourceDir)\source\playfab\OneDSEventsApi.cpp" />
     <ClCompile Include="$(SdkSourceDir)\source\playfab\OneDSEventPipeline.cpp" />
+    <ClCompile Include="$(SdkSourceDir)\source\playfab\PlayFabAuthenticationContext.cpp" />
+    <ClCompile Include="$(SdkSourceDir)\source\playfab\PlayFabApiSettings.cpp" />
 <% for(var i in apis) { var api = apis[i];%>
-    <ClCompile Include="$(SdkSourceDir)\source\playfab\PlayFab<%- api.name %>Api.cpp" /><% } %>
+    <ClCompile Include="$(SdkSourceDir)\source\playfab\PlayFab<%- api.name %>Api.cpp" />
+    <ClCompile Include="$(SdkSourceDir)\source\playfab\PlayFab<%- api.name %>InstanceApi.cpp" /><% } %>
     <ClCompile Include="$(SdkSourceDir)\source\playfab\PlayFabEvent.cpp" />
     <ClCompile Include="$(SdkSourceDir)\source\playfab\PlayFabEventApi.cpp" />
     <ClCompile Include="$(SdkSourceDir)\source\playfab\PlayFabEventBuffer.cpp" />

--- a/targets/XPlatCppSdk/source/build/Xbox/XPlatXbox.vcxproj.filters.ejs
+++ b/targets/XPlatCppSdk/source/build/Xbox/XPlatXbox.vcxproj.filters.ejs
@@ -35,7 +35,10 @@
     <ClInclude Include="$(SdkSourceDir)\include\playfab\OneDSEventPipeline.h">
       <Filter>Header Files\playfab</Filter>
     </ClInclude>
-        <ClInclude Include="$(SdkSourceDir)\include\playfab\PlayFabAuthenticationContext.h">
+    <ClInclude Include="$(SdkSourceDir)\include\playfab\PlayFabAuthenticationContext.h">
+      <Filter>Header Files\playfab</Filter>
+    </ClInclude>
+    <ClInclude Include="$(SdkSourceDir)\include\playfab\PlayFabApiSettings.h">
       <Filter>Header Files\playfab</Filter>
     </ClInclude>
     <ClInclude Include="$(SdkSourceDir)\include\playfab\PlayFabBaseModel.h">
@@ -43,6 +46,9 @@
     </ClInclude>
 <% for(var i in apis) { var api = apis[i];
 %>    <ClInclude Include="$(SdkSourceDir)\include\playfab\PlayFab<%- api.name %>API.h">
+      <Filter>Header Files\playfab</Filter>
+    </ClInclude>
+    <ClInclude Include="$(SdkSourceDir)\include\playfab\PlayFab<%- api.name %>InstanceAPI.h">
       <Filter>Header Files\playfab</Filter>
     </ClInclude>
     <ClInclude Include="$(SdkSourceDir)\include\playfab\PlayFab<%- api.name %>DataModels.h">
@@ -128,7 +134,13 @@
     <ClCompile Include="$(SdkSourceDir)\source\playfab\OneDSEventsApi.cpp">
       <Filter>Source Files\playfab</Filter>
     </ClCompile>
-     <ClCompile Include="$(SdkSourceDir)\source\playfab\OneDSEventPipeline.cpp">
+    <ClCompile Include="$(SdkSourceDir)\source\playfab\OneDSEventPipeline.cpp">
+      <Filter>Source Files\playfab</Filter>
+    </ClCompile>
+    <ClCompile Include="$(SdkSourceDir)\source\playfab\PlayFabAuthenticationContext.cpp">
+      <Filter>Source Files\playfab</Filter>
+    </ClCompile>
+    <ClCompile Include="$(SdkSourceDir)\source\playfab\PlayFabApiSettings.cpp">
       <Filter>Source Files\playfab</Filter>
     </ClCompile>
     <ClCompile Include="$(SdkSourceDir)\stdafx.cpp">
@@ -136,6 +148,9 @@
     </ClCompile>
 <% for(var i in apis) { var api = apis[i];
 %>    <ClCompile Include="$(SdkSourceDir)\source\playfab\PlayFab<%- api.name %>Api.cpp">
+      <Filter>Source Files\playfab</Filter>
+    </ClCompile>
+    <ClCompile Include="$(SdkSourceDir)\source\playfab\PlayFab<%- api.name %>InstanceAPI.cpp">
       <Filter>Source Files\playfab</Filter>
     </ClCompile>
 <% } %>    <ClCompile Include="$(SdkSourceDir)\source\playfab\PlayFabError.cpp">

--- a/targets/XPlatCppSdk/source/build/Xbox/XPlatXbox.vcxproj.filters.ejs
+++ b/targets/XPlatCppSdk/source/build/Xbox/XPlatXbox.vcxproj.filters.ejs
@@ -35,6 +35,9 @@
     <ClInclude Include="$(SdkSourceDir)\include\playfab\OneDSEventPipeline.h">
       <Filter>Header Files\playfab</Filter>
     </ClInclude>
+        <ClInclude Include="$(SdkSourceDir)\include\playfab\PlayFabAuthenticationContext.h">
+      <Filter>Header Files\playfab</Filter>
+    </ClInclude>
     <ClInclude Include="$(SdkSourceDir)\include\playfab\PlayFabBaseModel.h">
       <Filter>Header Files\playfab</Filter>
     </ClInclude>

--- a/targets/XPlatCppSdk/source/code/include/playfab/PlayFabApiSettings.h
+++ b/targets/XPlatCppSdk/source/code/include/playfab/PlayFabApiSettings.h
@@ -1,0 +1,29 @@
+#pragma once
+
+#include <string>
+#include <map>
+
+namespace PlayFab
+{
+    /// <summary>
+    /// The settings that can be used (optionally) by instance versions of PlayFab APIs.
+    /// </summary>
+    class PlayFabApiSettings
+    {
+    public:
+        std::string verticalName; // The name of a PlayFab service vertical
+        std::string baseServiceHost; // The base for a PlayFab service host
+        std::string titleId; // You must set this value for PlayFabSdk to work properly (found in the Game Manager for your title, at the PlayFab Website)
+#ifndef DISABLE_PLAYFABCLIENT_API
+        std::string advertisingIdType; // Set this to the appropriate AD_TYPE_X constant (defined in PlayFabSettings)
+        std::string advertisingIdValue; // Set this to corresponding device value
+
+        // DisableAdvertising is provided for completeness, but changing it is not suggested
+        // Disabling this may prevent your advertising-related PlayFab marketplace partners from working correctly
+        bool disableAdvertising;
+
+        PlayFabApiSettings();
+        std::string GetUrl(const std::string& urlPath, const std::map<std::string, std::string>& getParams);
+#endif
+    };
+}

--- a/targets/XPlatCppSdk/source/code/include/playfab/PlayFabApiSettings.h
+++ b/targets/XPlatCppSdk/source/code/include/playfab/PlayFabApiSettings.h
@@ -21,9 +21,9 @@ namespace PlayFab
         // DisableAdvertising is provided for completeness, but changing it is not suggested
         // Disabling this may prevent your advertising-related PlayFab marketplace partners from working correctly
         bool disableAdvertising;
+#endif
 
         PlayFabApiSettings();
         std::string GetUrl(const std::string& urlPath, const std::map<std::string, std::string>& getParams);
-#endif
     };
 }

--- a/targets/XPlatCppSdk/source/code/include/playfab/PlayFabAuthenticationContext.h
+++ b/targets/XPlatCppSdk/source/code/include/playfab/PlayFabAuthenticationContext.h
@@ -1,0 +1,23 @@
+#pragma once
+
+#include <string>
+
+namespace PlayFab
+{
+    /// <summary>
+    /// Container for PlayFab authentication credentials data.
+    /// </summary>
+    struct PlayFabAuthenticationContext
+    {
+        std::string clientSessionTicket; // Client session ticket that is used as an authentication token in many PlayFab API methods.
+        std::string entityToken; // User's entity token. Entity tokens are required by all Entity API methods.
+        std::string developerSecretKey; // Developer secret key. These keys can be used in development environments.
+
+        void ForgetAllCredentials()
+        {
+            clientSessionTicket.clear();
+            entityToken.clear();
+            developerSecretKey.clear();
+        }
+    };
+}

--- a/targets/XPlatCppSdk/source/code/include/playfab/PlayFabAuthenticationContext.h
+++ b/targets/XPlatCppSdk/source/code/include/playfab/PlayFabAuthenticationContext.h
@@ -7,17 +7,14 @@ namespace PlayFab
     /// <summary>
     /// Container for PlayFab authentication credentials data.
     /// </summary>
-    struct PlayFabAuthenticationContext
+    class PlayFabAuthenticationContext
     {
+    public:
         std::string clientSessionTicket; // Client session ticket that is used as an authentication token in many PlayFab API methods.
         std::string entityToken; // User's entity token. Entity tokens are required by all Entity API methods.
         std::string developerSecretKey; // Developer secret key. These keys can be used in development environments.
 
-        void ForgetAllCredentials()
-        {
-            clientSessionTicket.clear();
-            entityToken.clear();
-            developerSecretKey.clear();
-        }
+        PlayFabAuthenticationContext();
+        void ForgetAllCredentials();
     };
 }

--- a/targets/XPlatCppSdk/source/code/include/playfab/PlayFabAuthenticationContext.h
+++ b/targets/XPlatCppSdk/source/code/include/playfab/PlayFabAuthenticationContext.h
@@ -10,9 +10,15 @@ namespace PlayFab
     class PlayFabAuthenticationContext
     {
     public:
+#ifndef DISABLE_PLAYFABCLIENT_API
         std::string clientSessionTicket; // Client session ticket that is used as an authentication token in many PlayFab API methods.
+#endif
+#ifndef DISABLE_PLAYFABENTITY_API
         std::string entityToken; // User's entity token. Entity tokens are required by all Entity API methods.
+#endif
+#if defined(ENABLE_PLAYFABSERVER_API) || defined(ENABLE_PLAYFABADMIN_API)
         std::string developerSecretKey; // Developer secret key. These keys can be used in development environments.
+#endif
 
         PlayFabAuthenticationContext();
         void ForgetAllCredentials();

--- a/targets/XPlatCppSdk/source/code/include/playfab/PlayFabBaseModel.h
+++ b/targets/XPlatCppSdk/source/code/include/playfab/PlayFabBaseModel.h
@@ -8,9 +8,11 @@
 
 #include <sstream>
 #include <iomanip>
+#include <memory>
 
 #include <playfab/PlayFabPlatformMacros.h>
 #include <playfab/PlayFabJsonHeaders.h>
+#include <playfab/PlayFabAuthenticationContext.h>
 
 namespace PlayFab
 {
@@ -68,13 +70,22 @@ namespace PlayFab
     /// Base class for all PlayFab Requests
     /// Adds a parameter that controls how requests are threaded
     /// </summary>
-    struct PlayFabRequestCommon : public PlayFabBaseModel { };
+    struct PlayFabRequestCommon : public PlayFabBaseModel { 
+        std::shared_ptr<PlayFabAuthenticationContext> authenticationContext; // an optional authentication context (can used in multi-user scenarios)
+    };
 
     /// <summary>
     /// Base class for all PlayFab Results
     /// </summary>
     struct PlayFabResultCommon : public PlayFabBaseModel {
         Json::Value Request;
+    };
+
+    /// <summary>
+    /// Base class for all PlayFab Login method Results
+    /// </summary>
+    struct PlayFabLoginResultCommon : public PlayFabResultCommon {
+        std::shared_ptr<PlayFabAuthenticationContext> authenticationContext; // an authentication context returned by Login methods (can used in multi-user scenarios)
     };
 
     // Utilities for [de]serializing time_t to/from json

--- a/targets/XPlatCppSdk/source/code/include/playfab/PlayFabBaseModel.h
+++ b/targets/XPlatCppSdk/source/code/include/playfab/PlayFabBaseModel.h
@@ -71,7 +71,10 @@ namespace PlayFab
     /// Adds a parameter that controls how requests are threaded
     /// </summary>
     struct PlayFabRequestCommon : public PlayFabBaseModel { 
-        std::shared_ptr<PlayFabAuthenticationContext> authenticationContext; // an optional authentication context (can used in multi-user scenarios)
+        /// <summary>
+        /// An optional authentication context, it can used in multi-user scenarios
+        /// </summary>
+        std::shared_ptr<PlayFabAuthenticationContext> authenticationContext;
     };
 
     /// <summary>
@@ -85,7 +88,10 @@ namespace PlayFab
     /// Base class for all PlayFab Login method Results
     /// </summary>
     struct PlayFabLoginResultCommon : public PlayFabResultCommon {
-        std::shared_ptr<PlayFabAuthenticationContext> authenticationContext; // an authentication context returned by Login methods (can used in multi-user scenarios)
+        /// <summary>
+        /// An authentication context returned by Login methods, it can used in multi-user scenarios
+        /// </summary>
+        std::shared_ptr<PlayFabAuthenticationContext> authenticationContext;
     };
 
     // Utilities for [de]serializing time_t to/from json

--- a/targets/XPlatCppSdk/source/code/include/playfab/PlayFabCallRequestContainer.h
+++ b/targets/XPlatCppSdk/source/code/include/playfab/PlayFabCallRequestContainer.h
@@ -19,6 +19,7 @@ namespace PlayFab
             std::shared_ptr<PlayFabApiSettings> apiSettings = nullptr);
 
         virtual ~CallRequestContainer() override;
+        std::string GetFullUrl() const;
 
         // TODO: clean up these public variables with setters/getters when you have the chance.
 

--- a/targets/XPlatCppSdk/source/code/include/playfab/PlayFabCallRequestContainer.h
+++ b/targets/XPlatCppSdk/source/code/include/playfab/PlayFabCallRequestContainer.h
@@ -15,7 +15,8 @@ namespace PlayFab
             const std::unordered_map<std::string, std::string>& headers,
             std::string requestBody,
             CallRequestContainerCallback callback,
-            void* customData = nullptr);
+            void* customData = nullptr,
+            std::shared_ptr<PlayFabApiSettings> apiSettings = nullptr);
 
         virtual ~CallRequestContainer() override;
 
@@ -36,8 +37,9 @@ namespace PlayFab
         OneDSCallRequestContainer(const std::unordered_map<std::string, std::string>& headers,
             std::vector<uint8_t> requestBody,
             CallRequestContainerCallback callback,
-            void* customData = nullptr):
-            CallRequestContainer("", headers, "", callback, customData),
+            void* customData = nullptr,
+            std::shared_ptr<PlayFabApiSettings> apiSettings = nullptr):
+            CallRequestContainer("", headers, "", callback, customData, apiSettings),
             requestBinaryBody(std::move(requestBody))
         {
         }

--- a/targets/XPlatCppSdk/source/code/include/playfab/PlayFabCallRequestContainerBase.h
+++ b/targets/XPlatCppSdk/source/code/include/playfab/PlayFabCallRequestContainerBase.h
@@ -51,7 +51,7 @@ namespace PlayFab
 
         void* GetCustomData() const;
 
-    private:
+    protected:
         std::string url;
         std::unordered_map<std::string, std::string> headers;
         std::string requestBody;

--- a/targets/XPlatCppSdk/source/code/include/playfab/PlayFabCallRequestContainerBase.h
+++ b/targets/XPlatCppSdk/source/code/include/playfab/PlayFabCallRequestContainerBase.h
@@ -1,6 +1,8 @@
 #pragma once
 
+#include <playfab/PlayFabApiSettings.h>
 #include <unordered_map>
+#include <memory>
 
 namespace PlayFab
 {
@@ -25,7 +27,8 @@ namespace PlayFab
             const std::unordered_map<std::string, std::string>& headers,
             std::string requestBody,
             CallRequestContainerCallback callback,
-            void* customData = nullptr);
+            void* customData = nullptr,
+            std::shared_ptr<PlayFabApiSettings> apiSettings = nullptr);
 
         CallRequestContainerBase(const CallRequestContainerBase& reqContainer);
         const CallRequestContainerBase& operator=(const CallRequestContainerBase& reqContainer);
@@ -39,6 +42,7 @@ namespace PlayFab
         std::string GetUrl() const;
         std::unordered_map<std::string, std::string> GetHeaders() const;
         std::string GetRequestBody() const;
+        std::shared_ptr<PlayFabApiSettings> GetApiSettings() const;
 
         /// <summary>
         /// This function is meant to handle logic of calling the error callback or success
@@ -51,6 +55,7 @@ namespace PlayFab
         std::string url;
         std::unordered_map<std::string, std::string> headers;
         std::string requestBody;
+        std::shared_ptr<PlayFabApiSettings> apiSettings;
         CallRequestContainerCallback callback;
 
         // I never own this, I can never destroy it

--- a/targets/XPlatCppSdk/source/code/include/playfab/PlayFabCallRequestContainerBase.h
+++ b/targets/XPlatCppSdk/source/code/include/playfab/PlayFabCallRequestContainerBase.h
@@ -5,7 +5,7 @@
 namespace PlayFab
 {
     class CallRequestContainerBase;
-    typedef void(*CallRequestContainerCallback)(int, std::string, std::unique_ptr<CallRequestContainerBase>);
+    typedef std::function<void(int, std::string, std::unique_ptr<CallRequestContainerBase>)> CallRequestContainerCallback;
 
     /// <summary>
     /// A base container meant for holding everything necessary to make a full HTTP request and return a response.

--- a/targets/XPlatCppSdk/source/code/include/playfab/PlayFabEventPipeline.h
+++ b/targets/XPlatCppSdk/source/code/include/playfab/PlayFabEventPipeline.h
@@ -7,6 +7,7 @@
 
 #include <playfab/PlayFabEvent.h>
 #include <playfab/PlayFabEventBuffer.h>
+#include <playfab/PlayFabAuthenticationContext.h>
 
 namespace PlayFab
 {
@@ -25,6 +26,7 @@ namespace PlayFab
         size_t maximalNumberOfRetries; // The maximal number of retries for transient transport errors, before a batch is discarded.
         size_t maximalNumberOfBatchesInFlight; // The maximal number of batches currently "in flight" (sent to a transport plugin).
         int64_t readBufferWaitTime; // The wait time between attempts to read events from buffer when it is empty, in milliseconds.
+        std::shared_ptr<PlayFabAuthenticationContext> authenticationContext; // The optional PlayFab authentication context that can be used with static PlayFab events API
     };
 
     /// <summary>

--- a/targets/XPlatCppSdk/source/code/source/playfab/OneDSEventPipeline.cpp
+++ b/targets/XPlatCppSdk/source/code/source/playfab/OneDSEventPipeline.cpp
@@ -59,6 +59,11 @@ namespace PlayFab
         std::shared_ptr<bool> operationComplete = std::shared_ptr<bool>(new bool(false));
         std::shared_ptr<bool> isOneDSAuthenticated = std::shared_ptr<bool>(new bool(false));
         EventsModels::TelemetryIngestionConfigRequest configRequest;
+        if (this->GetSettings()->authenticationContext != nullptr)
+        {
+            configRequest.authenticationContext = this->GetSettings()->authenticationContext;
+        }
+
         OneDSEventsAPI::GetTelemetryIngestionConfig(configRequest,
             [&](const PlayFab::EventsModels::TelemetryIngestionConfigResponse& result, void* relayedCustomData)
             {

--- a/targets/XPlatCppSdk/source/code/source/playfab/OneDSEventsApi.cpp
+++ b/targets/XPlatCppSdk/source/code/source/playfab/OneDSEventsApi.cpp
@@ -345,7 +345,7 @@ namespace PlayFab
         std::string jsonAsString = writer.write(requestJson);
 
         std::unordered_map<std::string, std::string> headers;
-        headers.emplace("X-EntityToken", PlayFabSettings::entityToken);
+        headers.emplace("X-EntityToken", request.authenticationContext == nullptr ? PlayFabSettings::entityToken : request.authenticationContext->entityToken);
 
         auto reqContainer = std::unique_ptr<CallRequestContainer>(new CallRequestContainer(
             "/Event/GetTelemetryIngestionConfig",

--- a/targets/XPlatCppSdk/source/code/source/playfab/PlayFabApiSettings.cpp
+++ b/targets/XPlatCppSdk/source/code/source/playfab/PlayFabApiSettings.cpp
@@ -1,0 +1,56 @@
+#include <stdafx.h>
+
+#include <playfab/PlayFabApiSettings.h>
+#include <playfab/PlayFabSettings.h>
+
+namespace PlayFab
+{
+    PlayFabApiSettings::PlayFabApiSettings() :
+#ifndef DISABLE_PLAYFABCLIENT_API
+        advertisingIdType(PlayFabSettings::advertisingIdType),
+        advertisingIdValue(PlayFabSettings::advertisingIdValue),
+        disableAdvertising(PlayFabSettings::disableAdvertising),
+#endif
+        verticalName(PlayFabSettings::verticalName),
+        baseServiceHost(PlayFabSettings::productionEnvironmentURL),
+        titleId(PlayFabApiSettings::titleId)
+    {
+    }
+
+    std::string PlayFabApiSettings::GetUrl(const std::string& urlPath, const std::map<std::string, std::string>& getParams)
+    {
+        std::string fullUrl;
+        fullUrl.reserve(1000);
+
+        fullUrl += "https://";
+
+        if (verticalName.length() > 0)
+        {
+            fullUrl += verticalName;
+        }
+        else
+        {
+            fullUrl += titleId;
+        }
+
+        fullUrl += baseServiceHost;
+        fullUrl += urlPath;
+
+        bool firstParam = true;
+        for (auto const& paramPair : getParams)
+        {
+            if (firstParam) {
+                fullUrl += "?";
+                firstParam = false;
+            }
+            else {
+                fullUrl += "&";
+            }
+            fullUrl += paramPair.first;
+            fullUrl += "=";
+            fullUrl += paramPair.second;
+        }
+
+        return fullUrl;
+    }
+}

--- a/targets/XPlatCppSdk/source/code/source/playfab/PlayFabApiSettings.cpp
+++ b/targets/XPlatCppSdk/source/code/source/playfab/PlayFabApiSettings.cpp
@@ -13,7 +13,7 @@ namespace PlayFab
 #endif
         verticalName(PlayFabSettings::verticalName),
         baseServiceHost(PlayFabSettings::productionEnvironmentURL),
-        titleId(PlayFabApiSettings::titleId)
+        titleId(PlayFabSettings::titleId)
     {
     }
 

--- a/targets/XPlatCppSdk/source/code/source/playfab/PlayFabAuthenticationContext.cpp
+++ b/targets/XPlatCppSdk/source/code/source/playfab/PlayFabAuthenticationContext.cpp
@@ -5,17 +5,29 @@
 
 namespace PlayFab
 {
-    PlayFabAuthenticationContext::PlayFabAuthenticationContext() :
-        clientSessionTicket(PlayFabSettings::clientSessionTicket),
-        entityToken(PlayFabSettings::entityToken),
-        developerSecretKey(PlayFabSettings::developerSecretKey)
+    PlayFabAuthenticationContext::PlayFabAuthenticationContext()
     {
+#ifndef DISABLE_PLAYFABCLIENT_API
+        clientSessionTicket = PlayFabSettings::clientSessionTicket;
+#endif
+#ifndef DISABLE_PLAYFABENTITY_API
+        entityToken = PlayFabSettings::entityToken;
+#endif
+#if defined(ENABLE_PLAYFABSERVER_API) || defined(ENABLE_PLAYFABADMIN_API)
+        developerSecretKey = PlayFabSettings::developerSecretKey;
+#endif
     }
 
     void PlayFabAuthenticationContext::ForgetAllCredentials()
     {
+#ifndef DISABLE_PLAYFABCLIENT_API
         clientSessionTicket.clear();
+#endif
+#ifndef DISABLE_PLAYFABENTITY_API
         entityToken.clear();
+#endif
+#if defined(ENABLE_PLAYFABSERVER_API) || defined(ENABLE_PLAYFABADMIN_API)
         developerSecretKey.clear();
+#endif
     }
 }

--- a/targets/XPlatCppSdk/source/code/source/playfab/PlayFabAuthenticationContext.cpp
+++ b/targets/XPlatCppSdk/source/code/source/playfab/PlayFabAuthenticationContext.cpp
@@ -1,0 +1,21 @@
+#include <stdafx.h>
+
+#include <playfab/PlayFabAuthenticationContext.h>
+#include <playfab/PlayFabSettings.h>
+
+namespace PlayFab
+{
+    PlayFabAuthenticationContext::PlayFabAuthenticationContext() :
+        clientSessionTicket(PlayFabSettings::clientSessionTicket),
+        entityToken(PlayFabSettings::entityToken),
+        developerSecretKey(PlayFabSettings::developerSecretKey)
+    {
+    }
+
+    void PlayFabAuthenticationContext::ForgetAllCredentials()
+    {
+        clientSessionTicket.clear();
+        entityToken.clear();
+        developerSecretKey.clear();
+    }
+}

--- a/targets/XPlatCppSdk/source/code/source/playfab/PlayFabCallRequestContainer.cpp
+++ b/targets/XPlatCppSdk/source/code/source/playfab/PlayFabCallRequestContainer.cpp
@@ -1,6 +1,7 @@
 #include <stdafx.h>
 
 #include <playfab/PlayFabCallRequestContainer.h>
+#include <playfab/PlayFabSettings.h>
 
 namespace PlayFab
 {
@@ -32,5 +33,17 @@ namespace PlayFab
 
     CallRequestContainer::~CallRequestContainer()
     {
+    }
+
+    std::string CallRequestContainer::GetFullUrl() const
+    {
+        if (apiSettings == nullptr)
+        {
+            return PlayFabSettings::GetUrl(this->GetUrl(), PlayFabSettings::requestGetParams);
+        }
+        else
+        {
+            return apiSettings->GetUrl(this->GetUrl(), PlayFabSettings::requestGetParams);
+        }
     }
 }

--- a/targets/XPlatCppSdk/source/code/source/playfab/PlayFabCallRequestContainer.cpp
+++ b/targets/XPlatCppSdk/source/code/source/playfab/PlayFabCallRequestContainer.cpp
@@ -8,8 +8,9 @@ namespace PlayFab
         const std::unordered_map<std::string, std::string>& headers,
         std::string requestBody,
         CallRequestContainerCallback callback,
-        void* customData) :
-        CallRequestContainerBase(url, headers, requestBody, callback, customData),
+        void* customData,
+        std::shared_ptr<PlayFabApiSettings> settings) :
+        CallRequestContainerBase(url, headers, requestBody, callback, customData, settings),
         finished(false),
         responseString(""),
         responseJson(Json::Value::null),

--- a/targets/XPlatCppSdk/source/code/source/playfab/PlayFabCallRequestContainerBase.cpp
+++ b/targets/XPlatCppSdk/source/code/source/playfab/PlayFabCallRequestContainerBase.cpp
@@ -9,12 +9,14 @@ namespace PlayFab
         const std::unordered_map<std::string, std::string>& headers,
         std::string requestBody,
         CallRequestContainerCallback callback,
-        void* customData) :
+        void* customData,
+        std::shared_ptr<PlayFabApiSettings> settings) :
         url(url),
         headers(headers),
         requestBody(requestBody),
         callback(callback),
-        customData(customData)
+        customData(customData),
+        apiSettings(settings)
     {
     }
 
@@ -30,6 +32,7 @@ namespace PlayFab
             this->url = otherContainer.url;
             this->headers = otherContainer.headers;
             this->requestBody = otherContainer.requestBody;
+            this->apiSettings = otherContainer.apiSettings;
             this->callback = otherContainer.callback;
             this->customData = otherContainer.customData;
         }
@@ -54,6 +57,11 @@ namespace PlayFab
     std::string CallRequestContainerBase::GetRequestBody() const
     {
         return requestBody;
+    }
+
+    std::shared_ptr<PlayFabApiSettings> CallRequestContainerBase::GetApiSettings() const
+    {
+        return apiSettings;
     }
 
     CallRequestContainerCallback CallRequestContainerBase::GetCallback() const

--- a/targets/XPlatCppSdk/source/code/source/playfab/PlayFabCurlHttpPlugin.cpp
+++ b/targets/XPlatCppSdk/source/code/source/playfab/PlayFabCurlHttpPlugin.cpp
@@ -107,18 +107,7 @@ namespace PlayFab
         CURL* curlHandle = curl_easy_init();
         curl_easy_reset(curlHandle);
         curl_easy_setopt(curlHandle, CURLOPT_NOSIGNAL, true);
-
-        std::string urlString;
-        auto apiSettings = reqContainer.GetApiSettings();
-        if (apiSettings == nullptr)
-        {
-            urlString = PlayFabSettings::GetUrl(reqContainer.GetUrl(), PlayFabSettings::requestGetParams);
-        }
-        else
-        {
-            urlString = apiSettings->GetUrl(reqContainer.GetUrl(), PlayFabSettings::requestGetParams);
-        }
-
+        std::string urlString = reqContainer.GetFullUrl();
         curl_easy_setopt(curlHandle, CURLOPT_URL, urlString.c_str());
 
         // Set up headers

--- a/targets/XPlatCppSdk/source/code/source/playfab/PlayFabCurlHttpPlugin.cpp
+++ b/targets/XPlatCppSdk/source/code/source/playfab/PlayFabCurlHttpPlugin.cpp
@@ -107,7 +107,19 @@ namespace PlayFab
         CURL* curlHandle = curl_easy_init();
         curl_easy_reset(curlHandle);
         curl_easy_setopt(curlHandle, CURLOPT_NOSIGNAL, true);
-        curl_easy_setopt(curlHandle, CURLOPT_URL, PlayFabSettings::GetUrl(reqContainer.GetUrl(), PlayFabSettings::requestGetParams).c_str());
+
+        std::string urlString;
+        auto apiSettings = reqContainer.GetApiSettings();
+        if (apiSettings == nullptr)
+        {
+            urlString = PlayFabSettings::GetUrl(reqContainer.GetUrl(), PlayFabSettings::requestGetParams);
+        }
+        else
+        {
+            urlString = apiSettings->GetUrl(reqContainer.GetUrl(), PlayFabSettings::requestGetParams);
+        }
+
+        curl_easy_setopt(curlHandle, CURLOPT_URL, urlString.c_str());
 
         // Set up headers
         curl_slist* curlHttpHeaders = nullptr;

--- a/targets/XPlatCppSdk/source/code/source/playfab/PlayFabEventPipeline.cpp
+++ b/targets/XPlatCppSdk/source/code/source/playfab/PlayFabEventPipeline.cpp
@@ -13,7 +13,8 @@ namespace PlayFab
         maximalNumberOfItemsInBatch(5),
         maximalBatchWaitTime(3),
         maximalNumberOfBatchesInFlight(16),
-        readBufferWaitTime(10)
+        readBufferWaitTime(10),
+        authenticationContext(nullptr)
     {
     }
 
@@ -178,6 +179,11 @@ namespace PlayFab
     {
         // create a WriteEvents API request to send the batch
         EventsModels::WriteEventsRequest batchReq;
+        if (this->settings->authenticationContext != nullptr)
+        {
+            batchReq.authenticationContext = this->settings->authenticationContext;
+        }
+
         for (const auto& eventEmitRequest : this->batch)
         {
             const auto& playFabEmitRequest = std::dynamic_pointer_cast<const PlayFabEmitEventRequest>(eventEmitRequest);

--- a/targets/XPlatCppSdk/source/code/source/playfab/PlayFabIXHR2HttpPlugin.cpp
+++ b/targets/XPlatCppSdk/source/code/source/playfab/PlayFabIXHR2HttpPlugin.cpp
@@ -145,17 +145,7 @@ namespace PlayFab
         SetupRequestHeaders(reqContainer, headers);
 
         // Setup url
-        std::string urlString;
-        auto apiSettings = reqContainer.GetApiSettings();
-        if (apiSettings == nullptr)
-        {
-            urlString = PlayFabSettings::GetUrl(reqContainer.GetUrl(), PlayFabSettings::requestGetParams);
-        }
-        else
-        {
-            urlString = apiSettings->GetUrl(reqContainer.GetUrl(), PlayFabSettings::requestGetParams);
-        }
-
+        std::string urlString = reqContainer.GetFullUrl();
         std::wstring url(urlString.begin(), urlString.end());
         
         // Setup payload

--- a/targets/XPlatCppSdk/source/code/source/playfab/PlayFabIXHR2HttpPlugin.cpp
+++ b/targets/XPlatCppSdk/source/code/source/playfab/PlayFabIXHR2HttpPlugin.cpp
@@ -145,7 +145,17 @@ namespace PlayFab
         SetupRequestHeaders(reqContainer, headers);
 
         // Setup url
-        std::string urlString = PlayFabSettings::GetUrl(reqContainer.GetUrl(), PlayFabSettings::requestGetParams);
+        std::string urlString;
+        auto apiSettings = reqContainer.GetApiSettings();
+        if (apiSettings == nullptr)
+        {
+            urlString = PlayFabSettings::GetUrl(reqContainer.GetUrl(), PlayFabSettings::requestGetParams);
+        }
+        else
+        {
+            urlString = apiSettings->GetUrl(reqContainer.GetUrl(), PlayFabSettings::requestGetParams);
+        }
+
         std::wstring url(urlString.begin(), urlString.end());
         
         // Setup payload

--- a/targets/XPlatCppSdk/source/code/source/playfab/PlayFabWinHttpPlugin.cpp
+++ b/targets/XPlatCppSdk/source/code/source/playfab/PlayFabWinHttpPlugin.cpp
@@ -288,13 +288,7 @@ namespace PlayFab
 
     std::string PlayFabWinHttpPlugin::GetUrl(CallRequestContainer& reqContainer) const
     {
-        auto apiSettings = reqContainer.GetApiSettings();
-        if (apiSettings == nullptr)
-        {
-            return PlayFabSettings::GetUrl(reqContainer.GetUrl(), PlayFabSettings::requestGetParams);
-        }
-
-        return apiSettings->GetUrl(reqContainer.GetUrl(), PlayFabSettings::requestGetParams);
+        return reqContainer.GetFullUrl();
     }
 
     void PlayFabWinHttpPlugin::SetPredefinedHeaders(CallRequestContainer& requestContainer, HINTERNET hRequest)

--- a/targets/XPlatCppSdk/source/code/source/playfab/PlayFabWinHttpPlugin.cpp
+++ b/targets/XPlatCppSdk/source/code/source/playfab/PlayFabWinHttpPlugin.cpp
@@ -288,7 +288,13 @@ namespace PlayFab
 
     std::string PlayFabWinHttpPlugin::GetUrl(CallRequestContainer& reqContainer) const
     {
-        return PlayFabSettings::GetUrl(reqContainer.GetUrl(), PlayFabSettings::requestGetParams);
+        auto apiSettings = reqContainer.GetApiSettings();
+        if (apiSettings == nullptr)
+        {
+            return PlayFabSettings::GetUrl(reqContainer.GetUrl(), PlayFabSettings::requestGetParams);
+        }
+
+        return apiSettings->GetUrl(reqContainer.GetUrl(), PlayFabSettings::requestGetParams);
     }
 
     void PlayFabWinHttpPlugin::SetPredefinedHeaders(CallRequestContainer& requestContainer, HINTERNET hRequest)

--- a/targets/XPlatCppSdk/source/test/TestApp/TestApp.cpp
+++ b/targets/XPlatCppSdk/source/test/TestApp/TestApp.cpp
@@ -12,6 +12,7 @@
 #include <playfab/PlayFabProfilesApi.h>
 #include <playfab/PlayFabProfilesDataModels.h>
 #include <playfab/PlayFabSettings.h>
+#include <playfab/PlayFabAuthenticationContext.h>
 #include <playfab/OneDSEventsDataModels.h>
 #include <playfab/PlayFabEventsApi.h>
 #include <playfab/PlayFabEventsDataModels.h>
@@ -325,6 +326,106 @@ void TestLightweightEvents()
     }
 }
 
+void TestMultipleUsers()
+{
+    printf("\n========== Testing multiple users scenario ===========\n");
+    PlayFab::ClientModels::LoginWithCustomIDRequest loginRequest;
+    PlayFab::ClientModels::GetPlayerProfileRequest profileRequest;
+    bool loginCompletedUser1 = false;
+    bool loginCompletedUser2 = false;
+    bool loginSuccessfulUser1 = false;
+    bool loginSuccessfulUser2 = false;
+    bool profileCompletedUser1 = false;
+    bool profileCompletedUser2 = false;
+    std::shared_ptr<PlayFab::PlayFabAuthenticationContext> authContextUser1;
+    std::shared_ptr<PlayFab::PlayFabAuthenticationContext> authContextUser2;
+    loginRequest.CreateAccount = true;
+
+    // log in user 1
+    loginRequest.CustomId = "test_GSDK1";
+    PlayFab::PlayFabClientAPI::LoginWithCustomID(loginRequest,
+    [&](const PlayFab::ClientModels::LoginResult& result, void* customData)
+        {
+            printf("---------- Successfully logged in user 1\n");
+            printf(("---------- User 1 client session ticket: " + result.authenticationContext->clientSessionTicket + "\n").c_str());
+            authContextUser1 = result.authenticationContext;
+            loginCompletedUser1 = true;
+            loginSuccessfulUser1 = true;
+        }, 
+        [&](const PlayFab::PlayFabError& error, void* customData)
+        {
+            printf(("========== Failed to log in user 1: " + error.GenerateErrorReport() + "\n").c_str());
+            loginCompletedUser1 = true;
+        });
+
+    // log in user 2
+    loginRequest.CustomId = "test_GSDK2";
+    PlayFab::PlayFabClientAPI::LoginWithCustomID(loginRequest,
+        [&](const PlayFab::ClientModels::LoginResult& result, void* customData)
+        {
+            printf("---------- Successfully logged in user 2\n");
+            printf(("---------- User 2 client session ticket: " + result.authenticationContext->clientSessionTicket + "\n").c_str());
+            authContextUser2 = result.authenticationContext;
+            loginCompletedUser2 = true;
+            loginSuccessfulUser2 = true;
+        },
+        [&](const PlayFab::PlayFabError& error, void* customData)
+        {
+            printf(("========== Failed to log in user 2: " + error.GenerateErrorReport() + "\n").c_str());
+            loginCompletedUser2 = true;
+        });
+
+    // wait for both users to be logged in (we need to get their sessions)
+    while (!(loginCompletedUser1 && loginCompletedUser2))
+    {
+        std::this_thread::yield();
+    }
+
+    if (!loginSuccessfulUser1 || !loginSuccessfulUser2)
+    {
+        return;
+    }
+
+    // ensure that classic credentials (global, statically stored) aren't used:
+    PlayFab::PlayFabSettings::ForgetAllCredentials();
+    PlayFab::PlayFabSettings::clientSessionTicket.empty();
+    PlayFab::PlayFabSettings::entityToken.empty();
+
+    // user 1: make API call "get my profile"
+    profileRequest.authenticationContext = authContextUser1; // <- specify user 1 auth context
+    PlayFab::PlayFabClientAPI::GetPlayerProfile(profileRequest, 
+        [&](const PlayFab::ClientModels::GetPlayerProfileResult& result, void*) 
+        {
+            printf(("========== Successfully read user 1 profile. Player ID: " + result.PlayerProfile->PlayerId + "\n").c_str());
+            profileCompletedUser1 = true;
+        }, 
+        [&](const PlayFab::PlayFabError& error, void*)
+        {
+            printf(("========== Failed to get user 1 profile: " + error.GenerateErrorReport() + "\n").c_str());
+            profileCompletedUser1 = true;
+        });
+
+    // user 2: make API call "get my profile"
+    profileRequest.authenticationContext = authContextUser2; // <- specify user 2 auth context
+    PlayFab::PlayFabClientAPI::GetPlayerProfile(profileRequest,
+        [&](const PlayFab::ClientModels::GetPlayerProfileResult& result, void*)
+        {
+            printf(("========== Successfully read user 2 profile. Player ID: " + result.PlayerProfile->PlayerId + "\n").c_str());
+            profileCompletedUser2 = true;
+        },
+        [&](const PlayFab::PlayFabError& error, void*)
+        {
+            printf(("========== Failed to get user 2 profile: " + error.GenerateErrorReport() + "\n").c_str());
+            profileCompletedUser2 = true;
+        });
+
+    // wait for both users to be get their profiles
+    while (!(profileCompletedUser1 && profileCompletedUser2))
+    {
+        std::this_thread::yield();
+    }
+}
+
 int main()
 {
     // Super hacky short-term functionality PlayFab Test - TODO: Put the regular set of tests into proper Unit Test project
@@ -356,6 +457,9 @@ int main()
     // OneDS lightweight events (emitted individually
     // and processed in a background thread using event pipeline (router, batching, etc))
     TestLightweightEvents();
+
+    // Test multiple users scenario
+    TestMultipleUsers();
 
     return 0;
 }

--- a/targets/XPlatCppSdk/source/test/TestApp/TestApp.cpp
+++ b/targets/XPlatCppSdk/source/test/TestApp/TestApp.cpp
@@ -5,6 +5,7 @@
 #include <memory>
 
 #include "TestAppPch.h"
+#include <playfab/PlayFabApiSettings.h>
 #include <playfab/PlayFabClientApi.h>
 #include <playfab/PlayFabClientInstanceApi.h>
 #include <playfab/PlayFabClientDataModels.h>
@@ -327,7 +328,7 @@ void TestLightweightEvents()
     }
 }
 
-void TestMultipleUsers()
+void TestMultipleUsersWithStaticAPIs()
 {
     printf("\n========== Testing multiple users with static APIs scenario ===========\n");
     PlayFab::ClientModels::LoginWithCustomIDRequest loginRequest;
@@ -427,7 +428,7 @@ void TestMultipleUsers()
     }
 }
 
-void TestMultipleUsersOnMultipleAPIInstances()
+void TestMultipleUsersWithAPIInstances()
 {
     printf("\n========== Testing multiple users with API instances scenario ===========\n");
     PlayFab::ClientModels::LoginWithCustomIDRequest loginRequest;
@@ -439,7 +440,7 @@ void TestMultipleUsersOnMultipleAPIInstances()
     bool profileCompletedUser1 = false;
     bool profileCompletedUser2 = false;
     PlayFab::PlayFabClientInstanceAPI clientApi1;
-    PlayFab::PlayFabClientInstanceAPI clientApi2;
+    PlayFab::PlayFabClientInstanceAPI clientApi2(std::make_shared<PlayFab::PlayFabApiSettings>()); // also test explicit API settings
     loginRequest.CreateAccount = true;
 
     // log in user 1
@@ -556,10 +557,10 @@ int main()
     TestLightweightEvents();
 
     // Test multiple users scenario
-    TestMultipleUsers();
+    TestMultipleUsersWithStaticAPIs();
 
     // Test multiple users on multiple API instances scenario
-    TestMultipleUsersOnMultipleAPIInstances();
+    TestMultipleUsersWithAPIInstances();
 
     return 0;
 }

--- a/targets/XPlatCppSdk/templates/PlayFab_Api.cpp.ejs
+++ b/targets/XPlatCppSdk/templates/PlayFab_Api.cpp.ejs
@@ -34,7 +34,7 @@ namespace PlayFab
         void* customData
     )
     {
-<%- getRequestActions("        ", apiCall) %>
+<%- getRequestActions("        ", apiCall, false) %>
         IPlayFabHttpPlugin& http = *PlayFabPluginManager::GetPlugin<IPlayFabHttpPlugin>(PlayFabPluginContract::PlayFab_Transport);
         const auto requestJson = request.ToJson();
 
@@ -42,7 +42,7 @@ namespace PlayFab
         std::string jsonAsString = writer.write(requestJson);
 
         std::unordered_map<std::string, std::string> headers;
-        headers.emplace(<%- getAuthParams(apiCall) %>);
+        headers.emplace(<%- getAuthParams(apiCall, false) %>);
 
         auto reqContainer = std::unique_ptr<CallRequestContainer>(new CallRequestContainer(
             "<%- apiCall.url %>",
@@ -64,7 +64,7 @@ namespace PlayFab
         <%- apiCall.result %> outResult;
         if (ValidateResult(outResult, container))
         {
-<%- getResultActions("            ", apiCall) %>
+<%- getResultActions("            ", apiCall, false) %>
             const auto internalPtr = container.successCallback.get();
             if (internalPtr != nullptr)
             {

--- a/targets/XPlatCppSdk/templates/PlayFab_Api.cpp.ejs
+++ b/targets/XPlatCppSdk/templates/PlayFab_Api.cpp.ejs
@@ -6,6 +6,7 @@
 #include <playfab/PlayFabPluginManager.h>
 #include <playfab/PlayFabSettings.h>
 #include <playfab/PlayFabError.h>
+#include <memory>
 
 #pragma warning (disable: 4100) // formal parameters are part of a public interface
 

--- a/targets/XPlatCppSdk/templates/PlayFab_InstanceAPI.h.ejs
+++ b/targets/XPlatCppSdk/templates/PlayFab_InstanceAPI.h.ejs
@@ -1,0 +1,60 @@
+#pragma once
+
+<%- getApiDefine(api) %>
+
+#include <playfab/PlayFabCallRequestContainer.h>
+#include <playfab/PlayFabApiSettings.h>
+#include <playfab/PlayFabAuthenticationContext.h>
+#include <playfab/PlayFab<%- api.name %>DataModels.h>
+#include <memory>
+
+namespace PlayFab
+{
+    /// <summary>
+    /// Main interface for PlayFab Sdk, specifically all <%- api.name %> APIs
+    /// </summary>
+    class PlayFab<%- api.name %>InstanceAPI
+    {
+    private:
+        std::shared_ptr<PlayFabApiSettings> settings;
+        std::shared_ptr<PlayFabAuthenticationContext> authContext;
+
+    public:
+        PlayFab<%- api.name %>InstanceAPI();
+        explicit PlayFab<%- api.name %>InstanceAPI(std::shared_ptr<PlayFabApiSettings> apiSettings);
+        explicit PlayFab<%- api.name %>InstanceAPI(std::shared_ptr<PlayFabAuthenticationContext> authenticationContext);
+        PlayFab<%- api.name %>InstanceAPI(std::shared_ptr<PlayFabApiSettings> apiSettings, std::shared_ptr<PlayFabAuthenticationContext> authenticationContext);
+        ~PlayFab<%- api.name %>InstanceAPI();
+        PlayFab<%- api.name %>InstanceAPI(const PlayFab<%- api.name %>InstanceAPI& source) = delete; // disable copy
+        PlayFab<%- api.name %>InstanceAPI(PlayFab<%- api.name %>InstanceAPI&&) = delete; // disable move
+        PlayFab<%- api.name %>InstanceAPI& operator=(const PlayFab<%- api.name %>InstanceAPI& source) = delete; // disable assignment
+        PlayFab<%- api.name %>InstanceAPI& operator=(PlayFab<%- api.name %>InstanceAPI&& other) = delete; // disable move assignment
+
+        std::shared_ptr<PlayFabApiSettings> GetSettings() const;
+        void SetSettings(std::shared_ptr<PlayFabApiSettings> apiSettings);
+        std::shared_ptr<PlayFabAuthenticationContext> GetAuthenticationContext() const;
+        void SetAuthenticationContext(std::shared_ptr<PlayFabAuthenticationContext> authenticationContext);
+        size_t Update();
+        void ForgetAllCredentials();
+<% if (hasClientOptions) { %>
+        // Public, Client-Specific
+        bool IsClientLoggedIn();
+<% } %>
+        // ------------ Generated API calls
+<% for (var callIdx = 0; callIdx < api.calls.length; callIdx++) { var apiCall = api.calls[callIdx];
+%>        void <%- apiCall.name %>(<%- api.name %>Models::<%- apiCall.request %>& request, ProcessApiCallback<<%- api.name %>Models::<%- apiCall.result %>> callback, ErrorCallback errorCallback = nullptr, void* customData = nullptr);
+<% } %>
+        // ------------ Generated result handlers
+<% for (var callIdx = 0; callIdx < api.calls.length; callIdx++) { var apiCall = api.calls[callIdx];
+%>        void On<%- apiCall.name %>Result(int httpCode, std::string result, std::unique_ptr<CallRequestContainerBase> reqContainer);
+<% }
+if (hasClientOptions) { %>
+        // Private, Client-Specific
+        void MultiStepClientLogin(bool needsAttribution);
+<% } %>        bool ValidateResult(PlayFabResultCommon& resultCommon, CallRequestContainer& container);
+    private:
+        std::shared_ptr<PlayFabAuthenticationContext> GetOrCreateAuthenticationContext();
+    };
+}
+
+#endif

--- a/targets/XPlatCppSdk/templates/PlayFab_InstanceApi.cpp.ejs
+++ b/targets/XPlatCppSdk/templates/PlayFab_InstanceApi.cpp.ejs
@@ -106,7 +106,8 @@ namespace PlayFab
             headers,
             jsonAsString,
             std::bind(&PlayFab<%- api.name %>InstanceAPI::On<%- apiCall.name %>Result, this, std::placeholders::_1, std::placeholders::_2, std::placeholders::_3),
-            customData));
+            customData,
+            this->settings));
 
         reqContainer->successCallback = std::shared_ptr<void>((callback == nullptr) ? nullptr : new ProcessApiCallback<<%- apiCall.result %>>(callback));
         reqContainer->errorCallback = errorCallback;

--- a/targets/XPlatCppSdk/templates/PlayFab_InstanceApi.cpp.ejs
+++ b/targets/XPlatCppSdk/templates/PlayFab_InstanceApi.cpp.ejs
@@ -1,0 +1,192 @@
+#include <stdafx.h>
+
+<%- getApiDefine(api) %>
+
+#include <playfab/PlayFab<%- api.name %>InstanceApi.h>
+#include <playfab/PlayFabPluginManager.h>
+#include <playfab/PlayFabSettings.h>
+#include <playfab/PlayFabError.h>
+#include <memory>
+
+#pragma warning (disable: 4100) // formal parameters are part of a public interface
+
+namespace PlayFab
+{
+    using namespace <%- api.name %>Models;
+
+    PlayFab<%- api.name %>InstanceAPI::PlayFab<%- api.name %>InstanceAPI()
+    {
+    }
+
+    PlayFab<%- api.name %>InstanceAPI::PlayFab<%- api.name %>InstanceAPI(std::shared_ptr<PlayFabApiSettings> apiSettings)
+    {
+        this->settings = std::move(apiSettings);
+    }
+
+    PlayFab<%- api.name %>InstanceAPI::PlayFab<%- api.name %>InstanceAPI(std::shared_ptr<PlayFabAuthenticationContext> authenticationContext)
+    {
+        this->authContext = std::move(authenticationContext);
+    }
+
+    PlayFab<%- api.name %>InstanceAPI::PlayFab<%- api.name %>InstanceAPI(std::shared_ptr<PlayFabApiSettings> apiSettings, std::shared_ptr<PlayFabAuthenticationContext> authenticationContext)
+    {
+        this->settings = std::move(apiSettings);
+        this->authContext = std::move(authenticationContext);
+    }
+
+    PlayFab<%- api.name %>InstanceAPI::~PlayFab<%- api.name %>InstanceAPI()
+    {
+    }
+
+    std::shared_ptr<PlayFabApiSettings> PlayFab<%- api.name %>InstanceAPI::GetSettings() const
+    {
+        return this->settings;
+    }
+
+    void PlayFab<%- api.name %>InstanceAPI::SetSettings(std::shared_ptr<PlayFabApiSettings> apiSettings)
+    {
+        this->settings = std::move(apiSettings);
+    }
+
+    std::shared_ptr<PlayFabAuthenticationContext> PlayFab<%- api.name %>InstanceAPI::GetAuthenticationContext() const
+    {
+        return this->authContext;
+    }
+
+    void PlayFab<%- api.name %>InstanceAPI::SetAuthenticationContext(std::shared_ptr<PlayFabAuthenticationContext> authenticationContext)
+    {
+        this->authContext = std::move(authenticationContext);
+    }
+
+    std::shared_ptr<PlayFabAuthenticationContext> PlayFab<%- api.name %>InstanceAPI::GetOrCreateAuthenticationContext()
+    {
+        if (this->authContext == nullptr)
+        {
+            this->authContext = std::make_shared<PlayFabAuthenticationContext>();
+        }
+        
+        return this->authContext;
+    }
+
+    size_t PlayFab<%- api.name %>InstanceAPI::Update()
+    {
+        IPlayFabHttpPlugin& http = *PlayFabPluginManager::GetPlugin<IPlayFabHttpPlugin>(PlayFabPluginContract::PlayFab_Transport);
+        return http.Update();
+    }
+
+    void PlayFab<%- api.name %>InstanceAPI::ForgetAllCredentials()
+    {
+        if (this->authContext == nullptr)
+            return;
+
+        this->authContext->ForgetAllCredentials();
+    }
+
+    // PlayFab<%- api.name %> instance APIs
+<% for (var callIdx = 0; callIdx < api.calls.length; callIdx++) { var apiCall = api.calls[callIdx]; %>
+    void PlayFab<%- api.name %>InstanceAPI::<%- apiCall.name %>(
+        <%- apiCall.request %>& request,
+        ProcessApiCallback<<%- apiCall.result %>> callback,
+        ErrorCallback errorCallback,
+        void* customData
+    )
+    {
+<%- getRequestActions("        ", apiCall, true) %>
+        IPlayFabHttpPlugin& http = *PlayFabPluginManager::GetPlugin<IPlayFabHttpPlugin>(PlayFabPluginContract::PlayFab_Transport);
+        const auto requestJson = request.ToJson();
+
+        Json::FastWriter writer;
+        std::string jsonAsString = writer.write(requestJson);
+
+        std::unordered_map<std::string, std::string> headers;
+        headers.emplace(<%- getAuthParams(apiCall, true) %>);
+
+        auto reqContainer = std::unique_ptr<CallRequestContainer>(new CallRequestContainer(
+            "<%- apiCall.url %>",
+            headers,
+            jsonAsString,
+            std::bind(&PlayFab<%- api.name %>InstanceAPI::On<%- apiCall.name %>Result, this, std::placeholders::_1, std::placeholders::_2, std::placeholders::_3),
+            customData));
+
+        reqContainer->successCallback = std::shared_ptr<void>((callback == nullptr) ? nullptr : new ProcessApiCallback<<%- apiCall.result %>>(callback));
+        reqContainer->errorCallback = errorCallback;
+
+        http.MakePostRequest(std::unique_ptr<CallRequestContainerBase>(static_cast<CallRequestContainerBase*>(reqContainer.release())));
+    }
+
+    void PlayFab<%- api.name %>InstanceAPI::On<%- apiCall.name %>Result(int httpCode, std::string result, std::unique_ptr<CallRequestContainerBase> reqContainer)
+    {
+        CallRequestContainer& container = static_cast<CallRequestContainer&>(*reqContainer);
+
+        <%- apiCall.result %> outResult;
+        if (ValidateResult(outResult, container))
+        {
+<%- getResultActions("            ", apiCall, true) %>
+            const auto internalPtr = container.successCallback.get();
+            if (internalPtr != nullptr)
+            {
+                const auto callback = (*static_cast<ProcessApiCallback<<%- apiCall.result %>> *>(internalPtr));
+                callback(outResult, container.GetCustomData());
+            }
+        }
+    }
+<% } %><% if (hasClientOptions) { %>
+    // Private PlayFabClientInstanceAPI specific
+    bool PlayFabClientInstanceAPI::IsClientLoggedIn()
+    {
+        return !this->GetOrCreateAuthenticationContext()->clientSessionTicket.empty();
+    }
+
+    void PlayFabClientInstanceAPI::MultiStepClientLogin(bool needsAttribution)
+    {
+        auto apiSettings = this->GetSettings();
+        if (apiSettings == nullptr)
+        {
+            if (needsAttribution && !PlayFabSettings::disableAdvertising && PlayFabSettings::advertisingIdType.length() > 0 && PlayFabSettings::advertisingIdValue.length() > 0)
+            {
+                AttributeInstallRequest request;
+                if (PlayFabSettings::advertisingIdType == PlayFabSettings::AD_TYPE_IDFA)
+                    request.Idfa = PlayFabSettings::advertisingIdValue;
+                else if (PlayFabSettings::advertisingIdType == PlayFabSettings::AD_TYPE_ANDROID_ID)
+                    request.Adid = PlayFabSettings::advertisingIdValue;
+                else
+                    return;
+                AttributeInstall(request, nullptr, nullptr);
+            }
+        }
+        else
+        {
+            if (needsAttribution && !apiSettings->disableAdvertising && apiSettings->advertisingIdType.length() > 0 && apiSettings->advertisingIdValue.length() > 0)
+            {
+                AttributeInstallRequest request;
+                if (apiSettings->advertisingIdType == PlayFabSettings::AD_TYPE_IDFA)
+                    request.Idfa = apiSettings->advertisingIdValue;
+                else if (apiSettings->advertisingIdType == PlayFabSettings::AD_TYPE_ANDROID_ID)
+                    request.Adid = apiSettings->advertisingIdValue;
+                else
+                    return;
+                AttributeInstall(request, nullptr, nullptr);
+            }
+        }
+    }
+<% } %>
+    bool PlayFab<%- api.name %>InstanceAPI::ValidateResult(PlayFabResultCommon& resultCommon, CallRequestContainer& container)
+    {
+        if (container.errorWrapper.HttpCode == 200)
+        {
+            resultCommon.FromJson(container.errorWrapper.Data);
+            resultCommon.Request = container.errorWrapper.Request;
+            return true;
+        }
+        else // Process the error case
+        {
+            if (PlayFabSettings::globalErrorHandler != nullptr)
+                PlayFabSettings::globalErrorHandler(container.errorWrapper, container.GetCustomData());
+            if (container.errorCallback != nullptr)
+                container.errorCallback(container.errorWrapper, container.GetCustomData());
+            return false;
+        }
+    }
+}
+
+#endif


### PR DESCRIPTION
- Implemented instance-able API classes
- Added a functional E2E test to the Test app
- Verified on Windows and Linux
- Fixed a bug in makefile (Linux) where API classes were hardcoded before. The references are properly generated from API specs now