### PR TITLE
(MS #2-7) Replace Nullable equality checks to work around a Unity Net 4.x IL2CPP bug

### DIFF
--- a/targets/unity-v2/Testing/Tests/Shared/Uunit/UUnitTestContext.cs
+++ b/targets/unity-v2/Testing/Tests/Shared/Uunit/UUnitTestContext.cs
@@ -117,7 +117,7 @@ namespace PlayFab.UUnit
 
         public void SbyteEquals(sbyte? wanted, sbyte? got, string message = null)
         {
-            if (wanted == got)
+            if (NullableEquals(wanted, got))
                 return;
 
             if (string.IsNullOrEmpty(message))
@@ -127,7 +127,7 @@ namespace PlayFab.UUnit
 
         public void ByteEquals(byte? wanted, byte? got, string message = null)
         {
-            if (wanted == got)
+            if (NullableEquals(wanted, got))
                 return;
 
             if (string.IsNullOrEmpty(message))
@@ -137,7 +137,7 @@ namespace PlayFab.UUnit
 
         public void ShortEquals(short? wanted, short? got, string message = null)
         {
-            if (wanted == got)
+            if (NullableEquals(wanted, got))
                 return;
 
             if (string.IsNullOrEmpty(message))
@@ -147,7 +147,7 @@ namespace PlayFab.UUnit
 
         public void UshortEquals(ushort? wanted, ushort? got, string message = null)
         {
-            if (wanted == got)
+            if (NullableEquals(wanted, got))
                 return;
 
             if (string.IsNullOrEmpty(message))
@@ -157,7 +157,7 @@ namespace PlayFab.UUnit
 
         public void IntEquals(int? wanted, int? got, string message = null)
         {
-            if (wanted == got)
+            if (NullableEquals(wanted, got))
                 return;
 
             if (string.IsNullOrEmpty(message))
@@ -167,7 +167,7 @@ namespace PlayFab.UUnit
 
         public void UintEquals(uint? wanted, uint? got, string message = null)
         {
-            if (wanted == got)
+            if (NullableEquals(wanted, got))
                 return;
 
             if (string.IsNullOrEmpty(message))
@@ -177,7 +177,7 @@ namespace PlayFab.UUnit
 
         public void LongEquals(long? wanted, long? got, string message = null)
         {
-            if (wanted == got)
+            if (NullableEquals(wanted, got))
                 return;
 
             if (string.IsNullOrEmpty(message))
@@ -187,7 +187,7 @@ namespace PlayFab.UUnit
 
         public void ULongEquals(ulong? wanted, ulong? got, string message = null)
         {
-            if (wanted == got)
+            if (NullableEquals(wanted, got))
                 return;
 
             if (string.IsNullOrEmpty(message))
@@ -197,9 +197,9 @@ namespace PlayFab.UUnit
 
         public void FloatEquals(float? wanted, float? got, float precision = DefaultFloatPrecision, string message = null)
         {
-            if (wanted == null && got == null)
+            if (!wanted.HasValue && !got.HasValue)
                 return;
-            if (wanted != null && got != null && Math.Abs(wanted.Value - got.Value) < precision)
+            if (wanted.HasValue && got.HasValue && Math.Abs(wanted.Value - got.Value) < precision)
                 return;
 
             if (string.IsNullOrEmpty(message))
@@ -209,9 +209,9 @@ namespace PlayFab.UUnit
 
         public void DoubleEquals(double? wanted, double? got, double precision = DefaultDoublePrecision, string message = null)
         {
-            if (wanted == null && got == null)
+            if (!wanted.HasValue && !got.HasValue)
                 return;
-            if (wanted != null && got != null && Math.Abs(wanted.Value - got.Value) < precision)
+            if (wanted.HasValue && got.HasValue && Math.Abs(wanted.Value - got.Value) < precision)
                 return;
 
             if (string.IsNullOrEmpty(message))
@@ -221,9 +221,9 @@ namespace PlayFab.UUnit
 
         public void DateTimeEquals(DateTime? wanted, DateTime? got, TimeSpan precision, string message = null)
         {
-            if (wanted == null && got == null)
+            if (!wanted.HasValue && !got.HasValue)
                 return;
-            if (wanted != null && got != null
+            if (wanted.HasValue && got.HasValue
                 && wanted + precision > got
                 && got + precision > wanted)
                 return;
@@ -263,6 +263,16 @@ namespace PlayFab.UUnit
                 count++;
                 ObjEquals(wEnum.Current, gEnum.Current, "Element at " + count + ": " + message);
             }
+        }
+
+        private static bool NullableEquals<T>(T? left, T? right) where T : struct
+        {
+            // If both have a value, return whether the values match.
+            if (left.HasValue && right.HasValue)
+                return left.Value.Equals(right.Value);
+
+            // If neither has a value, return true. If only one does, return false.
+            return !left.HasValue && !right.HasValue;
         }
     }
 }

--- a/targets/unity-v2/Testing/Tests/Utility/JsonUnitTests.cs
+++ b/targets/unity-v2/Testing/Tests/Utility/JsonUnitTests.cs
@@ -322,12 +322,12 @@ namespace PlayFab.UUnit
                     continue;
                 }
 
-                if (testObj.BoolField != actualObj.BoolField) failures.Add("Nullable bool field does not serialize properly: " + testObj.BoolField + ", from " + actualJson);
-                if (testObj.BoolProperty != actualObj.BoolProperty) failures.Add("Nullable bool property does not serialize properly: " + testObj.BoolProperty + ", from " + actualJson);
-                if (testObj.IntField != actualObj.IntField) failures.Add("Nullable integer field does not serialize properly: " + testObj.IntField + ", from " + actualJson);
-                if (testObj.IntProperty != actualObj.IntProperty) failures.Add("Nullable integer property does not serialize properly: " + testObj.IntProperty + ", from " + actualJson);
-                if (testObj.EnumField != actualObj.EnumField) failures.Add("Nullable enum field does not serialize properly: " + testObj.EnumField + ", from " + actualJson);
-                if (testObj.EnumProperty != actualObj.EnumProperty) failures.Add("Nullable enum property does not serialize properly: " + testObj.EnumProperty + ", from " + actualJson);
+                if (NullableNotEquals(testObj.BoolField,actualObj.BoolField)) failures.Add("Nullable bool field does not serialize properly: " + testObj.BoolField + ", from " + actualJson);
+                if (NullableNotEquals(testObj.BoolProperty, actualObj.BoolProperty)) failures.Add("Nullable bool property does not serialize properly: " + testObj.BoolProperty + ", from " + actualJson);
+                if (NullableNotEquals(testObj.IntField, actualObj.IntField)) failures.Add("Nullable integer field does not serialize properly: " + testObj.IntField + ", from " + actualJson);
+                if (NullableNotEquals(testObj.IntProperty, actualObj.IntProperty)) failures.Add("Nullable integer property does not serialize properly: " + testObj.IntProperty + ", from " + actualJson);
+                if (NullableNotEquals(testObj.EnumField, actualObj.EnumField)) failures.Add("Nullable enum field does not serialize properly: " + testObj.EnumField + ", from " + actualJson);
+                if (NullableNotEquals(testObj.EnumProperty, actualObj.EnumProperty)) failures.Add("Nullable enum property does not serialize properly: " + testObj.EnumProperty + ", from " + actualJson);
 
                 if (testObj.TimeField.HasValue != actualObj.TimeField.HasValue)
                     failures.Add("Nullable struct field does not serialize properly: " + testObj.TimeField + ", from " + actualJson);
@@ -371,6 +371,21 @@ namespace PlayFab.UUnit
             testContext.StringEquals(expectedJson, actualJson, actualJson);
 
             testContext.EndTest(UUnitFinishState.PASSED, null);
+        }
+
+        private static bool NullableEquals<T>(T? left, T? right) where T : struct
+        {
+            // If both have a value, return whether the values match.
+            if (left.HasValue && right.HasValue)
+                return left.Value.Equals(right.Value);
+
+            // If neither has a value, return true. If only one does, return false.
+            return !left.HasValue && !right.HasValue;
+        }
+
+        private static bool NullableNotEquals<T>(T? left, T? right) where T : struct
+        {
+            return !NullableEquals(left, right);
         }
     }
 }


### PR DESCRIPTION
https://github.com/PlayFab/UnityBeta/pull/6

IL2CPP code generated for the .NET 4.x runtime has incorrect behavior when  testing equality
between two Nullable auto-properties, when the Set method is called via reflection. An equality
operator substitute method is introduced that checks whether the objects have a value before
testing their values.

Related tests have been updated to use the new equality test.