### PR TITLE
Fix Unity in Jenkins 3: compilation errors in older versions of Unity

### DIFF
--- a/targets/unity-v2/source/Shared/Internal/Util.cs
+++ b/targets/unity-v2/source/Shared/Internal/Util.cs
@@ -101,6 +101,7 @@ namespace PlayFab.Internal
             return _sb.ToString();
         }
 
+#if UNITY_2017_1_OR_NEWER
         internal static string GetLocalSettingsFileProperty(string propertyKey)
         {
             string envFileContent = null;
@@ -143,5 +144,6 @@ namespace PlayFab.Internal
             }
             return string.Empty;
         }
+#endif
     }
 }

--- a/targets/unity-v2/source/Shared/Public/PlayFabSettings.cs.ejs
+++ b/targets/unity-v2/source/Shared/Public/PlayFabSettings.cs.ejs
@@ -160,7 +160,11 @@ namespace PlayFab
         {
             get
             {
+#if UNITY_2017_1_OR_NEWER
                 return _localApiServer ?? PlayFabUtil.GetLocalSettingsFileProperty("LocalApiServer");
+#else
+                return _localApiServer;
+#endif
             }
 
             set 


### PR DESCRIPTION
- Fix a compilation error introduced recently by our friends from services team:
method PlayFabUtil.GetLocalSettingsFileProperty contains code incompatible with earlier versions of Unity. Fix: exclude that code path from older versions of Unity without breaking the API