### PR TITLE
Milestone 28: Added multi-user authenticationContext support in JavaScript

### DIFF
--- a/targets/javascript/make.js
+++ b/targets/javascript/make.js
@@ -97,12 +97,21 @@ function hasResultActions(apiCall) {
 function getResultActions(tabbing, apiCall) {
     if (apiCall.result === "LoginResult")
         return tabbing + "if (result != null) {\n"
-            + tabbing + "       if(result.data.SessionTicket != null) {\n"
-            + tabbing + "           PlayFab._internalSettings.sessionTicket = result.data.SessionTicket;\n"
-            + tabbing + "       }\n"
-            + tabbing + "       if (result.data.EntityToken != null) {\n"
-            + tabbing + "           PlayFab._internalSettings.entityToken = result.data.EntityToken.EntityToken;\n"
-            + tabbing + "       }\n"
+            + tabbing + "   // Capture the playFabId, and make sure the authenticationContext exists with the ID in question\n"
+            + tabbing + "   var playFabId = result.data.PlayFabId;\n"
+            + tabbing + "\n"
+            + tabbing + "   if(PlayFab._internalSettings.authenticationContext.hasOwnProperty(playFabId) == false) {\n"
+            + tabbing + "       var playFabId = result.data.PlayFabId;\n"
+            + tabbing + "   }\n"
+            + tabbing + "\n"
+            + tabbing + "   if(result.data.SessionTicket != null) {\n"
+            + tabbing + "       PlayFab._internalSettings.sessionTicket = result.data.SessionTicket;\n"
+            + tabbing + "       PlayFab._internalSettings.authenticationContext[playFabId]['sessionTicket'] = result.data.SessionTicket;\n"
+            + tabbing + "   }\n"
+            + tabbing + "   if (result.data.EntityToken != null) {\n"
+            + tabbing + "       PlayFab._internalSettings.entityToken = result.data.EntityToken.EntityToken;\n"
+            + tabbing + "       PlayFab._internalSettings.authenticationContext[playFabId]['entityToken'] = result.data.EntityToken.EntityToken;\n"
+            + tabbing + "   }\n"
             + tabbing + "    PlayFab.ClientApi._MultiStepClientLogin(result.data.SettingsForUser.NeedsAttribution);\n"
             + tabbing + "}";
     if (apiCall.result === "RegisterPlayFabUserResult")
@@ -127,11 +136,11 @@ function getAuthParams(apiCall) {
     if (apiCall.url === "/Authentication/GetEntityToken")
         return "authKey, authValue";
     if (apiCall.auth === "EntityToken")
-        return "\"X-EntityToken\", PlayFab._internalSettings.entityToken";
+        return "\"X-EntityToken\", PlayFab._internalSettings.GetAuthValue(request, \"X-EntityToken\")";
     if (apiCall.auth === "SecretKey")
-        return "\"X-SecretKey\", PlayFab.settings.developerSecretKey";
+        return "\"X-SecretKey\", PlayFab._internalSettings.GetAuthValue(request, \"X-SecretKey\")";
     if (apiCall.auth === "SessionTicket")
-        return "\"X-Authorization\", PlayFab._internalSettings.sessionTicket";
+        return "\"X-Authorization\", PlayFab._internalSettings.GetAuthValue(request, \"X-Authorization\")";
     return "null, null";
 }
 

--- a/targets/javascript/templates/PlayFab_Api.js.ejs
+++ b/targets/javascript/templates/PlayFab_Api.js.ejs
@@ -59,7 +59,7 @@ if(!PlayFab._internalSettings) {
             }
         },
 
-        ExecuteRequest: function (url, request, authkey, authValue, callback, customData, extraHeaders) {
+        ExecuteRequest: async function (url, request, authkey, authValue, callback, customData, extraHeaders) {
             if (callback != null && typeof (callback) != "function")
                 throw "Callback must be null of a function";
 
@@ -151,10 +151,44 @@ if(!PlayFab._internalSettings) {
                 callback(null, result);
             }
 
-            xhr.send(requestBody);
+            function sendRequest(xhr) {
+                return new Promise(resolve => {
+                    xhr.send(requestBody);
+                });
+            }
+            var resolvedPromise = await sendRequest(xhr);
+            return resolvedPromise;
         }
     }
 }
