### PR TITLE
fix for iOS packaging

### DIFF
--- a/targets/unity-v2/Testing/Editor/PlayFabPackager.cs
+++ b/targets/unity-v2/Testing/Editor/PlayFabPackager.cs
@@ -159,7 +159,7 @@ namespace PlayFab.Internal
             MkDir(GetBuildPath());
             MkDir(iosPath);
             BuildPipeline.BuildPlayer(TestScenes, iosPath, AppleBuildTarget, BuildOptions.None);
-            if (!File.Exists(iosPath))
+            if (Directory.GetFiles(iosPath).Length == 0)
                 throw new Exception("Target directory is empty: " + iosPath + ", " + string.Join(",", Directory.GetFiles(iosPath)));
         }
 


### PR DESCRIPTION
iOS WAS completing the build the file (which was a directory in this case) triggers false for Existence (wierd that it behaves differently for iOS vs Android).