### PR TITLE
Reprioritizing netstandard2 as the first TargetFramework

### DIFF
--- a/targets/csharp/templates/PlayFabSDK.csproj.ejs
+++ b/targets/csharp/templates/PlayFabSDK.csproj.ejs
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard1.1;netstandard2.0;net45;portable45-net45+win8+wpa81</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;netstandard1.1;net45;portable45-net45+win8+wpa81</TargetFrameworks>
     <RootNamespace>PlayFab<%- libname %>SDK</RootNamespace>
     <AssemblyName>PlayFab<%- libname %>SDK</AssemblyName>
     <DefaultLanguage>en-US</DefaultLanguage>


### PR DESCRIPTION
… in order to facilitate Xamarin iOS builds