+
+if (typeof PlayFab._internalSettings.authenticationContext == "undefined") {
+    // Initialize the authenticationContext if it doesnt exist
+    // We could use a ternary operator here, but length of the line of code would effect readability
+    PlayFab._internalSettings.authenticationContext = {};
+}
+
+PlayFab._internalSettings.GetAuthValue = function (request, authKey) {
+    // Use the most-recently saved sessionTicket, unless one was provided in the request via the PlayFabId property
+    var authInfoMap = {
+        'X-EntityToken': 'entityToken',
+        'X-Authorization': 'sessionTicket',
+        'X-SecretKey': 'developerSecretKey'
+    };
+    var authAttr = authInfoMap[authKey];
+    var sessionTicket = PlayFab._internalSettings.sessionTicket;
+    var authValue = authAttr ==  'developerSecretKey' ? PlayFab.settings[authAttr]: PlayFab._internalSettings[authAttr];
+    if (request.hasOwnProperty('PlayFabId')) {
+        var playFabId = request.PlayFabId;
+        // Make sure that the authenticationContext exists before attempting to access it
+        if (PlayFab._internalSettings.authenticationContext.hasOwnProperty(playFabId)) {
+            if (PlayFab._internalSettings.authenticationContext[playFabId].hasOwnProperty(authAttr)) {
+                authValue = PlayFab._internalSettings.authenticationContext[playFabId][authAttr];
+            }
+        }
+    }
+    return authValue;
+};
 
 PlayFab.buildIdentifier = "<%- buildIdentifier %>";
 PlayFab.sdkVersion = "<%- sdkVersion %>";
@@ -176,6 +210,7 @@ PlayFab.<%- api.name %>Api = {
 <% } %>    ForgetAllCredentials: function () {
         PlayFab._internalSettings.sessionTicket = null;
         PlayFab._internalSettings.entityToken = null;
+        PlayFab._internalSettings.authenticationContext = {};
     },
 <% for(var i in api.calls) { var apiCall = api.calls[i]; %>
 <%- getDeprecationAttribute("    ", apiCall)

--- a/targets/javascript/templates/PlayFab_Api.js.ejs
+++ b/targets/javascript/templates/PlayFab_Api.js.ejs
@@ -59,7 +59,7 @@ if(!PlayFab._internalSettings) {
             }
         },
 
