### PR TITLE
Adding a user exception callback for background threads

### DIFF
--- a/targets/XPlatCppSdk/source/code/include/playfab/PlayFabError.h.ejs
+++ b/targets/XPlatCppSdk/source/code/include/playfab/PlayFabError.h.ejs
@@ -40,4 +40,5 @@ namespace PlayFab
     };
 
     typedef std::function<void(const PlayFabError& error, void* customData)> ErrorCallback;
+    typedef std::function<void(const std::exception& exception)> ExceptionCallback;
 }

--- a/targets/XPlatCppSdk/source/code/include/playfab/PlayFabError.h.ejs
+++ b/targets/XPlatCppSdk/source/code/include/playfab/PlayFabError.h.ejs
@@ -40,5 +40,5 @@ namespace PlayFab
     };
 
     typedef std::function<void(const PlayFabError& error, void* customData)> ErrorCallback;
-    typedef std::function<void(const std::exception& exception)> ExceptionCallback;
+    typedef std::function<void(std::exception exception)> ExceptionCallback;
 }

--- a/targets/XPlatCppSdk/source/code/include/playfab/PlayFabEventPipeline.h
+++ b/targets/XPlatCppSdk/source/code/include/playfab/PlayFabEventPipeline.h
@@ -83,7 +83,7 @@ namespace PlayFab
         PlayFabEventBuffer buffer;
         std::thread workerThread;
         std::atomic<bool> isWorkerThreadRunning;
-        std::mutex userCallbackMutex;
+        std::mutex userExceptionCallbackMutex;
         ExceptionCallback userExceptionCallback;
     };
 }

--- a/targets/XPlatCppSdk/source/code/include/playfab/PlayFabEventPipeline.h
+++ b/targets/XPlatCppSdk/source/code/include/playfab/PlayFabEventPipeline.h
@@ -8,6 +8,7 @@
 #include <playfab/PlayFabEvent.h>
 #include <playfab/PlayFabEventBuffer.h>
 #include <playfab/PlayFabAuthenticationContext.h>
+#include <mutex>
 
 namespace PlayFab
 {
@@ -58,6 +59,8 @@ namespace PlayFab
         virtual void Start() override;
         virtual void IntakeEvent(std::shared_ptr<const IPlayFabEmitEventRequest> request) override;
 
+        void SetExceptionCallback(ExceptionCallback callback);
+
     protected:
         virtual void SendBatch(size_t& batchCounter);
 
@@ -80,6 +83,8 @@ namespace PlayFab
         PlayFabEventBuffer buffer;
         std::thread workerThread;
         std::atomic<bool> isWorkerThreadRunning;
+        std::mutex userCallbackMutex;
+        ExceptionCallback userExceptionCallback;
     };
 }
 

--- a/targets/XPlatCppSdk/source/code/include/playfab/PlayFabPluginManager.h
+++ b/targets/XPlatCppSdk/source/code/include/playfab/PlayFabPluginManager.h
@@ -2,6 +2,7 @@
 
 #include <playfab/PlayFabCallRequestContainer.h>
 #include <playfab/PlayFabError.h>
+#include <mutex>
 #include <unordered_map>
 
 namespace PlayFab
@@ -95,6 +96,12 @@ namespace PlayFab
         // If a plugin with specified contract and optional instance name already exists, it will be replaced with specified instance.
         void SetPluginInstance(std::shared_ptr<IPlayFabPlugin> plugin, const PlayFabPluginContract contract, const std::string& instanceName = "");
 
+        // Sets a custom exception handler for any possible background thread exceptions
+        void SetExceptionHandler(ExceptionCallback exceptionHandler);
+
+        // Called when an exception occured on a worker thread
+        void HandleException(const std::exception&);
+
     private:
         std::shared_ptr<IPlayFabPlugin> GetPluginInternal(const PlayFabPluginContract contract, const std::string& instanceName);
         void SetPluginInternal(std::shared_ptr<IPlayFabPlugin> plugin, const PlayFabPluginContract contract, const std::string& instanceName);
@@ -105,5 +112,7 @@ namespace PlayFab
 
     private:
         std::map<const std::pair<const PlayFabPluginContract, const std::string>, std::shared_ptr<IPlayFabPlugin>> plugins;
+        std::mutex userExceptionCallbackMutex;
+        ExceptionCallback userExceptionCallback;
     };
 }

--- a/targets/XPlatCppSdk/source/code/include/playfab/PlayFabWinHttpPlugin.h
+++ b/targets/XPlatCppSdk/source/code/include/playfab/PlayFabWinHttpPlugin.h
@@ -25,6 +25,8 @@ namespace PlayFab
         virtual void MakePostRequest(std::unique_ptr<CallRequestContainerBase> requestContainer) override;
         virtual size_t Update() override;
 
+        void SetExceptionHandler(ExceptionCallback exceptionHandler);
+
     protected:
         virtual void ExecuteRequest(std::unique_ptr<CallRequestContainer> requestContainer);
         virtual std::string GetUrl(CallRequestContainer& requestContainer) const;
