### PR TITLE
Milestone 26b: Package testTitleData.json in UE4 for easy inclusion in mobile builds

### DIFF
--- a/targets/UnrealMarketplacePlugin/examplesource/ExampleProject/Config/DefaultGame.ini
+++ b/targets/UnrealMarketplacePlugin/examplesource/ExampleProject/Config/DefaultGame.ini
@@ -1,2 +1,5 @@
 [/Script/EngineSettings.GeneralProjectSettings]
 ProjectID=F986E4664AE32897B5A743A39C984F69
+
+[/Script/UnrealEd.ProjectPackagingSettings]
++DirectoriesToAlwaysStageAsUFS=(Path="JSON")

--- a/targets/UnrealMarketplacePlugin/examplesource/ExampleProject/Plugins/PlayFab/Source/PlayFab/Classes/PfTestActor.h.ejs
+++ b/targets/UnrealMarketplacePlugin/examplesource/ExampleProject/Plugins/PlayFab/Source/PlayFab/Classes/PfTestActor.h.ejs
@@ -116,7 +116,7 @@ public:
         FString _outputSummary;
     // A bunch of constants: load these from testTitleData.json
     UPROPERTY()
-        FString TEST_TITLE_DATA_LOC = "testTitleData.json";
+        FString TEST_TITLE_DATA_LOC = FPaths::ProjectContentDir() + TEXT("JSON/testTitleData.json");
     UPROPERTY()
         FString userEmail;
     UPROPERTY()

--- a/targets/UnrealMarketplacePlugin/examplesource/ExampleProject/Source/ExampleProject/PlayFabApiTests.h
+++ b/targets/UnrealMarketplacePlugin/examplesource/ExampleProject/Source/ExampleProject/PlayFabApiTests.h
@@ -392,7 +392,7 @@ protected:
         bool success = true;
 
         FString jsonInput;
-        FString filename = TEXT("testTitleData.json");
+        FString filename = FPaths::ProjectContentDir() + TEXT("JSON/testTitleData.json");
 
         // Prefer to load path from environment variable, if present
 #if PLATFORM_WINDOWS


### PR DESCRIPTION
If environment variable PF_TEST_TITLE_DATA_JSON is defined, copy it to a Content/JSON within every UE4 ExampleProject.  Configure UE4 to include Content/JSON in asset packaging.  This allows access to the
file from a mobile build, without requiring the developer to manually copy testTitleData.json onto the mobile device, which is particularly difficult on iOS.  This is also potentially useful on desktop, but moreso on target platforms where apps are tightly sandboxed.

This utilizes UE4's file library that unifies packaged-asset-retrieval and raw-filesystem-retrieval to the same API.  If the file is not available at generation time, and thus does not become available in the correct packaged location, the environment variable still kicks in at runtime and can retrieve directly from the filesystem.