-        ExecuteRequest: async function (url, request, authkey, authValue, callback, customData, extraHeaders) {
+        ExecuteRequest: function (url, request, authkey, authValue, callback, customData, extraHeaders) {
             if (callback != null && typeof (callback) != "function")
                 throw "Callback must be null of a function";
 
@@ -151,76 +151,83 @@ if(!PlayFab._internalSettings) {
                 callback(null, result);
             }
 
-            function sendRequest(xhr) {
-                return new Promise(resolve => {
-                    xhr.send(requestBody);
-                });
+            xhr.send(requestBody);
+        },
+
+        authenticationContext: {
+            PlayFabId: null,
+            EntityId: null,
+            EntityType: null,
+            SessionTicket: null,
+            EntityToken: null
+        },
+
+        UpdateAuthenticationContext: function (authenticationContext, result) {
+            var authenticationContextUpdates = {};
+            if(result.data.PlayFabId !== null) {
+                PlayFab._internalSettings.authenticationContext.PlayFabId = result.data.PlayFabId;
+                authenticationContextUpdates.PlayFabId = result.data.PlayFabId;
             }
-            var resolvedPromise = await sendRequest(xhr);
-            return resolvedPromise;
+            if(result.data.SessionTicket !== null) {
+                PlayFab._internalSettings.authenticationContext.SessionTicket = result.data.SessionTicket;
+                authenticationContextUpdates.SessionTicket = result.data.SessionTicket;
+            }
+            if (result.data.EntityToken !== null) {
+                PlayFab._internalSettings.authenticationContext.EntityId = result.data.EntityToken.Entity.Id;
+                authenticationContextUpdates.EntityId = result.data.EntityToken.Entity.Id;
+                PlayFab._internalSettings.authenticationContext.EntityType = result.data.EntityToken.Entity.Type;
+                authenticationContextUpdates.EntityType = result.data.EntityToken.Entity.Type;
+                PlayFab._internalSettings.authenticationContext.EntityToken = result.data.EntityToken.EntityToken;
+                authenticationContextUpdates.EntityToken = result.data.EntityToken.EntityToken;
+            }
+            // Update the authenticationContext with values from the result
+            authenticationContext = Object.assign(authenticationContext, authenticationContextUpdates);
+            return authenticationContext;
+        },
+
+        AuthInfoMap: {
+            "X-EntityToken": {
+                authAttr: "entityToken",
+                authError: "errorEntityToken"
+            },
+            "X-Authorization": {
+                authAttr: "sessionTicket",
+                authError: "errorLoggedIn"
+            },
+            "X-SecretKey": {
+                authAttr: "developerSecretKey",
+                authError: "errorSecretKey"
+            }
+        },
+
+        GetAuthInfo: function (request, authKey) {
+            // Use the most-recently saved sessionTicket, unless one was provided in the request via the PlayFabId property
+            var authAttr = PlayFab._internalSettings.AuthInfoMap[authKey].authError;
+            var authError = PlayFab._internalSettings[authAttr];
+            authAttr = PlayFab._internalSettings.AuthInfoMap[authKey].authAttr;
+            var defaultAuthValue = null;
+            if (authAttr === "entityToken")
+                defaultAuthValue = PlayFab._internalSettings.entityToken;
+            else if (authAttr === "sessionTicket")
+                defaultAuthValue = PlayFab._internalSettings.sessionTicket;
+            else if (authAttr === "developerSecretKey")
+                defaultAuthValue = PlayFab.settings.developerSecretKey;
+            var authValue = request.AuthenticationContext ? request.AuthenticationContext[authAttr] : defaultAuthValue;
+            return {"authKey": authKey, "authValue": authValue, "authError": authError};
+        },
+
+        ExecuteRequestWrapper: function (apiURL, request, authKey, callback, customData, extraHeaders) {
+            var authValue = null;
+            if (authKey !== null){
+                var authInfo = PlayFab._internalSettings.GetAuthInfo(request, authKey=authKey);
+                var authKey = authInfo.authKey, authValue = authInfo.authValue, authError = authInfo.authError;
+
+                if (!authValue) throw authError;
+            }
+            PlayFab._internalSettings.ExecuteRequest(PlayFab._internalSettings.GetServerUrl() + apiURL, request, authKey, authValue, callback, customData, extraHeaders);
         }
     }
 }
