### PR TITLE
Replace remaining instances of X-Authentication with X-Authorization

### DIFF
--- a/targets/PhpSdk/make.js
+++ b/targets/PhpSdk/make.js
@@ -50,7 +50,7 @@ function getCurlAuthParams(apiCall) {
     if (apiCall.auth === "EntityToken")
         return "\"X-EntityToken\", $entityToken";
     if (apiCall.auth === "SessionTicket")
-        return "\"X-Authentication\", $clientSessionTicket";
+        return "\"X-Authorization\", $clientSessionTicket";
     if (apiCall.auth === "SecretKey")
         return "\"X-SecretKey\", $developerSecreteKey";
     return "null, null";
@@ -59,7 +59,7 @@ function getCurlAuthParams(apiCall) {
 function getRequestActions(tabbing, apiCall) {
     if (apiCall.url === "/Authentication/GetEntityToken")
         return tabbing + "if (!is_null($entityToken)) { $authKey = \"X-EntityToken\"; $authValue = $entityToken; }\n"
-            + tabbing + "elseif (!is_null($clientSessionTicket)) { $authKey = \"X-Authentication\"; $authValue = $clientSessionTicket; }\n"
+            + tabbing + "elseif (!is_null($clientSessionTicket)) { $authKey = \"X-Authorization\"; $authValue = $clientSessionTicket; }\n"
             + tabbing + "elseif (!is_null($developerSecreteKey)) { $authKey = \"X-SecretKey\"; $authValue = $developerSecreteKey; }\n";
     if (apiCall.result === "LoginResult" || apiCall.request === "RegisterPlayFabUserRequest")
         return tabbing + "if (!isset($titleId)) $titleId = PlayFabSettings::$titleId;\n"

--- a/targets/UnrealMarketplacePlugin/templates/PlayFab/PlayFab_API.cpp.ejs
+++ b/targets/UnrealMarketplacePlugin/templates/PlayFab/PlayFab_API.cpp.ejs
@@ -281,7 +281,7 @@ void UPlayFab<%- api.name %>API::Activate()
     if (useEntityToken && entityToken.Len() > 0)
         HttpRequest->SetHeader(TEXT("X-EntityToken"), entityToken);
     else if (useSessionTicket && clientToken.Len() > 0)
-        HttpRequest->SetHeader(TEXT("X-Authentication"), clientToken);
+        HttpRequest->SetHeader(TEXT("X-Authorization"), clientToken);
     else if (useSecretKey && devSecretKey.Len() > 0)
         HttpRequest->SetHeader(TEXT("X-SecretKey"), devSecretKey);
     HttpRequest->SetHeader(TEXT("Content-Type"), TEXT("application/json"));

--- a/targets/postman/make.js
+++ b/targets/postman/make.js
@@ -61,9 +61,9 @@ function getUrl(apiCall) {
 
 function getPostmanHeader(apiCall) {
     if (apiCall.url === "/Authentication/GetEntityToken")
-        return "X-PlayFabSDK: PostmanCollection-" + sdkGlobals.sdkVersion + "\\nContent-Type: application/json\\nX-Authentication: {{SessionTicket}}\\nX-SecretKey: {{SecretKey}}\\n";
+        return "X-PlayFabSDK: PostmanCollection-" + sdkGlobals.sdkVersion + "\\nContent-Type: application/json\\nX-Authorization: {{SessionTicket}}\\nX-SecretKey: {{SecretKey}}\\n";
     if (apiCall.auth === "SessionTicket")
-        return "X-PlayFabSDK: PostmanCollection-" + sdkGlobals.sdkVersion + "\\nContent-Type: application/json\\nX-Authentication: {{SessionTicket}}\\n";
+        return "X-PlayFabSDK: PostmanCollection-" + sdkGlobals.sdkVersion + "\\nContent-Type: application/json\\nX-Authorization: {{SessionTicket}}\\n";
     else if (apiCall.auth === "SecretKey")
         return "X-PlayFabSDK: PostmanCollection-" + sdkGlobals.sdkVersion + "\\nContent-Type: application/json\\nX-SecretKey: {{SecretKey}}\\n";
     else if (apiCall.auth === "EntityToken")


### PR DESCRIPTION
A few of the APIs use the deprecated `X-Authentication` header, which has been replaced with `X-Authorization`.  While the PlayFab server still technically supports `X-Authentication`, it should be phased out to reduce maintenance burden.