### PR TITLE
Fix for Unity in Jenkins, part 2

### DIFF
--- a/targets/unity-v2/source/Shared/External/aria/Utils.cs
+++ b/targets/unity-v2/source/Shared/External/aria/Utils.cs
@@ -32,9 +32,8 @@ namespace Microsoft.Applications.Events
             try
             {
                 var endIndex = tenant.IndexOf("-", StringComparison.Ordinal);
-                var tenantId = string.Empty;
                 if (endIndex > 0)
-                    return tenantId = tenant.Substring(0, endIndex);
+                    return tenant.Substring(0, endIndex);
             }
             catch
             {

--- a/targets/unity-v2/source/Shared/Internal/OneDsUtility.cs
+++ b/targets/unity-v2/source/Shared/Internal/OneDsUtility.cs
@@ -62,7 +62,7 @@ namespace PlayFab.Internal
                         error.HttpCode = (int) httpCode;
                         error.HttpStatus = httpResponseString;
                         error.Error = PlayFabErrorCode.JsonParseError;
-                        error.ErrorMessage = "Failed to parse response from OneDS server";
+                        error.ErrorMessage = "Failed to parse response from OneDS server: " + e.Message;
                         callback?.Invoke(error);
                     }
                 }

--- a/targets/unity-v2/source/Shared/Public/PlayFabEventAPI.cs
+++ b/targets/unity-v2/source/Shared/Public/PlayFabEventAPI.cs
@@ -15,8 +15,6 @@ namespace PlayFab
         /// Gets the event router
         /// </summary>
         public IPlayFabEventRouter EventRouter { get; private set; }
-        
-        private ILogger logger;
 
         /// <summary>
         /// Default constructor
@@ -24,7 +22,6 @@ namespace PlayFab
         public PlayFabEventAPI(ILogger logger = null)
         {
             if(logger == null) logger = new DebugLogger();
-            this.logger = logger;
             this.EventRouter = new PlayFabEventRouter(logger); 
         }
 

--- a/targets/unity-v2/source/Shared/Public/PluginManager.cs
+++ b/targets/unity-v2/source/Shared/Public/PluginManager.cs
@@ -100,19 +100,24 @@ namespace PlayFab
                 transport = new PlayFabWebRequest();
 #endif
 
-#if !UNITY_2018_2_OR_NEWER // PlayFabWww will throw warnings as Unity has deprecated Www
-            if (PlayFabSettings.RequestType == WebRequestType.UnityWww)
-            {
-                transport = new PlayFabWww();
-            }
-#endif
-
+#if UNITY_2018_2_OR_NEWER // PlayFabWww will throw warnings as Unity has deprecated Www
             if (transport == null)
                 transport = new PlayFabUnityHttp();
+#elif UNITY_2017_2_OR_NEWER
+            if (PlayFabSettings.RequestType == WebRequestType.UnityWww)
+                transport = new PlayFabWww();
+            
+            if (transport == null)
+                transport = new PlayFabUnityHttp();
+#else
+            if (transport == null)
+                transport = new PlayFabWww();
+#endif
 
             return transport;
         }
-#if NET_4_6   
+
+#if NET_4_6
         private IOneDSTransportPlugin CreateOneDSTransportPlugin()
         {
             IOneDSTransportPlugin transport = null;
@@ -120,12 +125,20 @@ namespace PlayFab
             if (PlayFabSettings.RequestType == WebRequestType.HttpWebRequest)
                 transport = new OneDsWebRequestPlugin();
 #endif
-#if !UNITY_2018_2_OR_NEWER
+
+#if UNITY_2018_2_OR_NEWER // OneDsWwwPlugin will throw warnings as Unity has deprecated Www
+            if (transport == null)
+                transport = new OneDsUnityHttpPlugin();
+#elif UNITY_2017_2_OR_NEWER
             if (PlayFabSettings.RequestType == WebRequestType.UnityWww)
                 transport = new OneDsWwwPlugin();
-#endif
-            if(transport == null)
+            
+            if (transport == null)
                 transport = new OneDsUnityHttpPlugin();
+#else
+            if (transport == null)
+                transport = new OneDsWwwPlugin();
+#endif
 
             return transport;
         }


### PR DESCRIPTION
- Prior code had a compilation bug for versions of Unity earlier than 2017.2 (PlayFabUnityHttp is available only after 2017.2, so earlier Unity could not find it)
- Fixed a few yellow warnings in Unity