### PR TITLE
Fix UE4 ExampleProject crash in standalone build by lazy-loading data

### DIFF
--- a/targets/UnrealMarketplacePlugin/examplesource/ExampleProject/Source/ExampleProject/PlayFabApiTests.h
+++ b/targets/UnrealMarketplacePlugin/examplesource/ExampleProject/Source/ExampleProject/PlayFabApiTests.h
@@ -431,8 +431,6 @@ protected:
 
     bool InvalidLogin() const
     {
-        if (!testTitleDataStorage.loaded)
-            return false;
         ADD_LATENT_AUTOMATION_COMMAND(PlayFabApiTest_0LoginWithEmail(testTitleDataStorage.userEmail, INVALID_PASSWORD));
 
         return true;


### PR DESCRIPTION
Move UE4 C++ SDK test setup (LoadTitleData) to lazy-load from first test.  Previously, it was called from the constructor, however the test class (as per UE4 convention) must have a static instance.  In standalone builds, it was constructing before the log system was ready, causing a crash when the file-loading method attempted to log.  `FAutomationTestBase` does not have a "setup" override, and `GetTests` which is the closest thing to a setup function is declared `const`, so the remaining solution was to set up in `RunTest`.