### PR TITLE
Support for various local debug URI structure (unity)

### DIFF
--- a/targets/unity-v2/make.js
+++ b/targets/unity-v2/make.js
@@ -487,7 +487,7 @@ function getCustomApiLogic(tabbing, apiCall)
             tabbing + "if (!string.IsNullOrEmpty(localApiServerString))\n" +
             tabbing + "{\n" +
             tabbing + "    var baseUri = new Uri(localApiServerString);\n" +
-            tabbing + "    var fullUri = new Uri(baseUri, \"" + apiCall.url + "\");\n" +
+            tabbing + "    var fullUri = new Uri(baseUri, \"" + apiCall.url + "\".TrimStart('/'));\n" +
             tabbing + "    PlayFabHttp.MakeApiCallWithFullUri(fullUri.AbsoluteUri, request, AuthType.EntityToken, resultCallback, errorCallback, customData, extraHeaders);\n" +
             tabbing + "    return;\n" + 
             tabbing + "}\n";


### PR DESCRIPTION
Change the unity local debugging code so that now users can have whatever way of base path they wish to pick in the `playfab.local.settings.json` file and still have local debug URI redirection work properly.