### PR TITLE
Fix for Unity Jenkins failure

### DIFF
--- a/targets/unity-v2/source/Shared/Internal/PlayFabHttp/OneDsUnityHttpPlugin.cs
+++ b/targets/unity-v2/source/Shared/Internal/PlayFabHttp/OneDsUnityHttpPlugin.cs
@@ -21,7 +21,9 @@ namespace PlayFab.Internal
             
             string currentTimestampString = Microsoft.Applications.Events.Utils.MsFrom1970().ToString();
             extraHeaders.Add("sdk-version", "OCT_C#-0.11.1.0");
+#if !UNITY_WSA && !UNITY_WP8 && !UNITY_WEBGL
             extraHeaders.Add("Content-Encoding", "gzip");
+#endif
             extraHeaders.Add("Content-Type", "application/bond-compact-binary");
             extraHeaders.Add("Upload-Time", currentTimestampString);
             extraHeaders.Add("client-time-epoch-millis", currentTimestampString);

--- a/targets/unity-v2/source/Shared/Internal/PlayFabHttp/OneDsWebRequestPlugin.cs
+++ b/targets/unity-v2/source/Shared/Internal/PlayFabHttp/OneDsWebRequestPlugin.cs
@@ -19,7 +19,9 @@ namespace PlayFab.Internal
                 httpRequest.Method = "POST";
                 httpRequest.ContentType = "application/bond-compact-binary";
                 httpRequest.Headers.Add("sdk-version", "OCT_C#-0.11.1.0");
+#if !UNITY_WSA && !UNITY_WP8 && !UNITY_WEBGL
                 httpRequest.Headers.Add("Content-Encoding", "gzip");
+#endif
                 httpRequest.Headers.Add("Upload-Time", currentTimestampString);
                 httpRequest.Headers.Add("client-time-epoch-millis", currentTimestampString);
                 httpRequest.Headers.Add("Client-Id", "NO_AUTH");

--- a/targets/unity-v2/source/Shared/Internal/PlayFabHttp/OneDsWwwPlugin.cs
+++ b/targets/unity-v2/source/Shared/Internal/PlayFabHttp/OneDsWwwPlugin.cs
@@ -38,7 +38,9 @@ namespace PlayFab.Internal
 
             string currentTimestampString = Microsoft.Applications.Events.Utils.MsFrom1970().ToString();
             www.SetRequestHeader("sdk-version", "OCT_C#-0.11.1.0");
+#if !UNITY_WSA && !UNITY_WP8 && !UNITY_WEBGL
             www.SetRequestHeader("Content-Encoding", "gzip");
+#endif
             www.SetRequestHeader("Content-Type", "application/bond-compact-binary");
             www.SetRequestHeader("Upload-Time", currentTimestampString);
             www.SetRequestHeader("client-time-epoch-millis", currentTimestampString);

--- a/targets/unity-v2/source/Shared/Public/OneDSEventsAPI.cs
+++ b/targets/unity-v2/source/Shared/Public/OneDSEventsAPI.cs
@@ -3,7 +3,9 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Threading.Tasks;
+#if !UNITY_WSA && !UNITY_WP8
 using Ionic.Zlib;
+#endif
 using Microsoft.Applications.Events;
 using PlayFab.EventsModels;
 using PlayFab.Internal;
@@ -119,6 +121,7 @@ namespace PlayFab
                     BondHelper.Serialize(csEvent, ms);
                 }
 
+#if !UNITY_WSA && !UNITY_WP8 && !UNITY_WEBGL
                 ms.Position = 0;
                 byte[] packageBytes = ms.ToArray();
                 ms.SetLength(0);
@@ -128,6 +131,7 @@ namespace PlayFab
                 {
                     gZipStream.Write(packageBytes, 0, packageBytes.Length);
                 }
+#endif
 
                 serializedBatch = ms.ToArray();
             }


### PR DESCRIPTION
- wrapped ionic compression calls into mutators (same thing as we have in our HTTP plugins)