### PR TITLE
Remove the last 32 bytes of GC allocation from PluginManager.GetPlugin()

### DIFF
--- a/targets/unity-v2/source/Shared/Public/PluginContractKey.cs
+++ b/targets/unity-v2/source/Shared/Public/PluginContractKey.cs
@@ -1,11 +1,8 @@
-using System;
 using System.Collections.Generic;
-using PlayFab.Internal;
-using PlayFab.Json;
 
 namespace PlayFab
 {
-    public class PluginContractKey
+    public struct PluginContractKey
     {
         public PluginContract _pluginContract;
         public string _pluginName;


### PR DESCRIPTION
Strictly speaking, the way this is accomplished is by making these objects "new" onto the stack instead of the heap, by making them structs.
We could do crazy complicated logic to avoid the "new" in GetPluginInternal, but this is much easier, and won't hurt performance as long as the struct is small.