@@ -42,5 +44,6 @@ namespace PlayFab
         int activeRequestCount;
         std::deque<std::unique_ptr<CallRequestContainerBase>> pendingRequests;
         std::deque<std::unique_ptr<CallRequestContainerBase>> pendingResults;
+        ExceptionCallback userExceptionCallback;
     };
 }

--- a/targets/XPlatCppSdk/source/code/include/playfab/PlayFabWinHttpPlugin.h
+++ b/targets/XPlatCppSdk/source/code/include/playfab/PlayFabWinHttpPlugin.h
@@ -25,8 +25,6 @@ namespace PlayFab
         virtual void MakePostRequest(std::unique_ptr<CallRequestContainerBase> requestContainer) override;
         virtual size_t Update() override;
 
-        void SetExceptionHandler(ExceptionCallback exceptionHandler);
-
     protected:
         virtual void ExecuteRequest(std::unique_ptr<CallRequestContainer> requestContainer);
         virtual std::string GetUrl(CallRequestContainer& requestContainer) const;
@@ -44,6 +42,5 @@ namespace PlayFab
         int activeRequestCount;
         std::deque<std::unique_ptr<CallRequestContainerBase>> pendingRequests;
         std::deque<std::unique_ptr<CallRequestContainerBase>> pendingResults;
-        ExceptionCallback userExceptionCallback;
     };
 }

--- a/targets/XPlatCppSdk/source/code/source/playfab/PlayFabCurlHttpPlugin.cpp
+++ b/targets/XPlatCppSdk/source/code/source/playfab/PlayFabCurlHttpPlugin.cpp
@@ -29,38 +29,45 @@ namespace PlayFab
 
     void PlayFabCurlHttpPlugin::WorkerThread()
     {
-        size_t queueSize;
-
-        while (this->threadRunning)
+        try
         {
-            std::unique_ptr<CallRequestContainerBase> requestContainer = nullptr;
+            size_t queueSize;
 
-            { // LOCK httpRequestMutex
-                std::unique_lock<std::mutex> lock(this->httpRequestMutex);
-
-                queueSize = this->pendingRequests.size();
-                if (queueSize != 0)
-                {
-                    requestContainer = std::move(this->pendingRequests[0]);
-                    this->pendingRequests.pop_front();
-                }
-            } // UNLOCK httpRequestMutex
-
-            if (queueSize == 0)
+            while (this->threadRunning)
             {
-                std::this_thread::sleep_for(std::chrono::milliseconds(10));
-                continue;
-            }
+                std::unique_ptr<CallRequestContainerBase> requestContainer = nullptr;
 
-            if (requestContainer != nullptr)
-            {
-                CallRequestContainer* requestContainerPtr = dynamic_cast<CallRequestContainer*>(requestContainer.get());
-                if (requestContainerPtr != nullptr)
+                { // LOCK httpRequestMutex
+                    std::unique_lock<std::mutex> lock(this->httpRequestMutex);
+
+                    queueSize = this->pendingRequests.size();
+                    if (queueSize != 0)
+                    {
+                        requestContainer = std::move(this->pendingRequests[0]);
+                        this->pendingRequests.pop_front();
+                    }
+                } // UNLOCK httpRequestMutex
+
+                if (queueSize == 0)
                 {
-                    requestContainer.release();
-                    ExecuteRequest(std::unique_ptr<CallRequestContainer>(requestContainerPtr));
+                    std::this_thread::sleep_for(std::chrono::milliseconds(10));
+                    continue;
+                }
+
+                if (requestContainer != nullptr)
+                {
+                    CallRequestContainer* requestContainerPtr = dynamic_cast<CallRequestContainer*>(requestContainer.get());
+                    if (requestContainerPtr != nullptr)
+                    {
+                        requestContainer.release();
+                        ExecuteRequest(std::unique_ptr<CallRequestContainer>(requestContainerPtr));
+                    }
                 }
             }
+        }
+        catch (std::exception ex)
+        {
+            PlayFabPluginManager::GetInstance().HandleException(ex);
         }
     }
 

--- a/targets/XPlatCppSdk/source/code/source/playfab/PlayFabEventPipeline.cpp
+++ b/targets/XPlatCppSdk/source/code/source/playfab/PlayFabEventPipeline.cpp
@@ -104,7 +104,7 @@ namespace PlayFab
     void PlayFabEventPipeline::SetExceptionCallback(ExceptionCallback ex)
     {
         { // LOCK userCallbackMutex
-            std::unique_lock<std::mutex> lock(userCallbackMutex);
+            std::unique_lock<std::mutex> lock(userExceptionCallbackMutex);
             userExceptionCallback = ex;
         } // UNLOCK userCallbackMutex
     }
