### PR TITLE
Add CSharp SDK support for Local Debugging Azure Functions

### DIFF
--- a/targets/csharp/make.js
+++ b/targets/csharp/make.js
@@ -345,7 +345,7 @@ function getCustomApiLogic(tabbing, apiCall) {
             + tabbing + "if (!string.IsNullOrEmpty(localApiServerString))\n"
             + tabbing + "{\n"
             + tabbing + "    var baseUri = new Uri(localApiServerString);\n"
-            + tabbing + "    var fullUri = new Uri(baseUri, \"" + apiCall.url + "\");\n\n"
+            + tabbing + "    var fullUri = new Uri(baseUri, \"" + apiCall.url + "\".TrimStart('/'));\n\n"
             + tabbing + "    // Duplicate code necessary to avoid changing all SDK methods to new convention\n"
             + tabbing + "    var debugHttpResult = await PlayFabHttp.DoPostWithFullUri(fullUri.AbsoluteUri, request, " + getAuthParams(apiCall) + ", extraHeaders);\n"
             + tabbing + "    if (debugHttpResult is PlayFabError debugError)\n"

--- a/targets/csharp/source/source/PlayFabHttp/PlayFabHttp.cs
+++ b/targets/csharp/source/source/PlayFabHttp/PlayFabHttp.cs
@@ -50,6 +50,17 @@ namespace PlayFab.Internal
         {
             var settings = instanceSettings ?? PlayFabSettings.staticSettings;
             var fullPath = settings.GetFullUrl(urlPath);
+            return await _DoPost(fullPath, request, authType, authKey, extraHeaders, instanceSettings);
+        }
+
+        public static async Task<object> DoPostWithFullUri(string fullUriPath, PlayFabRequestCommon request, string authType, string authKey, Dictionary<string, string> extraHeaders, PlayFabApiSettings instanceSettings = null)
+        {
+            return await _DoPost(fullUriPath, request, authType, authKey, extraHeaders, instanceSettings);
+        }
+
+        private static async Task<object> _DoPost(string fullPath, PlayFabRequestCommon request, string authType, string authKey, Dictionary<string, string> extraHeaders, PlayFabApiSettings instanceSettings = null)
+        {
+            var settings = instanceSettings ?? PlayFabSettings.staticSettings;
             var titleId = settings.TitleId;
             if (titleId == null)
                 throw new PlayFabException(PlayFabExceptionCode.TitleNotSet, "You must set your titleId before making an api call");

--- a/targets/csharp/source/source/PlayFabSettings.cs.ejs
+++ b/targets/csharp/source/source/PlayFabSettings.cs.ejs
@@ -47,6 +47,26 @@ namespace PlayFab
 <% }
 %>        #endregion Deprecated staticSettingsredirect properties
 
+        private static string _localApiServer;
+
+        public static string LocalApiServer
+        {
+            get
+            {
+#if NET45 || NETCOREAPP2_0
+                return PlayFabUtil.GetLocalSettingsFileProperty("LocalApiServer");
+#else
+                return _localApiServer;
+#endif
+            }
+#if !NET45 && !NETCOREAPP2_0
+            set
+            {
+                _localApiServer = value;
+            }
+#endif
+        }
+
         public static string GetFullUrl(string apiCall, Dictionary<string, string> getParams, PlayFabApiSettings instanceSettings = null)
         {
             StringBuilder sb = new StringBuilder(1000);

--- a/targets/csharp/templates/API.cs.ejs
+++ b/targets/csharp/templates/API.cs.ejs
@@ -18,6 +18,7 @@ namespace PlayFab
 %>        public static async Task<PlayFabResult<<%- apiCall.result %>>> <%- apiCall.name %>Async(<%- apiCall.request %> request, object customData = null, Dictionary<string, string> extraHeaders = null)
         {
 <%- getRequestActions("            ", apiCall, false) %>
+<%- getCustomApiLogic("            ", apiCall) %>
             var httpResult = await PlayFabHttp.DoPost("<%- apiCall.url %>", request, <%- getAuthParams(apiCall) %>, extraHeaders);
             if (httpResult is PlayFabError)
             {

--- a/targets/csharp/templates/PlayFabUtil.cs.ejs
+++ b/targets/csharp/templates/PlayFabUtil.cs.ejs
@@ -25,6 +25,7 @@ namespace PlayFab
 
     public static partial class PlayFabUtil
     {
+        private static string _localSettingsFileName = "playfab.local.settings.json";
         public static readonly string[] DefaultDateTimeFormats = { // All parseable ISO 8601 formats for DateTime.[Try]ParseExact - Lets us deserialize any legacy timestamps in one of these formats
             // These are the standard format with ISO 8601 UTC markers (T/Z)
             "yyyy-MM-ddTHH:mm:ss.FFFFFFZ",
@@ -49,6 +50,82 @@ namespace PlayFab
                 return null;
             return error.GenerateErrorReport();
         }
+
+#if NET45 || NETCOREAPP2_0
+        [ThreadStatic]
+        private static StringBuilder _sb;
+        /// <summary>
+        /// A threadsafe way to block and load a text file
+        /// 
+        /// Load a text file, and return the file as text.
+        /// Used for small (usually json) files.
+        /// </summary>
+        private static string ReadAllFileText(string filename)
+        {
+            if (!File.Exists(filename))
+            {
+                return string.Empty;
+            }
+                
+            if (_sb == null)
+            {
+                _sb = new StringBuilder();
+            }
+            _sb.Length = 0;
+
+            using (var fs = new FileStream(filename, FileMode.Open))
+            {
+                using (BinaryReader br = new BinaryReader(fs))
+                {
+                    while (br.BaseStream.Position != br.BaseStream.Length)
+                    {
+                        _sb.Append(br.ReadChar());
+                    }
+                }
+            }
+            return _sb.ToString();
+        }
+
+        internal static string GetLocalSettingsFileProperty(string propertyKey)
+        {
+            string envFileContent = null;
+            string currDir = Directory.GetCurrentDirectory();
+            string currDirEnvFile = Path.Combine(currDir, _localSettingsFileName);
+
+            if (File.Exists(currDirEnvFile))
+            {
+                envFileContent = ReadAllFileText(currDirEnvFile);
+            }
+            else
+            {
+                string tempDir = Path.GetTempPath();
+                string tempDirEnvFile = Path.Combine(tempDir, _localSettingsFileName);
+
+                if (File.Exists(tempDirEnvFile))
+                {
+                    envFileContent = ReadAllFileText(tempDirEnvFile);
+                }
+            }
+            
+            if (!string.IsNullOrEmpty(envFileContent))
+            {
+                var jsonPlugin = PluginManager.GetPlugin<ISerializerPlugin>(PluginContract.PlayFab_Serializer);
+                dynamic envJson = jsonPlugin.DeserializeObject(envFileContent);
+                string result = string.Empty;
+                try
+                {
+                    result = envJson[propertyKey]?.ToString();
+                    return result;
+                }
+                catch (KeyNotFoundException)
+                {
+                    return string.Empty;
+                }
+            }
+            return string.Empty;
+        }
+#endif
+
 <% if (hasClientOptions || hasServerOptions) { %>
         private static readonly StringBuilder Sb = new StringBuilder();
         public static string GetCloudScriptErrorReport(PlayFabResult<ExecuteCloudScriptResult> result)


### PR DESCRIPTION
Support for local debugging has been added in the CSharp SDK. 

The feature follows the same patterns as the previous work on the Unity SDK with the exception that there are certain #ifdefine tags added to allow local debugging only if the target framework is .NET 4.5 or NETCore 2.0 as providing such capabilities in .NETPortable and others is neither feasible nor possible with our implementation.