-
-if (typeof PlayFab._internalSettings.authenticationContext == "undefined") {
-    // Initialize the authenticationContext if it doesnt exist
-    // We could use a ternary operator here, but length of the line of code would effect readability
-    PlayFab._internalSettings.authenticationContext = {};
-}
-
-PlayFab._internalSettings.GetAuthValue = function (request, authKey) {
-    // Use the most-recently saved sessionTicket, unless one was provided in the request via the PlayFabId property
-    var authInfoMap = {
-        'X-EntityToken': 'entityToken',
-        'X-Authorization': 'sessionTicket',
-        'X-SecretKey': 'developerSecretKey'
-    };
-    var authAttr = authInfoMap[authKey];
-    var authValue = authAttr ==  'developerSecretKey' ? PlayFab.settings[authAttr]: PlayFab._internalSettings[authAttr];
-    if (request.hasOwnProperty('PlayFabId')) {
-        var playFabId = request.PlayFabId;
-        // Make sure that the authenticationContext exists before attempting to access it
-        if (PlayFab._internalSettings.authenticationContext.hasOwnProperty(playFabId)) {
-            if (PlayFab._internalSettings.authenticationContext[playFabId].hasOwnProperty(authAttr)) {
-                authValue = PlayFab._internalSettings.authenticationContext[playFabId][authAttr];
-            }
-        }
-    }
-    return authValue;
-};
-
-PlayFab._internalSettings.GetAuthInfo = function (request, authKey) {
-    // Use the most-recently saved sessionTicket, unless one was provided in the request via the PlayFabId property
-    var authInfoMap = {
-        'X-EntityToken': {
-            'authAttr': 'entityToken',
-            'authError': 'errorEntityToken'
-        },
-        'X-Authorization': {
-            'authAttr': 'sessionTicket',
-            'authError': 'errorLoggedIn'
-        },
-        'X-SecretKey': {
-            'authAttr': 'developerSecretKey',
-            'authError': 'errorSecretKey'
-        }
-    };
-    var authAttr = authInfoMap[authKey]['authAttr'];
-    var authValue = authAttr ==  'developerSecretKey' ? PlayFab.settings[authAttr]: PlayFab._internalSettings[authAttr];
-    if (request.hasOwnProperty('PlayFabId')) {
-        var playFabId = request.PlayFabId;
-        // Make sure that the authenticationContext exists before attempting to access it
-        if (PlayFab._internalSettings.authenticationContext.hasOwnProperty(playFabId)) {
-            if (PlayFab._internalSettings.authenticationContext[playFabId].hasOwnProperty(authAttr)) {
-                authValue = PlayFab._internalSettings.authenticationContext[playFabId][authAttr];
-            }
-        }
-    }
-    authAttr = authInfoMap[authKey]['authError'];
-    var authError = PlayFab._internalSettings[authAttr];
-
-    return {'authValue': authValue, 'authError': authError};
-};
 
 PlayFab.buildIdentifier = "<%- buildIdentifier %>";
 PlayFab.sdkVersion = "<%- sdkVersion %>";
