### PR TITLE
Add FunctionExecutionContext to C# SDK

### DIFF
--- a/SDKGenerator.njsproj
+++ b/SDKGenerator.njsproj
@@ -197,6 +197,7 @@
     <Content Include="targets\csharp\source\source\WsaReflectionExtensions.cs" />
     <Content Include="targets\csharp\templates\API.cs.ejs" />
     <Content Include="targets\csharp\templates\APIInstance.cs.ejs" />
+    <Content Include="targets\csharp\source\source\Extensions\Models\PlayFabCloudScriptModelsExtensions.cs.ejs" />
     <Content Include="targets\csharp\templates\Enum.cs.ejs" />
     <Content Include="targets\csharp\templates\Errors.cs.ejs" />
     <Content Include="targets\csharp\templates\Model.cs.ejs" />
@@ -944,7 +945,9 @@
     <Folder Include="targets\csharp\" />
     <Folder Include="targets\csharp\source\" />
     <Folder Include="targets\csharp\source\source\" />
+    <Folder Include="targets\csharp\source\source\Extensions\Models\" />
     <Folder Include="targets\csharp\source\source\Json\" />
+    <Folder Include="targets\csharp\source\source\Extensions\" />
     <Folder Include="targets\csharp\source\source\PlayFabHttp\" />
     <Folder Include="targets\csharp\source\source\Properties\" />
     <Folder Include="targets\csharp\source\source\Uunit\" />

--- a/targets/csharp/source/source/Extensions/Models/PlayFabCloudScriptModelsExtensions.cs.ejs
+++ b/targets/csharp/source/source/Extensions/Models/PlayFabCloudScriptModelsExtensions.cs.ejs
@@ -1,0 +1,63 @@
+namespace PlayFab.CloudScriptModels
+{
+    public class FunctionExecutionContext<T>
+    {
+        public PlayFabApiSettings ApiSettings { get; private set; }
+
+        public PlayFabAuthenticationContext AuthenticationContext { get; set; }
+
+        public ProfilesModels.EntityProfileBody CallerEntityProfile { get; set; }
+
+        public T FunctionArgument { get; set; }
+
+        protected FunctionExecutionContext() { }
+
+        public static async System.Threading.Tasks.Task<FunctionExecutionContext<T>> Create(System.Net.Http.HttpRequestMessage request)
+        {
+            string body = await request.Content.ReadAsStringAsync();
+            var contextInternal = Json.PlayFabSimpleJson.DeserializeObject<FunctionExecutionContextInternal<T>>(body);
+            var settings = new PlayFabApiSettings
+            {
+                TitleId = contextInternal.TitleAuthenticationContext.Id,
+                DeveloperSecretKey = contextInternal.TitleAuthenticationContext.SecretKey
+            };
+            var authContext = new PlayFabAuthenticationContext
+            {
+                EntityToken = contextInternal.TitleAuthenticationContext.EntityToken
+            };
+
+            
+            return new FunctionExecutionContext<T>()
+            {
+                ApiSettings = settings,
+                CallerEntityProfile = contextInternal.CallerEntityProfile,
+                FunctionArgument = contextInternal.FunctionArgument,
+                AuthenticationContext = authContext
+            };
+        }
+
+        private class FunctionExecutionContextInternal<V>
+        {
+            public TitleAuthenticationContext TitleAuthenticationContext { get; set; }
+
+            public ProfilesModels.EntityProfileBody CallerEntityProfile { get; set; }
+
+            public V FunctionArgument { get; set; }
+        }
+
+        private class FunctionExecutionContextInternal : FunctionExecutionContextInternal<object>
+        {
+        }
+
+        private class TitleAuthenticationContext
+        {
+            public string Id { get; set; }
+            public string SecretKey { get; set; }
+            public string EntityToken { get; set; }
+        }
+    }
+
+    public class FunctionExecutionContext : FunctionExecutionContext<object>
+    {
+    }
+}

