### PR TITLE
Fixed compilation error in Unity SDK when runtime 3.5 is used

### DIFF
--- a/targets/unity-v2/source/Shared/Internal/Util.cs
+++ b/targets/unity-v2/source/Shared/Internal/Util.cs
@@ -128,7 +128,13 @@ namespace PlayFab.Internal
                 JsonObject envJson = PlayFabSimpleJson.DeserializeObject<JsonObject>(envFileContent);
                 try
                 {
-                    return envJson[propertyKey]?.ToString();
+                    object result;
+                    if (envJson.TryGetValue(propertyKey, out result))
+                    {
+                        return result == null ? null : result.ToString();
+                    }
+
+                    return null;
                 } 
                 catch (KeyNotFoundException)
                 {


### PR DESCRIPTION
That syntax is not supported when Unity is using .NET 3.5 runtime