### PR TITLE
Milestone #24: Multi-user support for Unity.

### DIFF
--- a/targets/unity-v2/Testing/Tests/Client/ClientMultiUserTests.cs
+++ b/targets/unity-v2/Testing/Tests/Client/ClientMultiUserTests.cs
@@ -53,11 +53,11 @@ namespace PlayFab.UUnit
                 if (_player1 == null || _player2 == null) return;
 
                 // reset delegate to avoid calling this method again
-                _tickAction = delegate { };
+                _tickAction = null;
 
                 // players must not be equals
-                testContext.False(_player1 == _player2);
-                testContext.EndTest(UUnitFinishState.PASSED, "Two players are successfully login.");
+                testContext.False(_player1.PlayFabId == _player2.PlayFabId);
+                testContext.EndTest(UUnitFinishState.PASSED, "Two players are successfully login. " + _player1.PlayFabId + ", " + _player2.PlayFabId);
             };
         }
 
@@ -84,14 +84,14 @@ namespace PlayFab.UUnit
                 if (player1AccountInfo == null || player2AccountInfo == null) return;
 
                 // reset delegate to avoid calling this method again
-                _tickAction = delegate { };
+                _tickAction = null;
 
                 // compares received data with cached data to make sure everything works correctly
-                testContext.True(_player1.PlayFabId == player1AccountInfo.PlayFabId, "Player1 Ids not match!");
-                testContext.True(_player2.PlayFabId == player2AccountInfo.PlayFabId, "Player2 Ids not match!");
+                testContext.True(_player1.PlayFabId == player1AccountInfo.PlayFabId, "Player1 PlayFabIds not match!");
+                testContext.True(_player2.PlayFabId == player2AccountInfo.PlayFabId, "Player2 PlayFabIds not match!");
 
                 // playFabId at different players must be different
-                testContext.False(player1AccountInfo.PlayFabId == player2AccountInfo.PlayFabId, "Player ids is equals!");
+                testContext.False(player1AccountInfo.PlayFabId == player2AccountInfo.PlayFabId, "Players PlayFabId is equals!");
                 testContext.EndTest(UUnitFinishState.PASSED, _player1.PlayFabId + ", " + _player2.PlayFabId);
             };
         }

--- a/targets/unity-v2/Testing/Tests/Client/ClientMultiUserTests.cs
+++ b/targets/unity-v2/Testing/Tests/Client/ClientMultiUserTests.cs
@@ -1,0 +1,100 @@
+﻿#if !DISABLE_PLAYFABCLIENT_API
+using System;
+using PlayFab.ClientModels;
+
+namespace PlayFab.UUnit
+{
+    public class ClientMultiUserTests : UUnitTestCase
+    {
+        private Action _tickAction;
+
+        private PlayFabAuthenticationContext _player1;
+        private PlayFabAuthenticationContext _player2;
+
+        public override void Tick(UUnitTestContext testContext)
+        {
+            if (_tickAction != null)
+                _tickAction();
+        }
+
+        private void SharedErrorCallback(PlayFabError error)
+        {
+            // This error was not expected.  Report it and fail.
+            ((UUnitTestContext) error.CustomData).Fail(error.GenerateErrorReport());
+        }
+
+        /// <summary>
+        /// CLIENT API
+        /// Test for more then one user can login at the same time asynchronously 
+        /// </summary>
+        [UUnitTest]
+        public void AsyncMultiUserLogin(UUnitTestContext testContext)
+        {
+            var player1LoginRequest = new LoginWithCustomIDRequest
+            {
+                CustomId = PlayFabSettings.BuildIdentifier + "0",
+                CreateAccount = true
+            };
+
+            var player2LoginRequest = new LoginWithCustomIDRequest
+            {
+                CustomId = PlayFabSettings.BuildIdentifier + "1",
+                CreateAccount = true
+            };
+
+            PlayFabClientAPI.LoginWithCustomID(player1LoginRequest, x => _player1 = x.AuthenticationContext,
+                PlayFabUUnitUtils.ApiActionWrapper<PlayFabError>(testContext, SharedErrorCallback), testContext);
+            PlayFabClientAPI.LoginWithCustomID(player2LoginRequest, x => _player2 = x.AuthenticationContext,
+                PlayFabUUnitUtils.ApiActionWrapper<PlayFabError>(testContext, SharedErrorCallback), testContext);
+
+            _tickAction = () =>
+            {
+                // return if players not loaded yet
+                if (_player1 == null || _player2 == null) return;
+
+                // reset delegate to avoid calling this method again
+                _tickAction = delegate { };
+
+                // players must not be equals
+                testContext.False(_player1 == _player2);
+                testContext.EndTest(UUnitFinishState.PASSED, "Two players are successfully login.");
+            };
+        }
+
+        /// <summary>
+        /// CLIENT API
+        /// Test for more than one user can make an API call at the same time asynchronously
+        /// </summary>
+        [UUnitTest]
+        public void AsyncMultiUserApiCall(UUnitTestContext testContext)
+        {
+            var player1Request = new GetAccountInfoRequest {AuthenticationContext = _player1};
+            var player2Request = new GetAccountInfoRequest {AuthenticationContext = _player2};
+            UserAccountInfo player1AccountInfo = null;
+            UserAccountInfo player2AccountInfo = null;
+
+            PlayFabClientAPI.GetAccountInfo(player1Request, x => player1AccountInfo = x.AccountInfo,
+                PlayFabUUnitUtils.ApiActionWrapper<PlayFabError>(testContext, SharedErrorCallback), testContext);
+            PlayFabClientAPI.GetAccountInfo(player2Request, x => player2AccountInfo = x.AccountInfo,
+                PlayFabUUnitUtils.ApiActionWrapper<PlayFabError>(testContext, SharedErrorCallback), testContext);
+
+            _tickAction = () =>
+            {
+                // wait loading account info
+                if (player1AccountInfo == null || player2AccountInfo == null) return;
+
+                // reset delegate to avoid calling this method again
+                _tickAction = delegate { };
+
+                // compares received data with cached data to make sure everything works correctly
+                testContext.True(_player1.PlayFabId == player1AccountInfo.PlayFabId, "Player1 Ids not match!");
+                testContext.True(_player2.PlayFabId == player2AccountInfo.PlayFabId, "Player2 Ids not match!");
+
+                // playFabId at different players must be different
+                testContext.False(player1AccountInfo.PlayFabId == player2AccountInfo.PlayFabId, "Player ids is equals!");
+                testContext.EndTest(UUnitFinishState.PASSED, _player1.PlayFabId + ", " + _player2.PlayFabId);
+            };
+        }
+    }
+}
+#endif