--- a/targets/csharp/source/source/Extensions/Models/PlayFabCloudScriptModelsExtensions.cs.ejs
+++ b/targets/csharp/source/source/Extensions/Models/PlayFabCloudScriptModelsExtensions.cs.ejs
@@ -1,12 +1,13 @@
 namespace PlayFab.CloudScriptModels
 {
+    using System.Threading.Tasks;
     /// <summary>
     /// Used for extracting the data fields incoming as payload to Azure Functions into their respective objects. 
     /// Provides  fields through ApiSettings and AuthenticationContext, the profile of the caller, as well as the 
     /// arguments passed to the execution request.
     /// </summary>
-    /// <typeparam name="T">Type of FunctionArgument</typeparam>
-    public class FunctionExecutionContext<T>
+    /// <typeparam name="TFunctionArgument">Type of FunctionArgument</typeparam>
+    public class FunctionExecutionContext<TFunctionArgument>
     {
         public PlayFabApiSettings ApiSettings { get; private set; }
 
@@ -14,7 +15,7 @@ namespace PlayFab.CloudScriptModels
 
         public ProfilesModels.EntityProfileBody CallerEntityProfile { get; set; }
 
-        public T FunctionArgument { get; set; }
+        public TFunctionArgument FunctionArgument { get; set; }
 
         protected FunctionExecutionContext() { }
 
@@ -23,10 +24,10 @@ namespace PlayFab.CloudScriptModels
         /// </summary>
         /// <param name="request">The request incoming to an Azure Function from the PlayFab server</param>
         /// <returns>A new populated <c>FunctionExecutionContext</c> instance</returns>
-        public static async System.Threading.Tasks.Task<FunctionExecutionContext<T>> Create(System.Net.Http.HttpRequestMessage request)
+        public static async Task<FunctionExecutionContext<TFunctionArgument>> Create(System.Net.Http.HttpRequestMessage request)
         {
             string body = await request.Content.ReadAsStringAsync();
-            var contextInternal = Json.PlayFabSimpleJson.DeserializeObject<FunctionExecutionContextInternal<T>>(body);
+            var contextInternal = Json.PlayFabSimpleJson.DeserializeObject<FunctionExecutionContextInternal>(body);
             var settings = new PlayFabApiSettings
             {
                 TitleId = contextInternal.TitleAuthenticationContext.Id,
@@ -38,7 +39,7 @@ namespace PlayFab.CloudScriptModels
             };
 
             
-            return new FunctionExecutionContext<T>()
+            return new FunctionExecutionContext<TFunctionArgument>()
             {
                 ApiSettings = settings,
                 CallerEntityProfile = contextInternal.CallerEntityProfile,
@@ -53,7 +54,7 @@ namespace PlayFab.CloudScriptModels
 
             public ProfilesModels.EntityProfileBody CallerEntityProfile { get; set; }
 
-            public T FunctionArgument { get; set; }
+            public TFunctionArgument FunctionArgument { get; set; }
         }
 
         private class TitleAuthenticationContext

--- a/targets/csharp/source/source/Extensions/Models/PlayFabCloudScriptModelsExtensions.cs.ejs
+++ b/targets/csharp/source/source/Extensions/Models/PlayFabCloudScriptModelsExtensions.cs.ejs
@@ -1,5 +1,11 @@
 namespace PlayFab.CloudScriptModels
 {
+    /// <summary>
+    /// Used for extracting the data fields incoming as payload to Azure Functions into their respective objects. 
+    /// Provides  fields through ApiSettings and AuthenticationContext, the profile of the caller, as well as the 
+    /// arguments passed to the execution request.
+    /// </summary>
+    /// <typeparam name="T">Type of FunctionArgument</typeparam>
     public class FunctionExecutionContext<T>
     {
         public PlayFabApiSettings ApiSettings { get; private set; }
@@ -12,6 +18,11 @@ namespace PlayFab.CloudScriptModels
 
         protected FunctionExecutionContext() { }
 
+        /// <summary>
+        /// Creates a new <c>FunctionExecutionContext</c> out of the incoming request to an Azure Function.
+        /// </summary>
+        /// <param name="request">The request incoming to an Azure Function from the PlayFab server</param>
+        /// <returns>A new populated <c>FunctionExecutionContext</c> instance</returns>
         public static async System.Threading.Tasks.Task<FunctionExecutionContext<T>> Create(System.Net.Http.HttpRequestMessage request)
         {
             string body = await request.Content.ReadAsStringAsync();
@@ -36,17 +47,13 @@ namespace PlayFab.CloudScriptModels
             };
         }
 
-        private class FunctionExecutionContextInternal<V>
+        private class FunctionExecutionContextInternal
         {
             public TitleAuthenticationContext TitleAuthenticationContext { get; set; }
 
             public ProfilesModels.EntityProfileBody CallerEntityProfile { get; set; }
 
-            public V FunctionArgument { get; set; }
-        }
-
-        private class FunctionExecutionContextInternal : FunctionExecutionContextInternal<object>
-        {
+            public T FunctionArgument { get; set; }
         }
 
         private class TitleAuthenticationContext

--- a/targets/csharp/source/source/Extensions/Models/PlayFabCloudScriptModelsExtensions.cs.ejs
+++ b/targets/csharp/source/source/Extensions/Models/PlayFabCloudScriptModelsExtensions.cs.ejs
@@ -26,26 +26,28 @@ namespace PlayFab.CloudScriptModels
         /// <returns>A new populated <c>FunctionExecutionContext</c> instance</returns>
         public static async Task<FunctionExecutionContext<TFunctionArgument>> Create(System.Net.Http.HttpRequestMessage request)
         {
-            string body = await request.Content.ReadAsStringAsync();
-            var contextInternal = Json.PlayFabSimpleJson.DeserializeObject<FunctionExecutionContextInternal>(body);
-            var settings = new PlayFabApiSettings
+            using (var content = request.Content) 
             {
-                TitleId = contextInternal.TitleAuthenticationContext.Id,
-                DeveloperSecretKey = contextInternal.TitleAuthenticationContext.SecretKey
-            };
-            var authContext = new PlayFabAuthenticationContext
-            {
-                EntityToken = contextInternal.TitleAuthenticationContext.EntityToken
-            };
+                var body = await content.ReadAsStringAsync();
+                var contextInternal = Json.PlayFabSimpleJson.DeserializeObject<FunctionExecutionContextInternal>(body);
+                var settings = new PlayFabApiSettings
+                {
+                    TitleId = contextInternal.TitleAuthenticationContext.Id,
+                    DeveloperSecretKey = contextInternal.TitleAuthenticationContext.SecretKey
+                };
+                var authContext = new PlayFabAuthenticationContext
+                {
+                    EntityToken = contextInternal.TitleAuthenticationContext.EntityToken
+                };
 
-            
-            return new FunctionExecutionContext<TFunctionArgument>()
-            {
-                ApiSettings = settings,
-                CallerEntityProfile = contextInternal.CallerEntityProfile,
-                FunctionArgument = contextInternal.FunctionArgument,
-                AuthenticationContext = authContext
-            };
+                return new FunctionExecutionContext<TFunctionArgument>()
+                {
+                    ApiSettings = settings,
+                    CallerEntityProfile = contextInternal.CallerEntityProfile,
+                    FunctionArgument = contextInternal.FunctionArgument,
+                    AuthenticationContext = authContext
+                };
+            }
         }
 
         private class FunctionExecutionContextInternal


### PR DESCRIPTION
This PR adds an extension file to `CloudScriptModels` that is necessary for the work we are doing on Azure Functions. It allows for us to provide extra payload to the function from MainServer and then populate fields for the user (developer) to simply grab and use on each InstanceAPI they wish to use.