@@ -182,7 +182,7 @@ namespace PlayFab
             this->isWorkerThreadRunning = false;
 
             { // LOCK userCallbackMutex
-                std::unique_lock<std::mutex> lock(userCallbackMutex);
+                std::unique_lock<std::mutex> lock(userExceptionCallbackMutex);
                 if (userExceptionCallback)
                 {
                     userExceptionCallback(ex);

--- a/targets/XPlatCppSdk/source/code/source/playfab/PlayFabIXHR2HttpPlugin.cpp
+++ b/targets/XPlatCppSdk/source/code/source/playfab/PlayFabIXHR2HttpPlugin.cpp
@@ -28,38 +28,45 @@ namespace PlayFab
 
     void PlayFabIXHR2HttpPlugin::WorkerThread()
     {
-        size_t queueSize;
-
-        while (this->threadRunning)
+        try
         {
-            std::unique_ptr<CallRequestContainerBase> requestContainer = nullptr;
+            size_t queueSize;
 
-            { // LOCK httpRequestMutex
-                std::unique_lock<std::mutex> lock(this->httpRequestMutex);
-
-                queueSize = this->pendingRequests.size();
-                if (queueSize != 0)
-                {
-                    requestContainer = std::move(this->pendingRequests[0]);
-                    this->pendingRequests.pop_front();
-                }
-            } // UNLOCK httpRequestMutex
-
-            if (queueSize == 0)
+            while (this->threadRunning)
             {
-                std::this_thread::sleep_for(std::chrono::milliseconds(10));
-                continue;
-            }
+                std::unique_ptr<CallRequestContainerBase> requestContainer = nullptr;
 
-            if (requestContainer != nullptr)
-            {
-                CallRequestContainer* requestContainerPtr = dynamic_cast<CallRequestContainer*>(requestContainer.get());
-                if (requestContainerPtr != nullptr)
+                { // LOCK httpRequestMutex
+                    std::unique_lock<std::mutex> lock(this->httpRequestMutex);
+
+                    queueSize = this->pendingRequests.size();
+                    if (queueSize != 0)
+                    {
+                        requestContainer = std::move(this->pendingRequests[0]);
+                        this->pendingRequests.pop_front();
+                    }
+                } // UNLOCK httpRequestMutex
+
+                if (queueSize == 0)
                 {
-                    requestContainer.release();
-                    ExecuteRequest(std::unique_ptr<CallRequestContainer>(requestContainerPtr));
+                    std::this_thread::sleep_for(std::chrono::milliseconds(10));
+                    continue;
+                }
+
+                if (requestContainer != nullptr)
+                {
+                    CallRequestContainer* requestContainerPtr = dynamic_cast<CallRequestContainer*>(requestContainer.get());
+                    if (requestContainerPtr != nullptr)
+                    {
+                        requestContainer.release();
+                        ExecuteRequest(std::unique_ptr<CallRequestContainer>(requestContainerPtr));
+                    }
                 }
             }
+        }
+        catch (std::exception ex)
+        {
+            PlayFabPluginManager::GetInstance().HandleException(ex);
         }
     }
 

--- a/targets/XPlatCppSdk/source/code/source/playfab/PlayFabPluginManager.cpp
+++ b/targets/XPlatCppSdk/source/code/source/playfab/PlayFabPluginManager.cpp
@@ -99,4 +99,23 @@ namespace PlayFab
         return std::make_shared<OneDSCurlHttpPlugin>();
 #endif // PLAYFAB_PLATFORM_XBOX
     }
+
+    void PlayFabPluginManager::HandleException(const std::exception& ex)
+    {
+        { // LOCK userExceptionCallbackMutex
+            std::unique_lock<std::mutex> lock(userExceptionCallbackMutex);
+            if (userExceptionCallback)
+            {
+                userExceptionCallback(ex);
+            }
+        } // UNLOCK userExceptionCallbackMutex
+    }
+
+    void PlayFabPluginManager::SetExceptionHandler(ExceptionCallback exceptionCallback)
+    {
+        { // LOCK userExceptionCallbackMutex
+            std::unique_lock<std::mutex> lock(userExceptionCallbackMutex);
+            userExceptionCallback = exceptionCallback;
+        } // UNLOCK userExceptionCallbackMutex
+    }
 }

--- a/targets/XPlatCppSdk/source/code/source/playfab/PlayFabWinHttpPlugin.cpp
+++ b/targets/XPlatCppSdk/source/code/source/playfab/PlayFabWinHttpPlugin.cpp
@@ -70,13 +70,7 @@ namespace PlayFab
         }
         catch (std::exception ex)
         {
-            { // LOCK httpRequestMutex
-                std::unique_lock<std::mutex> lock(httpRequestMutex);
-                if (userExceptionCallback)
-                {
-                    userExceptionCallback(ex);
-                }
-            } // UNLOCK httpRequestMutex
+            PlayFabPluginManager::GetInstance().HandleException(ex);
         }
     }
 
@@ -394,13 +388,5 @@ namespace PlayFab
             std::unique_lock<std::mutex> lock(httpRequestMutex);
             return activeRequestCount;
         }
-    }
-
-    void PlayFabWinHttpPlugin::SetExceptionHandler(ExceptionCallback callback)
-    {
-        { // LOCK httpRequestMutex
-            std::unique_lock<std::mutex> lock(httpRequestMutex);
-            userExceptionCallback = callback;
-        } // UNLOCK httpRequestMutex
     }
 }


### PR DESCRIPTION
we can potentially throw an exception on a background thread. We should allow users to handle these exceptions as they wish.