--- a/targets/unity-v2/make.js
+++ b/targets/unity-v2/make.js
@@ -94,6 +94,8 @@ function makePlayStreamDatatype(datatype, sourceDir) {
 };
 
 function getBaseTypeSyntax(datatype) {
+    if (datatype.className === "LoginResult" || datatype.className === "RegisterPlayFabUserResult")
+        return " : PlayFabLoginResultCommon";
     if (datatype.className.toLowerCase().endsWith("request"))
         return " : PlayFabRequestCommon";
     if (datatype.className.toLowerCase().endsWith("response") || datatype.className.toLowerCase().endsWith("result"))

--- a/targets/unity-v2/source/Authentication/PlayFabAuthenticationContext.cs
+++ b/targets/unity-v2/source/Authentication/PlayFabAuthenticationContext.cs
@@ -1,0 +1,36 @@
+﻿namespace PlayFab
+{
+    public sealed class PlayFabAuthenticationContext
+    {
+#if !DISABLE_PLAYFABCLIENT_API
+        public string ClientSessionTicket;
+#endif
+
+#if !DISABLE_PLAYFABENTITY_API
+        public string EntityToken;
+#endif
+
+#if ENABLE_PLAYFABSERVER_API || ENABLE_PLAYFABADMIN_API || UNITY_EDITOR
+        public string DeveloperSecretKey;
+#endif
+        public string PlayFabId;
+            
+        public PlayFabAuthenticationContext() 
+        {        
+#if ENABLE_PLAYFABSERVER_API || ENABLE_PLAYFABADMIN_API
+            DeveloperSecretKey = PlayFabSettings.DeveloperSecretKey;
+#endif
+        }
+
+        public PlayFabAuthenticationContext(string clientSessionTicket, string entityToken, string playFabId) : this()
+        {
+#if !DISABLE_PLAYFABCLIENT_API
+                ClientSessionTicket = clientSessionTicket;
+#endif
+#if !DISABLE_PLAYFABENTITY_API
+                EntityToken = entityToken;
+#endif
+                PlayFabId = playFabId;
+        }
+    }
+}

--- a/targets/unity-v2/source/Authentication/PlayFabAuthenticationContext.cs
+++ b/targets/unity-v2/source/Authentication/PlayFabAuthenticationContext.cs
@@ -25,12 +25,12 @@
         public PlayFabAuthenticationContext(string clientSessionTicket, string entityToken, string playFabId) : this()
         {
 #if !DISABLE_PLAYFABCLIENT_API
-                ClientSessionTicket = clientSessionTicket;
+            ClientSessionTicket = clientSessionTicket;
 #endif
 #if !DISABLE_PLAYFABENTITY_API
-                EntityToken = entityToken;
+            EntityToken = entityToken;
 #endif
-                PlayFabId = playFabId;
+            PlayFabId = playFabId;
         }
     }
 }

--- a/targets/unity-v2/source/Authentication/PlayFabLoginResultCommon.cs
+++ b/targets/unity-v2/source/Authentication/PlayFabLoginResultCommon.cs
@@ -1,0 +1,9 @@
+﻿using PlayFab.SharedModels;
+
+namespace PlayFab
+{
+    public class PlayFabLoginResultCommon : PlayFabResultCommon
+    {
+        public PlayFabAuthenticationContext AuthenticationContext;
+    }
+}