@@ -242,7 +249,6 @@ PlayFab.<%- api.name %>Api = {
 <% } %>    ForgetAllCredentials: function () {
         PlayFab._internalSettings.sessionTicket = null;
         PlayFab._internalSettings.entityToken = null;
-        PlayFab._internalSettings.authenticationContext = {};
     },
 <% for(var i in api.calls) { var apiCall = api.calls[i]; %>
 <%- getDeprecationAttribute("    ", apiCall)
@@ -253,9 +259,11 @@ PlayFab.<%- api.name %>Api = {
             if (callback != null && typeof (callback) == "function")
                 callback(result, error);
         };
-        PlayFab._internalSettings.ExecuteRequest(<%- getUrl(apiCall) %>, request, <%- getAuthParams(apiCall) %>, overloadCallback, customData, extraHeaders);<%
+        PlayFab._internalSettings.ExecuteRequestWrapper(<%- getPartialUrl(apiCall) %>, request, <%- getAuthParams(apiCall) %>, overloadCallback, customData, extraHeaders);<% if (apiCall.result === "LoginResult") { %>
+        // Return a Promise so that multiple asynchronous calls to this method can be handled simultaneously with Promise.all()
+        return new Promise(function(resolve){resolve(authenticationContext);});<% } %><%
 }else{
-%>        PlayFab._internalSettings.ExecuteRequest(<%- getUrl(apiCall) %>, request, <%- getAuthParams(apiCall) %>, callback, customData, extraHeaders);<% } %>
+%>        PlayFab._internalSettings.ExecuteRequestWrapper(<%- getPartialUrl(apiCall) %>, request, <%- getAuthParams(apiCall) %>, callback, customData, extraHeaders);<% } %>
     },
 <% } if (hasClientOptions) {%>
     _MultiStepClientLogin: function (needsAttribution) {

--- a/targets/javascript/templates/PlayFab_Api.js.ejs
+++ b/targets/javascript/templates/PlayFab_Api.js.ejs
@@ -176,7 +176,6 @@ PlayFab._internalSettings.GetAuthValue = function (request, authKey) {
         'X-SecretKey': 'developerSecretKey'
     };
     var authAttr = authInfoMap[authKey];
-    var sessionTicket = PlayFab._internalSettings.sessionTicket;
     var authValue = authAttr ==  'developerSecretKey' ? PlayFab.settings[authAttr]: PlayFab._internalSettings[authAttr];
     if (request.hasOwnProperty('PlayFabId')) {
         var playFabId = request.PlayFabId;
@@ -188,6 +187,39 @@ PlayFab._internalSettings.GetAuthValue = function (request, authKey) {
         }
     }
     return authValue;
+};
+
+PlayFab._internalSettings.GetAuthInfo = function (request, authKey) {
+    // Use the most-recently saved sessionTicket, unless one was provided in the request via the PlayFabId property
+    var authInfoMap = {
+        'X-EntityToken': {
+            'authAttr': 'entityToken',
+            'authError': 'errorEntityToken'
+        },
+        'X-Authorization': {
+            'authAttr': 'sessionTicket',
+            'authError': 'errorLoggedIn'
+        },
+        'X-SecretKey': {
+            'authAttr': 'developerSecretKey',
+            'authError': 'errorSecretKey'
+        }
+    };
+    var authAttr = authInfoMap[authKey]['authAttr'];
+    var authValue = authAttr ==  'developerSecretKey' ? PlayFab.settings[authAttr]: PlayFab._internalSettings[authAttr];
+    if (request.hasOwnProperty('PlayFabId')) {
+        var playFabId = request.PlayFabId;
+        // Make sure that the authenticationContext exists before attempting to access it
+        if (PlayFab._internalSettings.authenticationContext.hasOwnProperty(playFabId)) {
+            if (PlayFab._internalSettings.authenticationContext[playFabId].hasOwnProperty(authAttr)) {
+                authValue = PlayFab._internalSettings.authenticationContext[playFabId][authAttr];
+            }
+        }
+    }
+    authAttr = authInfoMap[authKey]['authError'];
+    var authError = PlayFab._internalSettings[authAttr];
+
+    return {'authValue': authValue, 'authError': authError};
 };
 
 PlayFab.buildIdentifier = "<%- buildIdentifier %>";

--- a/targets/javascript/testingFiles/PlayFabApiTest.ts
+++ b/targets/javascript/testingFiles/PlayFabApiTest.ts
@@ -44,7 +44,6 @@ var PlayFabApiTests = {
         QUnit.test("InvalidRegistration", PlayFabApiTests.InvalidRegistration);
         QUnit.test("LoginOrRegister", PlayFabApiTests.LoginOrRegister);
         QUnit.test("LoginWithAdvertisingId", PlayFabApiTests.LoginWithAdvertisingId);
-        QUnit.test("LoginWithAuthenticationContext", PlayFabApiTests.LoginWithAuthenticationContext);
 
         setTimeout(function (): void { PlayFabApiTests.PostLoginTests(0); }, PlayFabApiTests.testRetryDelay);
         setTimeout(function (): void { PlayFabApiTests.PostEntityTokenTests(0); }, PlayFabApiTests.testRetryDelay);
@@ -203,7 +202,9 @@ var PlayFabApiTests = {
             loginDone();
         };
 
-        PlayFabClientSDK.LoginWithCustomID(loginRequest, PlayFabApiTests.CallbackWrapper("loginCallback", loginCallback, assert));
+        var loginPromise = Promise.resolve(PlayFabClientSDK.LoginWithCustomID(loginRequest, PlayFabApiTests.CallbackWrapper("loginCallback", loginCallback, assert)))
+        // By definition, a promise object should have a .then function, and Promise.resolve(promise) should equal promise
+        assert.ok(typeof loginPromise.then === "function" && Promise.resolve(loginPromise) === loginPromise, "Testing whether the login request returned a promise object");
     },
 
     /* CLIENT API
@@ -232,97 +233,7 @@ var PlayFabApiTests = {
             CustomId: PlayFab.buildIdentifier,
             CreateAccount: true
         };
-        PlayFabClientSDK.LoginWithCustomID(loginRequest, PlayFabApiTests.CallbackWrapper("advertLoginCallback", advertLoginCallback, assert));
-    },
-
-    /* CLIENT API
-     * Test that the login call sequence uses the AuthenticationContext when set
-     */
-    LoginWithAuthenticationContext: function (assert) {
-        var loginCount = 4;
-        var loginDone = assert.async(loginCount);
-        var testDone = assert.async();
-        // We need a dictionary of counts storing one count per playFabId
-        var retryCountDict = {};
-        var resultDataDict = {};
-
-        var checkAuthenticationContext = function (result_data) {
-             // Capture the playFabId, and make sure the authenticationContext exists with the ID in question
-            playFabId = typeof result_data['playFabId'] != "undefined" ? result_data['playFabId'] : null;
-            retryCountDict[playFabId] = typeof retryCountDict[playFabId] != "undefined" ? retryCountDict[playFabId] + 1 : -1;
-            sessionTicket = typeof result_data['sessionTicket'] != "undefined" ? result_data['sessionTicket'] : null;
-            entityToken = typeof result_data['entityToken'] != "undefined" ? result_data['entityToken'] : null;
-            // TODO: Handle the playFabId/sessionTicket/entityToken = null case
-            console.log(retryCountDict[playFabId]);
-            if (retryCountDict[playFabId] <= 10 && PlayFab._internalSettings.authenticationContext.hasOwnProperty(playFabId) == false) {
-                setTimeout(PlayFabApiTests.SimpleCallbackWrapper("checkAuthenticationContext", checkAuthenticationContext, assert, result_data), 200);
-            }
-            else {
-                assert.ok(PlayFab._internalSettings.authenticationContext[playFabId]['sessionTicket'] === sessionTicket, "Testing whether authenticationContext updated sessionTicket properly");
-                assert.ok(PlayFab._internalSettings.authenticationContext[playFabId]['entityToken'] === entityToken, "Testing whether authenticationContext updated entityToken properly");
-                loginDone();
-            }
-        };
-        var authenticationContextLoginCallback = function (result, error) {
-            var playFabId = playFabId = result.data.PlayFabId;
-            var sessionTicket = null;
-            var entityToken = null;
-
-            sessionTicket = result.data.SessionTicket;
-            entityToken = result.data.EntityToken.EntityToken;
-            resultDataDict[playFabId] = {
-                'playFabId': playFabId,
-                'sessionTicket': sessionTicket,
-                'entityToken': entityToken
-            };
-
-            PlayFabApiTests.VerifyNullError(result, error, assert, "Testing AuthenticationContext-Login result");
-            setTimeout(PlayFabApiTests.SimpleCallbackWrapper("checkAuthenticationContext", checkAuthenticationContext, assert, resultDataDict[playFabId]), 200);
-        };
-
-        function runTestWrapup (){
-            // TODO: PlayFab._internalSettings.authenticationContext has one more key/value pair than it should here
-            console.log("TestWrapup() called");
-            setTimeout(assert.ok(Object.keys(PlayFab._internalSettings.authenticationContext).length === loginCount, "Testing whether authenticationContext was updated properly"), 200);
-            testDone();
-        }
-
-        function runLoginWrapper(){
-            var multiUserLoginRequests = [];
-            for (var i=loginCount; i>0; i--){
-                var loginRequest = {
-                    CustomId: PlayFab.buildIdentifier+i,
-                    CreateAccount: true,
-                    AuthenticationContext: true
-                };
-                multiUserLoginRequests.push(runLogin(loginRequest));
-            }
-            var resolvedPromises = Promise.all(multiUserLoginRequests);
-            resolvedPromises.then(function(result){
-                console.log("then result", result);
-                setTimeout(runTestWrapup, 500, "resolvedPromise.then() called");
-//                runTestWrapup();
-            }).catch(err => {
-                return {
-                    name: null,
-                    // err.code or whatever your error looks like, maybe just 404
-                    status: err.code
-                }
-            });
-            // TODO: Try to wait on resolvePromises to resolve without forcing a delay via setTimeout()
-            // This setTimeout delay isn't guaranteed to work every time
-//            setTimeout(function(){
-//                runTestWrapup();
-//            }, 5000);
-
-        }
-        var runLogin = function (loginRequest){
-            return new Promise(resolve => {
-                PlayFabClientSDK.LoginWithCustomID(loginRequest, PlayFabApiTests.CallbackWrapper("authenticationContextLoginCallback", authenticationContextLoginCallback, assert));
-                setTimeout(resolve, 500);
-            });
-        };
-        runLoginWrapper();
+        Promise.resolve(PlayFabClientSDK.LoginWithCustomID(loginRequest, PlayFabApiTests.CallbackWrapper("advertLoginCallback", advertLoginCallback, assert)));
     },
 
     /* CLIENT API
@@ -656,7 +567,6 @@ var PlayFabApiTests = {
     ForgetCredentials: function (assert): void {
         assert.ok(PlayFabClientSDK.IsClientLoggedIn(), "Client should be logged in.");
         PlayFabClientSDK.ForgetAllCredentials();
-        assert.ok($.isEmptyObject(PlayFab._internalSettings.authenticationContext), "Client authenticationContext should be empty.");
         assert.ok(!PlayFabClientSDK.IsClientLoggedIn(), "Client should NOT be logged in.");
     },
 };

--- a/targets/javascript/testingFiles/index.html.ejs
+++ b/targets/javascript/testingFiles/index.html.ejs
@@ -9,7 +9,7 @@
     <div id="qunit"></div>
     <div id="qunit-fixture"></div>
     <script src="http://code.jquery.com/jquery-1.7.1.min.js"></script><!-- HTTP vs HTTPS here should match where this file is hosted (This file is not strictly meant to be hosted, but rather run locally) -->
-    <script src="http://code.jquery.com/qunit/qunit-1.19.0.js"></script>
+    <script src="http://code.jquery.com/qunit/qunit-2.0.1.js"></script>
 <% for(var i in apis) { var api = apis[i];
 %>    <script src="src/PlayFab/PlayFab<%- api.name %>Api.js"></script>
 <% } %>    <script src="PlayFabApiTest.js"></script>


### PR DESCRIPTION
There's a refactor-in-progress of PlayFab._internalSettings.GetAuthValue called PlayFab._internalSettings.GetAuthInfo.  It currently breaks on GetPlayerProfile in the unit tests, but all other previous tests before that one pass.  I'm submitting this pull request using GetAuthValue for now, but I wanted to make you aware of the unused function before you come across it in the code.  The idea behind the refactor is to generalize the logic in the various API methods, so that a method such as GetPlayerProfile, for example, can go from

```
GetPlayerProfile: function (request, callback, customData, extraHeaders) {
        var authKey = "X-Authorization"; var authValue = PlayFab._internalSettings.GetAuthValue(request, authKey);
        if (!authValue) throw PlayFab._internalSettings.errorLoggedIn;
        PlayFab._internalSettings.ExecuteRequest(PlayFab._internalSettings.GetServerUrl() + "/Client/GetPlayerProfile", request, authKey, authValue, callback, customData, extraHeaders);
    },
```

to 

```
GetPlayerProfile: function (request, callback, customData, extraHeaders) {
        var authKey = "X-Authorization"; var authInfo = PlayFab._internalSettings.GetAuthInfo(request, authKey);
        var authValue = authInfo.authValue  ; var authError = authInfo.authError;
        if (!authValue) throw authError ;
        PlayFab._internalSettings.ExecuteRequest(PlayFab._internalSettings.GetServerUrl() + "/Client/GetPlayerProfile", request, authKey, authValue, callback, customData, extraHeaders);
    },
```


I think this change would make it easier to abstract the logic for the bulk of the API methods into one or two helper functions, which should significantly reduce the number of lines of code in the various API files.  Let me know what you think!