### PR TITLE
Fixing unity 2018 builds

### DIFF
--- a/targets/unity-v2/Testing/Editor/PlayFabPackager.cs
+++ b/targets/unity-v2/Testing/Editor/PlayFabPackager.cs
@@ -141,7 +141,7 @@ namespace PlayFab.Internal
             var androidPackage = Path.Combine(GetBuildPath(), "PlayFabAndroid.apk");
             MkDir(GetBuildPath());
             BuildPipeline.BuildPlayer(TestScenes, androidPackage, BuildTarget.Android, BuildOptions.None);
-            if (Directory.GetFiles(androidPackage).Length == 0)
+            if (!File.Exists(androidPackage))
                 throw new Exception("Target file did not build: " + androidPackage);
         }
 
@@ -149,14 +149,17 @@ namespace PlayFab.Internal
         public static void MakeIPhoneBuild()
         {
             Setup();
-            // SetScriptingBackend(ScriptingImplementation.IL2CPP, AppleBuildTarget, AppleBuildTargetGroup); // Ideally we should be testing both at some point, but ...
+#if UNITY_2018_1_OR_NEWER
+            SetScriptingBackend(ScriptingImplementation.IL2CPP, AppleBuildTarget, AppleBuildTargetGroup); // Ideally we should be testing both at some point, but ...
+#else
             SetScriptingBackend(ScriptingImplementation.Mono2x, AppleBuildTarget, AppleBuildTargetGroup); // Mono2x is traditionally the one with issues, and it's a lot faster to build/test
+#endif
             SetIdentifier(AppleBuildTargetGroup, "com.PlayFab.PlayFabTest");
             var iosPath = Path.Combine(GetBuildPath(), "PlayFabIOS");
             MkDir(GetBuildPath());
             MkDir(iosPath);
             BuildPipeline.BuildPlayer(TestScenes, iosPath, AppleBuildTarget, BuildOptions.None);
-            if (Directory.GetFiles(iosPath).Length == 0)
+            if (!File.Exists(iosPath))
                 throw new Exception("Target directory is empty: " + iosPath + ", " + string.Join(",", Directory.GetFiles(iosPath)));
         }
 
@@ -176,7 +179,7 @@ namespace PlayFab.Internal
             MkDir(GetBuildPath());
             MkDir(wp8Path);
             BuildPipeline.BuildPlayer(TestScenes, wp8Path, WsaBuildTarget, BuildOptions.None);
-            if (Directory.GetFiles(wp8Path).Length == 0)
+            if (!File.Exists(wp8Path))
                 throw new Exception("Target directory is empty: " + wp8Path + ", " + string.Join(",", Directory.GetFiles(wp8Path)));
         }
 


### PR DESCRIPTION
iOS doesn't have the option for Mono in Unity 2018.3, so it will fail to load assemblies and not outputting any files which failed the build process.

Removes all Directory Length checks in favor of File.Exists