### PR TITLE
Fix logic typo in call to OnPlayFabResponse

### DIFF
--- a/targets/UnrealMarketplacePlugin/templates/PlayFab/PlayFab_API.cpp.ejs
+++ b/targets/UnrealMarketplacePlugin/templates/PlayFab/PlayFab_API.cpp.ejs
@@ -259,7 +259,7 @@ void UPlayFab<%- api.name %>API::OnProcessRequestComplete(FHttpRequestPtr Reques
         pfSettings->setEntityToken(myResponse.responseData->GetObjectField("data")->GetStringField("EntityToken"));
 
     // Broadcast the result event
-    OnPlayFabResponse.Broadcast(myResponse, mCustomData, myResponse.responseError.hasError);
+    OnPlayFabResponse.Broadcast(myResponse, mCustomData, !myResponse.responseError.hasError);
     pfSettings->ModifyPendingCallCount(-1);
 }
 


### PR DESCRIPTION
`OnPlayFabResponse`, a multicast delegate, has a third parameter `bool successful`.  One usage of the delegate calls it passing `hasError` to `successful`.  This is clearly a typo.  This change has no effect on the API, as the `successful` parameter is not actually used internally, however it is accessible to end-users.