--- a/targets/unity-v2/source/Authentication/PlayFabLoginResultCommon.cs
+++ b/targets/unity-v2/source/Authentication/PlayFabLoginResultCommon.cs
@@ -1,9 +1,0 @@
-﻿using PlayFab.SharedModels;
-
-namespace PlayFab
-{
-    public class PlayFabLoginResultCommon : PlayFabResultCommon
-    {
-        public PlayFabAuthenticationContext AuthenticationContext;
-    }
-}

--- a/targets/unity-v2/source/Shared/Internal/PlayFabHttp/PlayFabHTTP.cs
+++ b/targets/unity-v2/source/Shared/Internal/PlayFabHttp/PlayFabHTTP.cs
@@ -220,10 +220,29 @@ namespace PlayFab.Internal
             switch (authType)
             {
 #if ENABLE_PLAYFABSERVER_API || ENABLE_PLAYFABADMIN_API || UNITY_EDITOR
-                case AuthType.DevSecretKey: reqContainer.RequestHeaders["X-SecretKey"] = PlayFabSettings.DeveloperSecretKey; break;
+                case AuthType.DevSecretKey: reqContainer.RequestHeaders["X-SecretKey"] = request.AuthenticationContext != null && request.AuthenticationContext.DeveloperSecretKey != null 
+                        ? request.AuthenticationContext.DeveloperSecretKey
+                        : PlayFabSettings.DeveloperSecretKey;
+                    break;
 #endif
-                case AuthType.LoginSession: reqContainer.RequestHeaders["X-Authorization"] = transport.AuthKey; break;
-                case AuthType.EntityToken: reqContainer.RequestHeaders["X-EntityToken"] = transport.EntityToken; break;
+                case AuthType.LoginSession: 
+#if !DISABLE_PLAYFABCLIENT_API                    
+                    reqContainer.RequestHeaders["X-Authorization"] = request.AuthenticationContext != null && request.AuthenticationContext.ClientSessionTicket != null 
+                        ? request.AuthenticationContext.ClientSessionTicket 
+                        : transport.AuthKey;
+#else
+                    reqContainer.RequestHeaders["X-Authorization"] = transport.AuthKey;
+#endif
+                    break;
+                case AuthType.EntityToken: 
+#if !DISABLE_PLAYFABENTITY_API
+                    reqContainer.RequestHeaders["X-EntityToken"] = request.AuthenticationContext != null && request.AuthenticationContext.EntityToken != null 
+                        ? request.AuthenticationContext.EntityToken
+                        : transport.EntityToken;
+#else
+                    reqContainer.RequestHeaders["X-EntityToken"] = transport.EntityToken;
+#endif
+                    break;
             }
 
             // These closures preserve the TResult generic information in a way that's safe for all the devices
@@ -274,6 +293,7 @@ namespace PlayFab.Internal
                 transport.AuthKey = logRes.SessionTicket;
                 if (logRes.EntityToken != null)
                     transport.EntityToken = logRes.EntityToken.EntityToken;
+                logRes.AuthenticationContext = new PlayFabAuthenticationContext(transport.AuthKey, transport.EntityToken, logRes.PlayFabId);
             }
             else if (regRes != null)
             {
@@ -281,6 +301,7 @@ namespace PlayFab.Internal
                 transport.AuthKey = regRes.SessionTicket;
                 if (regRes.EntityToken != null)
                     transport.EntityToken = regRes.EntityToken.EntityToken;
+                regRes.AuthenticationContext = new PlayFabAuthenticationContext(transport.AuthKey, transport.EntityToken, regRes.PlayFabId);
             }
 #endif
         }

--- a/targets/unity-v2/source/Shared/Models/SharedModels.cs
+++ b/targets/unity-v2/source/Shared/Models/SharedModels.cs
@@ -9,6 +9,7 @@ namespace PlayFab.SharedModels
 
     public class PlayFabRequestCommon
     {
+        public PlayFabAuthenticationContext AuthenticationContext;
     }
 
     public class PlayFabResultCommon

--- a/targets/unity-v2/source/Shared/Models/SharedModels.cs
+++ b/targets/unity-v2/source/Shared/Models/SharedModels.cs
@@ -17,4 +17,9 @@ namespace PlayFab.SharedModels
         public PlayFabRequestCommon Request;
         public object CustomData;
     }
+    
+    public class PlayFabLoginResultCommon : PlayFabResultCommon
+    {
+        public PlayFabAuthenticationContext AuthenticationContext;
+    }
 }


### PR DESCRIPTION
PlayFab currently supports only a single login of a player in Unity SDK.
Added support multiple players logging from within the same SDK (Client).

- Introduce new class called PlayFabAuthenticationContext.
- Modify PlayFabRequestCommon to contain a pointer to PlayFabAuthenticationContext.
- PlayFabLoginResultCommon class based on an existing class PlayFabResultCommon. This’ll also have a reference to PlayFabAuthenticationContext.