### PR TITLE
Remove SecretKey from TitleAuthenticationContext

### DIFF
--- a/targets/csharp/source/source/Extensions/Models/PlayFabCloudScriptModelsExtensions.cs.ejs
+++ b/targets/csharp/source/source/Extensions/Models/PlayFabCloudScriptModelsExtensions.cs.ejs
@@ -32,10 +32,7 @@ namespace PlayFab.CloudScriptModels
                 var contextInternal = Json.PlayFabSimpleJson.DeserializeObject<FunctionExecutionContextInternal>(body);
                 var settings = new PlayFabApiSettings
                 {
-                    TitleId = contextInternal.TitleAuthenticationContext.Id,
-#if ENABLE_PLAYFABSERVER_API || ENABLE_PLAYFABADMIN_API
-                    DeveloperSecretKey = contextInternal.TitleAuthenticationContext.SecretKey
-#endif
+                    TitleId = contextInternal.TitleAuthenticationContext.Id
                 };
                 var authContext = new PlayFabAuthenticationContext
                 {
@@ -64,7 +61,6 @@ namespace PlayFab.CloudScriptModels
         private class TitleAuthenticationContext
         {
             public string Id { get; set; }
-            public string SecretKey { get; set; }
             public string EntityToken { get; set; }
         }
     }


### PR DESCRIPTION
We have decided to ask developers to store their title secret key in the app settings of their Azure Functions App and as a result removed this field from `TitleAuthenticationContext`