### PR TITLE
Replace Contains with TryContains in a few places to improve perf

### DIFF
--- a/targets/csharp/source/source/Json/SimpleJson.cs
+++ b/targets/csharp/source/source/Json/SimpleJson.cs
@@ -267,7 +267,8 @@ namespace PlayFab.Json
         /// </returns>
         public bool Contains(KeyValuePair<string, object> item)
         {
-            return _members.ContainsKey(item.Key) && _members[item.Key] == item.Value;
+            object value;
+            return _members.TryGetValue(item.Key, out value) && value == item.Value;
         }
 
         /// <summary>

--- a/targets/csharp/source/source/PluginManager.cs
+++ b/targets/csharp/source/source/PluginManager.cs
@@ -25,7 +25,7 @@ namespace PlayFab
         /// <param name="contract">The plugin contract.</param>
         /// <param name="instanceName">The optional plugin instance name. Instance names allow to have mulptiple plugins with the same contract.</param>
         /// <returns>The plugin instance.</returns>
-        public static T GetPlugin<T>(PluginContract contract, string instanceName = "") where T : IPlayFabPlugin
+        public static T GetPlugin<T>(PluginContract contract, string instanceName = string.Empty) where T : IPlayFabPlugin
         {
             return (T)Instance.GetPluginInternal(contract, instanceName);
         }
@@ -37,7 +37,7 @@ namespace PlayFab
         /// <param name="plugin">The plugin instance.</param>
         /// <param name="contract">The app contract of plugin.</param>
         /// <param name="instanceName">The optional plugin instance name. Instance names allow to have mulptiple plugins with the same contract.</param>
-        public static void SetPlugin(IPlayFabPlugin plugin, PluginContract contract, string instanceName = "")
+        public static void SetPlugin(IPlayFabPlugin plugin, PluginContract contract, string instanceName = string.Empty)
         {
             Instance.SetPluginInternal(plugin, contract, instanceName);
         }
@@ -45,10 +45,10 @@ namespace PlayFab
         private IPlayFabPlugin GetPluginInternal(PluginContract contract, string instanceName)
         {
             var key = new Tuple<PluginContract, string>(contract, instanceName);
-            if (!this.plugins.ContainsKey(key))
+            IPlayFabPlugin plugin;
+            if (!this.plugins.TryGetValue(key, out plugin))
             {
                 // Requested plugin is not in the cache, create the default one
-                IPlayFabPlugin plugin;
                 switch (contract)
                 {
                     case PluginContract.PlayFab_Serializer:
@@ -64,7 +64,7 @@ namespace PlayFab
                 this.plugins[key] = plugin;
             }
 
-            return this.plugins[key];
+            return plugin;
         }
 
         private void SetPluginInternal(IPlayFabPlugin plugin, PluginContract contract, string instanceName)

--- a/targets/unity-v2/source/Shared/Internal/PlayFabHttp/PlayFabHTTP.cs
+++ b/targets/unity-v2/source/Shared/Internal/PlayFabHttp/PlayFabHTTP.cs
@@ -431,8 +431,9 @@ namespace PlayFab.Internal
             catch (Exception) { /* Unusual, but shouldn't actually matter */ }
             try
             {
-                if (errorDict != null && errorDict.ContainsKey("errorDetails"))
-                    errorDetails = serializer.DeserializeObject<Dictionary<string, List<string>>>(errorDict["errorDetails"].ToString());
+                object errorDetailsString;
+                if (errorDict != null && errorDict.TryGetValue("errorDetails", out errorDetailsString))
+                    errorDetails = serializer.DeserializeObject<Dictionary<string, List<string>>>(errorDetailsString.ToString());
             }
             catch (Exception) { /* Unusual, but shouldn't actually matter */ }
 

--- a/targets/unity-v2/source/Shared/Internal/SimpleJson.cs
+++ b/targets/unity-v2/source/Shared/Internal/SimpleJson.cs
@@ -279,7 +279,8 @@ namespace PlayFab.Json
         /// </returns>
         public bool Contains(KeyValuePair<string, object> item)
         {
-            return _members.ContainsKey(item.Key) && _members[item.Key] == item.Value;
+            object value;
+            return _members.TryGetValue(item.Key, out value) && value == item.Value;
         }
 
         /// <summary>

--- a/targets/unity-v2/source/Shared/Public/PluginManager.cs
+++ b/targets/unity-v2/source/Shared/Public/PluginManager.cs
@@ -45,10 +45,10 @@ namespace PlayFab
         private IPlayFabPlugin GetPluginInternal(PluginContract contract, string instanceName)
         {
             var key = new PluginContractKey { _pluginContract = contract, _pluginName = instanceName };
-            if (!this.plugins.ContainsKey(key))
+            IPlayFabPlugin plugin;
+            if (!this.plugins.TryGetValue(key, out plugin))
             {
                 // Requested plugin is not in the cache, create the default one
-                IPlayFabPlugin plugin;
                 switch (contract)
                 {
                     case PluginContract.PlayFab_Serializer:
@@ -64,7 +64,7 @@ namespace PlayFab
                 this.plugins[key] = plugin;
             }
 
-            return this.plugins[key];
+            return plugin;
         }
 
         private void SetPluginInternal(IPlayFabPlugin plugin, PluginContract contract, string instanceName)


### PR DESCRIPTION
There are a few places where we use `thing.ContainsKey` followed by `thing[key]` which results in two lookups for in the object the majority of the time.  By switching these to use TryGetValue instead, we can optimize this.

There should be no functional impact to this, but since this is used in the Json and Http libraries which are use relatively frequently, hopefully this will help with perf a bit.