### PR TITLE
Adding in error codes to successful parsing

### DIFF
--- a/targets/XPlatCppSdk/source/code/source/playfab/PlayFabCurlHttpPlugin.cpp
+++ b/targets/XPlatCppSdk/source/code/source/playfab/PlayFabCurlHttpPlugin.cpp
@@ -172,6 +172,7 @@ namespace PlayFab
                 reqContainer.errorWrapper.HttpStatus = reqContainer.responseJson.get("status", Json::Value::null).asString();
                 reqContainer.errorWrapper.Data = reqContainer.responseJson.get("data", Json::Value::null);
                 reqContainer.errorWrapper.ErrorName = reqContainer.responseJson.get("error", Json::Value::null).asString();
+                reqContainer.errorWrapper.ErrorCode = static_cast<PlayFab::PlayFabErrorCode>(reqContainer.responseJson.get("errorCode", Json::Value::null).asInt());
                 reqContainer.errorWrapper.ErrorMessage = reqContainer.responseJson.get("errorMessage", Json::Value::null).asString();
                 reqContainer.errorWrapper.ErrorDetails = reqContainer.responseJson.get("errorDetails", Json::Value::null);
             }

--- a/targets/XPlatCppSdk/source/code/source/playfab/PlayFabCurlHttpPlugin.cpp
+++ b/targets/XPlatCppSdk/source/code/source/playfab/PlayFabCurlHttpPlugin.cpp
@@ -172,7 +172,7 @@ namespace PlayFab
                 reqContainer.errorWrapper.HttpStatus = reqContainer.responseJson.get("status", Json::Value::null).asString();
                 reqContainer.errorWrapper.Data = reqContainer.responseJson.get("data", Json::Value::null);
                 reqContainer.errorWrapper.ErrorName = reqContainer.responseJson.get("error", Json::Value::null).asString();
-                reqContainer.errorWrapper.ErrorCode = static_cast<PlayFab::PlayFabErrorCode>(reqContainer.responseJson.get("errorCode", Json::Value::null).asInt());
+                reqContainer.errorWrapper.ErrorCode = static_cast<PlayFabErrorCode>(reqContainer.responseJson.get("errorCode", Json::Value::null).asInt());
                 reqContainer.errorWrapper.ErrorMessage = reqContainer.responseJson.get("errorMessage", Json::Value::null).asString();
                 reqContainer.errorWrapper.ErrorDetails = reqContainer.responseJson.get("errorDetails", Json::Value::null);
             }

--- a/targets/XPlatCppSdk/source/code/source/playfab/PlayFabIXHR2HttpPlugin.cpp
+++ b/targets/XPlatCppSdk/source/code/source/playfab/PlayFabIXHR2HttpPlugin.cpp
@@ -199,7 +199,7 @@ namespace PlayFab
                 reqContainer.errorWrapper.HttpStatus = reqContainer.responseJson.get("status", Json::Value::null).asString();
                 reqContainer.errorWrapper.Data = reqContainer.responseJson.get("data", Json::Value::null);
                 reqContainer.errorWrapper.ErrorName = reqContainer.responseJson.get("error", Json::Value::null).asString();
-                reqContainer.errorWrapper.ErrorCode = static_cast<PlayFab::PlayFabErrorCode>(reqContainer.responseJson.get("errorCode", Json::Value::null).asInt());
+                reqContainer.errorWrapper.ErrorCode = static_cast<PlayFabErrorCode>(reqContainer.responseJson.get("errorCode", Json::Value::null).asInt());
                 reqContainer.errorWrapper.ErrorMessage = reqContainer.responseJson.get("errorMessage", Json::Value::null).asString();
                 reqContainer.errorWrapper.ErrorDetails = reqContainer.responseJson.get("errorDetails", Json::Value::null);
             }

--- a/targets/XPlatCppSdk/source/code/source/playfab/PlayFabIXHR2HttpPlugin.cpp
+++ b/targets/XPlatCppSdk/source/code/source/playfab/PlayFabIXHR2HttpPlugin.cpp
@@ -199,6 +199,7 @@ namespace PlayFab
                 reqContainer.errorWrapper.HttpStatus = reqContainer.responseJson.get("status", Json::Value::null).asString();
                 reqContainer.errorWrapper.Data = reqContainer.responseJson.get("data", Json::Value::null);
                 reqContainer.errorWrapper.ErrorName = reqContainer.responseJson.get("error", Json::Value::null).asString();
+                reqContainer.errorWrapper.ErrorCode = static_cast<PlayFab::PlayFabErrorCode>(reqContainer.responseJson.get("errorCode", Json::Value::null).asInt());
                 reqContainer.errorWrapper.ErrorMessage = reqContainer.responseJson.get("errorMessage", Json::Value::null).asString();
                 reqContainer.errorWrapper.ErrorDetails = reqContainer.responseJson.get("errorDetails", Json::Value::null);
             }

--- a/targets/XPlatCppSdk/source/code/source/playfab/PlayFabWinHttpPlugin.cpp
+++ b/targets/XPlatCppSdk/source/code/source/playfab/PlayFabWinHttpPlugin.cpp
@@ -318,6 +318,7 @@ namespace PlayFab
             reqContainer.errorWrapper.HttpStatus = reqContainer.responseJson.get("status", Json::Value::null).asString();
             reqContainer.errorWrapper.Data = reqContainer.responseJson.get("data", Json::Value::null);
             reqContainer.errorWrapper.ErrorName = reqContainer.responseJson.get("error", Json::Value::null).asString();
+            reqContainer.errorWrapper.ErrorCode = static_cast<PlayFab::PlayFabErrorCode>(reqContainer.responseJson.get("errorCode", Json::Value::null).asInt());
             reqContainer.errorWrapper.ErrorMessage = reqContainer.responseJson.get("errorMessage", Json::Value::null).asString();
             reqContainer.errorWrapper.ErrorDetails = reqContainer.responseJson.get("errorDetails", Json::Value::null);
         }

--- a/targets/XPlatCppSdk/source/code/source/playfab/PlayFabWinHttpPlugin.cpp
+++ b/targets/XPlatCppSdk/source/code/source/playfab/PlayFabWinHttpPlugin.cpp
@@ -318,7 +318,7 @@ namespace PlayFab
             reqContainer.errorWrapper.HttpStatus = reqContainer.responseJson.get("status", Json::Value::null).asString();
             reqContainer.errorWrapper.Data = reqContainer.responseJson.get("data", Json::Value::null);
             reqContainer.errorWrapper.ErrorName = reqContainer.responseJson.get("error", Json::Value::null).asString();
-            reqContainer.errorWrapper.ErrorCode = static_cast<PlayFab::PlayFabErrorCode>(reqContainer.responseJson.get("errorCode", Json::Value::null).asInt());
+            reqContainer.errorWrapper.ErrorCode = static_cast<PlayFabErrorCode>(reqContainer.responseJson.get("errorCode", Json::Value::null).asInt());
             reqContainer.errorWrapper.ErrorMessage = reqContainer.responseJson.get("errorMessage", Json::Value::null).asString();
             reqContainer.errorWrapper.ErrorDetails = reqContainer.responseJson.get("errorDetails", Json::Value::null);
         }


### PR DESCRIPTION
When we parse messages from playfab, we have at least 2 segments the client side handles for "CURL failed" and then "json failed" but if CURL doesn't fail AND json doesn't fail, there is still a chance there was a 500 error on the server that should be re-iterated back to the user.

This is W.R.T. https://dev.azure.com/playfab/PlayFab/_workitems/edit/27034