### PR TITLE
Add Unreal CPP & BP SDK support for Local Debugging Azure Functions

### DIFF
--- a/targets/UnrealMarketplacePlugin/makeBp.js
+++ b/targets/UnrealMarketplacePlugin/makeBp.js
@@ -44,6 +44,8 @@ function makeApiFiles(api, copyright, apiOutputDir, sourceDir, libName) {
         getPropertySerialization: getPropertySerialization,
         getPropertyDeserialization: getPropertyDeserialization,
         getDataTypeSafeName: getDataTypeSafeName,
+        getCustomApiAssignmentLogic: getCustomApiAssignmentLogic,
+        getCustomApiActivationUrlLogic: getCustomApiActivationUrlLogic,
         hasClientOptions: getAuthMechanisms([api]).includes("SessionTicket"),
         libName: libName,
         sdkVersion: sdkGlobals.sdkVersion
@@ -295,4 +297,30 @@ function getAuthBools(tabbing, apiCall) {
         output += tabbing + "manager->returnsEntityToken = true;\n";
 
     return output;
+}
+
+function getCustomApiAssignmentLogic(tabbing, api, apiCall) {
+    if (api.name === "CloudScript" && apiCall.name === "ExecuteFunction")
+    {
+        return tabbing + "// Check for local debugging\n"
+            + tabbing + "FString localApiServer = PlayFabCommon::PlayFabCommonUtils::GetLocalSettingsFileProperty(TEXT(\"LocalApiServer\"));\n"
+            + tabbing + "if (!localApiServer.IsEmpty())\n"
+            + tabbing + "{\n"
+            + tabbing + "    FString endpoint = TEXT(\"" + apiCall.url + "\");\n"
+            + tabbing + "    endpoint.RemoveFromStart(TEXT(\"/\"));\n"
+            + tabbing + "    FString url = localApiServer + endpoint;\n"
+            + tabbing + "    manager->PlayFabRequestFullURL = url;\n"
+            + tabbing + "}\n"
+    }
+}
+
+function getCustomApiActivationUrlLogic(api) {
+    if (api.name === "CloudScript")
+    {
+        return "RequestUrl = this->PlayFabRequestFullURL.IsEmpty() ? pfSettings->getUrl(PlayFabRequestURL) : this->PlayFabRequestFullURL;\n"
+    }
+    else 
+    {
+        return "RequestUrl = pfSettings->getUrl(PlayFabRequestURL);\n"
+    }
 }

--- a/targets/UnrealMarketplacePlugin/makeCpp.js
+++ b/targets/UnrealMarketplacePlugin/makeCpp.js
@@ -39,6 +39,7 @@ function makeApi(api, copyright, sourceDir, apiOutputDir, subdir) {
         generateApiSummary: generateApiSummary,
         getAuthParams: getAuthParams,
         getRequestActions: getRequestActions,
+        getCustomApiLogic: getCustomApiLogic,
         getResultActions: getResultActions,
         getUrlAccessor: getUrlAccessor,
         hasClientOptions: getAuthMechanisms([api]).includes("SessionTicket"),
@@ -658,6 +659,20 @@ function getRequestActions(tabbing, apiCall, isInstanceApi) {
             + tabbing + "    UE_LOG(LogPlayFabCpp, Error, TEXT(\"You must log in before calling this function\"));\n"
             + tabbing + "}\n";
     return "";
+}
+
+function getCustomApiLogic(tabbing, api, apiCall, isInstanceApi) {
+    if (api.name === "CloudScript" && apiCall.name === "ExecuteFunction")
+        return tabbing + "FString localApiServer = PlayFabSettings::GetLocalApiServer();\n"
+            + tabbing + "if (!localApiServer.IsEmpty())\n"
+            + tabbing + "{\n"
+            + tabbing + "    FString endpoint = TEXT(\"" + apiCall.url + "\");\n"
+            + tabbing + "    endpoint.RemoveFromStart(TEXT(\"/\"));\n"
+            + tabbing + "    FString url = localApiServer + endpoint;\n"
+            + tabbing + "    auto HttpRequest = PlayFabRequestHandler::SendRequest(url, request.toJSONString(), TEXT(\"X-EntityToken\"), !request.AuthenticationContext.IsValid() ? PlayFabSettings::GetEntityToken() : request.AuthenticationContext->GetEntityToken());\n"
+            + tabbing + "    HttpRequest->OnProcessRequestComplete().BindRaw(this, &UPlayFab" + api.name + (isInstanceApi ? "Instance" : "") + "API::On" + apiCall.name + "Result, SuccessDelegate, ErrorDelegate);\n"
+            + tabbing + "    return HttpRequest->ProcessRequest();\n"
+            + tabbing + "}\n"
 }
 
 function getResultActions(tabbing, apiCall, isInstanceApi) {

--- a/targets/UnrealMarketplacePlugin/source/PlayFab/Source/PlayFabCommon/Private/PlayFabCommmonUtils.cpp.ejs
+++ b/targets/UnrealMarketplacePlugin/source/PlayFab/Source/PlayFabCommon/Private/PlayFabCommmonUtils.cpp.ejs
@@ -1,0 +1,46 @@
+﻿<%- copyright %>
+
+#include "PlayFabCommonUtils.h"
+
+using namespace PlayFabCommon;
+
+FString PlayFabCommonUtils::GetTempDir()
+{
+    FString vars[] = { TEXT("TEMPDIR"), TEXT("TEMP"), TEXT("TMP") };
+    for (FString envVar : vars)
+    {
+        FString tempDir = FPlatformMisc::GetEnvironmentVariable((TEXT("%s"), *envVar));
+        if (!tempDir.IsEmpty())
+        {
+            return tempDir;
+        }
+    }
+    return FString();
+}
+
+FString PlayFabCommonUtils::GetLocalSettingsFileContent()
+{
+    FString tempDirPath = PlayFabCommonUtils::GetTempDir();
+    FString localSettingsFilePath = FPaths::Combine(tempDirPath, TEXT("playfab.local.settings.json"));
+    FString localSettingsFileContent = "";
+    return FFileHelper::LoadFileToString(localSettingsFileContent, *localSettingsFilePath)
+        ? localSettingsFileContent
+        : FString();
+}
+
+TSharedPtr<FJsonObject> PlayFabCommonUtils::GetLocalSettingsFileJson()
+{
+    FString fileContent = PlayFabCommonUtils::GetLocalSettingsFileContent();
+    TSharedPtr<FJsonObject> jsonObject = MakeShareable(new FJsonObject());
+    TSharedRef<TJsonReader<>> jsonReader = TJsonReaderFactory<>::Create(fileContent);
+    return (FJsonSerializer::Deserialize(jsonReader, jsonObject) && jsonObject.IsValid())
+        ? jsonObject
+        : MakeShareable(new FJsonObject());
+}
+
+FString PlayFabCommonUtils::GetLocalSettingsFileProperty(const FString& propertyKey)
+{
+    TSharedPtr<FJsonObject> jsonObject = PlayFabCommonUtils::GetLocalSettingsFileJson();
+    FString outString;
+    return jsonObject->TryGetStringField(propertyKey, outString) ? outString : FString();
+}

--- a/targets/UnrealMarketplacePlugin/source/PlayFab/Source/PlayFabCommon/Public/PlayFabCommonSettings.h.ejs
+++ b/targets/UnrealMarketplacePlugin/source/PlayFab/Source/PlayFabCommon/Public/PlayFabCommonSettings.h.ejs
@@ -38,7 +38,7 @@ namespace PlayFabCommon
         {
             if (serverURL.Len() == 0)
             {
-                serverURL = TEXT("https://") + (!verticalName.IsEmpty() ? verticalName : titleId) + productionEnvironmentURL;
+                serverURL = TEXT("https://") + titleId + (verticalName.IsEmpty() ? "" : "." + verticalName) + productionEnvironmentURL;
             }
             return serverURL + callPath + TEXT("?sdk=") + versionString;
         }

--- a/targets/UnrealMarketplacePlugin/source/PlayFab/Source/PlayFabCommon/Public/PlayFabCommonUtils.h.ejs
+++ b/targets/UnrealMarketplacePlugin/source/PlayFab/Source/PlayFabCommon/Public/PlayFabCommonUtils.h.ejs
@@ -1,0 +1,21 @@
+﻿<%- copyright %>
+
+#pragma once
+
+#include "CoreMinimal.h"
+#include "FileHelper.h"
+#include "Misc/Paths.h"
+#include "Json.h"
+
+namespace PlayFabCommon
+{
+    class PLAYFABCOMMON_API PlayFabCommonUtils
+    {
+    private:
+        static FString GetTempDir();
+        static FString GetLocalSettingsFileContent();
+        static TSharedPtr<FJsonObject> GetLocalSettingsFileJson();
+    public:
+        static FString GetLocalSettingsFileProperty(const FString& propertyKey);
+    };
+}

--- a/targets/UnrealMarketplacePlugin/source/PlayFab/Source/PlayFabCpp/Private/Core/PlayFabSettings.cpp.ejs
+++ b/targets/UnrealMarketplacePlugin/source/PlayFab/Source/PlayFabCpp/Private/Core/PlayFabSettings.cpp.ejs
@@ -2,6 +2,7 @@
 
 #include "PlayFabSettings.h"
 #include "PlayFabCommon.h"
+#include "PlayFabCommonUtils.h"
 
 namespace PlayFab
 {
@@ -56,6 +57,10 @@ namespace PlayFab
     FString PlayFabSettings::GetUrl(const FString& callPath)
     {
         return IPlayFabCommonModuleInterface::Get().GetUrl(callPath);
+    }
+    FString PlayFabSettings::GetLocalApiServer()
+    {
+        return PlayFabCommon::PlayFabCommonUtils::GetLocalSettingsFileProperty(TEXT("LocalApiServer"));
     }
 
     // Setters

--- a/targets/UnrealMarketplacePlugin/source/PlayFab/Source/PlayFabCpp/Public/Core/PlayFabSettings.h.ejs
+++ b/targets/UnrealMarketplacePlugin/source/PlayFab/Source/PlayFabCpp/Public/Core/PlayFabSettings.h.ejs
@@ -27,6 +27,7 @@ namespace PlayFab
         static FString GetAdvertisingIdValue();
         static bool GetDisableAdvertising();
         static FString GetVerticalName();
+        static FString GetLocalApiServer();
 
 
         static void SetUseDevelopmentEnvironment(bool useDevelopmentEnvironment);

--- a/targets/UnrealMarketplacePlugin/templates/PlayFab/PlayFab_API.cpp.ejs
+++ b/targets/UnrealMarketplacePlugin/templates/PlayFab/PlayFab_API.cpp.ejs
@@ -12,6 +12,7 @@
 #include "PlayFabPrivate.h"
 #include "PlayFabEnums.h"
 #include "PlayFabCommon/Public/PlayFabAuthenticationContext.h"
+#include "PlayFabCommon/Public/PlayFabCommonUtils.h"
 
 UPlayFab<%- api.name %>API::UPlayFab<%- api.name %>API(const FObjectInitializer& ObjectInitializer)
     : Super(ObjectInitializer)
@@ -114,6 +115,7 @@ for(var subgroup in api.subgroups)
 <%            %>    manager->SetCallAuthenticationContext(request.AuthenticationContext);
 <%            %>    manager->PlayFabRequestURL = "<%- apiCall.url %>";
 <%            %><%- getAuthBools("    ", apiCall) %>
+<%            %><%- getCustomApiAssignmentLogic("    ", api, apiCall) %>
 <%            %>    // Serialize all the request properties to json
 <%          var properties = api.datatypes[apiCall.request].properties;
             for(var z in properties) {
@@ -302,7 +304,7 @@ void UPlayFab<%- api.name %>API::Activate()
     IPlayFab* pfSettings = &(IPlayFab::Get());
 
     FString RequestUrl;
-    RequestUrl = pfSettings->getUrl(PlayFabRequestURL);
+    <%- getCustomApiActivationUrlLogic(api) %>
 
     TSharedRef<IHttpRequest> HttpRequest = FHttpModule::Get().CreateRequest();
     HttpRequest->SetURL(RequestUrl);

--- a/targets/UnrealMarketplacePlugin/templates/PlayFab/PlayFab_API.h.ejs
+++ b/targets/UnrealMarketplacePlugin/templates/PlayFab/PlayFab_API.h.ejs
@@ -93,6 +93,9 @@ public:
 
     /** PlayFab Request Info */
     FString PlayFabRequestURL;
+<% if (api.name === "CloudScript") {
+%>    FString PlayFabRequestFullURL;
+<% } %>
     bool useEntityToken = false;
     bool useSecretKey = false;
     bool useSessionTicket = false;

--- a/targets/UnrealMarketplacePlugin/templates/PlayFabCpp/core/PlayFab_API.cpp.ejs
+++ b/targets/UnrealMarketplacePlugin/templates/PlayFabCpp/core/PlayFab_API.cpp.ejs
@@ -83,8 +83,9 @@ bool UPlayFab<%- api.name %>API::<%- apiCall.name %>(
     const F<%- apiCall.name %>Delegate& SuccessDelegate,
     const FPlayFabErrorDelegate& ErrorDelegate)
 {
-<%- getRequestActions("    ", apiCall, false)
-%>    auto HttpRequest = PlayFabRequestHandler::SendRequest(<%- getUrlAccessor(apiCall, false) %>, request.toJSONString(), <%- getAuthParams(apiCall, false) %>);
+<%- getRequestActions("    ", apiCall, false)%>
+<%- getCustomApiLogic("    ", api, apiCall, false)%>
+    auto HttpRequest = PlayFabRequestHandler::SendRequest(<%- getUrlAccessor(apiCall, false) %>, request.toJSONString(), <%- getAuthParams(apiCall, false) %>);
     HttpRequest->OnProcessRequestComplete().BindRaw(this, &UPlayFab<%- api.name %>API::On<%- apiCall.name %>Result, SuccessDelegate, ErrorDelegate);
     return HttpRequest->ProcessRequest();
 }

--- a/targets/UnrealMarketplacePlugin/templates/PlayFabCpp/core/PlayFab_InstanceAPI.cpp.ejs
+++ b/targets/UnrealMarketplacePlugin/templates/PlayFabCpp/core/PlayFab_InstanceAPI.cpp.ejs
@@ -120,8 +120,9 @@ bool UPlayFab<%- api.name %>InstanceAPI::<%- apiCall.name %>(
     const F<%- apiCall.name %>Delegate& SuccessDelegate,
     const FPlayFabErrorDelegate& ErrorDelegate)
 {
-<%- getRequestActions("    ", apiCall, true)
-%>    auto HttpRequest = PlayFabRequestHandler::SendRequest(<%- getUrlAccessor(apiCall, true) %>, request.toJSONString(), <%- getAuthParams(apiCall, true) %>);
+<%- getRequestActions("    ", apiCall, true)%>
+<%- getCustomApiLogic("    ", apiCall, true) %>
+    auto HttpRequest = PlayFabRequestHandler::SendRequest(<%- getUrlAccessor(apiCall, true) %>, request.toJSONString(), <%- getAuthParams(apiCall, true) %>);
     HttpRequest->OnProcessRequestComplete().BindRaw(this, &UPlayFab<%- api.name %>InstanceAPI::On<%- apiCall.name %>Result, SuccessDelegate, ErrorDelegate);
     return HttpRequest->ProcessRequest();
 }


### PR DESCRIPTION
**New PR Update:** 
* [Comments ](https://github.com/PlayFab/SDKGenerator/pull/482#discussion_r275516442) regarding _not strict enough checking of api.name and apiCall.name_ have been addressed. 
* [Comment](https://github.com/PlayFab/SDKGenerator/pull/482#discussion_r275521407) regarding unity changes bleeding into this PR have been addressed. 
* [Comment](https://github.com/PlayFab/SDKGenerator/pull/482#discussion_r275520135) regarding testing compilation on other platforms has **not yet been addressed** and will be hopefully this week.

Support for local debugging has been added in both the C++ and Blueprints SDKs in the Unreal Marketplace Plugin. The feature is summarized as follows:

C++:

* Following the same pattern as the Unity and C# SDKs, we have created a series of utility functions in `PlayFabUtilities.cpp` that allow us to extract the location of the TEMP dir in a user's device (mac and pc), find the local settings file, extract the `LocalApiServer` field, and attempt to send the `ExecuteFunctionRequest` to that address instead of the remote PlayFab address.

BP:

* The logic here is separated out into two parts, and does not follow the same exact approach as the other SDK work we've done for this feature before. This is mainly due to the fact that the process of actually sending over the HTTP request in the BP SDK is decoupled from the API method. As a result, the API method only takes care of assigning a value to a field that represents a full url being present, and the `Activator` method then looks at that field and if it's assigned decides to override the API url with it.