### PR TITLE
Add Task and Player PlayStream based Function Contexts

### DIFF
--- a/targets/csharp/source/source/Extensions/Models/PlayFabCloudScriptModelsExtensions.cs.ejs
+++ b/targets/csharp/source/source/Extensions/Models/PlayFabCloudScriptModelsExtensions.cs.ejs
@@ -146,7 +146,7 @@ namespace PlayFab.CloudScriptModels
 
         public PlayFabAuthenticationContext AuthenticationContext { get; set; }
 
-        public ClientModels.NameIdentifier ScheduledTaskNameId { get; set; }
+        public NameIdentifier ScheduledTaskNameId { get; set; }
 
         public Stack<PlayStreamEventHistory> EventHistory { get; set; }
 
@@ -187,7 +187,7 @@ namespace PlayFab.CloudScriptModels
 
         private class FunctionTaskContextInternal
         {
-            public ClientModels.NameIdentifier ScheduledTaskNameId { get; set; }
+            public NameIdentifier ScheduledTaskNameId { get; set; }
 
             public Stack<PlayStreamEventHistory> EventHistory { get; set; }
 
@@ -195,6 +195,13 @@ namespace PlayFab.CloudScriptModels
 
             public TFunctionArgument FunctionArgument { get; set; }
         }
+    }
+
+    public class NameIdentifier
+    {
+        public string Name { get; set; }
+
+        public string Id { get; set; }
     }
 
     public class PlayStreamEventEnvelope

--- a/targets/csharp/source/source/Extensions/Models/PlayFabCloudScriptModelsExtensions.cs.ejs
+++ b/targets/csharp/source/source/Extensions/Models/PlayFabCloudScriptModelsExtensions.cs.ejs
@@ -2,6 +2,7 @@
 namespace PlayFab.CloudScriptModels
 {
     using PlayFab.Json;
+    using System;
     using System.Collections.Generic;
     using System.Net.Http;
     using System.Threading.Tasks;
@@ -40,6 +41,9 @@ namespace PlayFab.CloudScriptModels
                 {
                     TitleId = contextInternal.TitleAuthenticationContext.Id
                 };
+
+                FunctionContextUtil.TrySetSecretKey(settings);
+
                 var authContext = new PlayFabAuthenticationContext
                 {
                     EntityToken = contextInternal.TitleAuthenticationContext.EntityToken
@@ -105,6 +109,9 @@ namespace PlayFab.CloudScriptModels
                 {
                     TitleId = contextInternal.TitleAuthenticationContext.Id
                 };
+
+                FunctionContextUtil.TrySetSecretKey(settings);
+
                 var authContext = new PlayFabAuthenticationContext
                 {
                     EntityToken = contextInternal.TitleAuthenticationContext.EntityToken
@@ -169,6 +176,9 @@ namespace PlayFab.CloudScriptModels
                 {
                     TitleId = contextInternal.TitleAuthenticationContext.Id
                 };
+
+                FunctionContextUtil.TrySetSecretKey(settings);
+
                 var authContext = new PlayFabAuthenticationContext
                 {
                     EntityToken = contextInternal.TitleAuthenticationContext.EntityToken
@@ -227,6 +237,25 @@ namespace PlayFab.CloudScriptModels
     {
         public string Id { get; set; }
         public string EntityToken { get; set; }
+    }
+
+    internal static class FunctionContextUtil
+    {
+        internal static void TrySetSecretKey(PlayFabApiSettings apiSettings)
+        {
+            var secretKey = Environment.GetEnvironmentVariable("PLAYFAB_DEV_SECRET_KEY", EnvironmentVariableTarget.Process);
+            if (string.IsNullOrEmpty(apiSettings.DeveloperSecretKey))
+            {
+                if (!string.IsNullOrEmpty(secretKey))
+                {
+                    apiSettings.DeveloperSecretKey = secretKey;
+                }
+                else
+                {
+                    throw new Exception("Please set the value in the PLAYFAB_DEV_SECRET_KEY field of the local.settings.json file, within the Values object.");
+                }
+            }
+        }
     }
 }
 #endif

--- a/targets/csharp/source/source/Extensions/Models/PlayFabCloudScriptModelsExtensions.cs.ejs
+++ b/targets/csharp/source/source/Extensions/Models/PlayFabCloudScriptModelsExtensions.cs.ejs
@@ -84,7 +84,7 @@ namespace PlayFab.CloudScriptModels
 
         public PlayStreamEventEnvelope PlayStreamEventEnvelope { get; set; }
 
-        public AdminModels.PlayerProfile PlayerProfile { get; set; }
+        public ServerModels.PlayerProfile PlayerProfile { get; set; }
 
         public TFunctionArgument FunctionArgument { get; set; }
 
@@ -127,7 +127,7 @@ namespace PlayFab.CloudScriptModels
 
             public PlayStreamEventEnvelope PlayStreamEventEnvelope { get; set; }
 
-            public AdminModels.PlayerProfile PlayerProfile { get; set; }
+            public ServerModels.PlayerProfile PlayerProfile { get; set; }
 
             public TitleAuthenticationContext TitleAuthenticationContext { get; set; }
         }
@@ -146,7 +146,7 @@ namespace PlayFab.CloudScriptModels
 
         public PlayFabAuthenticationContext AuthenticationContext { get; set; }
 
-        public AdminModels.NameIdentifier ScheduledTaskNameId { get; set; }
+        public ClientModels.NameIdentifier ScheduledTaskNameId { get; set; }
 
         public Stack<PlayStreamEventHistory> EventHistory { get; set; }
 
@@ -187,7 +187,7 @@ namespace PlayFab.CloudScriptModels
 
         private class FunctionTaskContextInternal
         {
-            public AdminModels.NameIdentifier ScheduledTaskNameId { get; set; }
+            public ClientModels.NameIdentifier ScheduledTaskNameId { get; set; }
 
             public Stack<PlayStreamEventHistory> EventHistory { get; set; }
 

--- a/targets/csharp/source/source/Extensions/Models/PlayFabCloudScriptModelsExtensions.cs.ejs
+++ b/targets/csharp/source/source/Extensions/Models/PlayFabCloudScriptModelsExtensions.cs.ejs
@@ -1,35 +1,42 @@
 namespace PlayFab.CloudScriptModels
 {
+    using PlayFab.AdminModels;
+    using PlayFab.Json;
+    using PlayFab.ProfilesModels;
+    using System.Collections.Generic;
+    using System.Net.Http;
     using System.Threading.Tasks;
+
     /// <summary>
     /// Used for extracting the data fields incoming as payload to Azure Functions into their respective objects. 
+    /// Meant to be used with basic HTTP based Azure Functions.
     /// Provides  fields through ApiSettings and AuthenticationContext, the profile of the caller, as well as the 
     /// arguments passed to the execution request.
     /// </summary>
     /// <typeparam name="TFunctionArgument">Type of FunctionArgument</typeparam>
-    public class FunctionExecutionContext<TFunctionArgument>
+    public class FunctionContext<TFunctionArgument>
     {
         public PlayFabApiSettings ApiSettings { get; private set; }
 
         public PlayFabAuthenticationContext AuthenticationContext { get; set; }
 
-        public ProfilesModels.EntityProfileBody CallerEntityProfile { get; set; }
+        public EntityProfileBody CallerEntityProfile { get; set; }
 
         public TFunctionArgument FunctionArgument { get; set; }
 
-        protected FunctionExecutionContext() { }
+        protected FunctionContext() { }
 
         /// <summary>
-        /// Creates a new <c>FunctionExecutionContext</c> out of the incoming request to an Azure Function.
+        /// Creates a new <c>FunctionContext</c> out of the incoming request to an Azure Function.
         /// </summary>
         /// <param name="request">The request incoming to an Azure Function from the PlayFab server</param>
-        /// <returns>A new populated <c>FunctionExecutionContext</c> instance</returns>
-        public static async Task<FunctionExecutionContext<TFunctionArgument>> Create(System.Net.Http.HttpRequestMessage request)
+        /// <returns>A new populated <c>FunctionContext</c> instance</returns>
+        public static async Task<FunctionContext<TFunctionArgument>> Create(HttpRequestMessage request)
         {
             using (var content = request.Content) 
             {
                 var body = await content.ReadAsStringAsync();
-                var contextInternal = Json.PlayFabSimpleJson.DeserializeObject<FunctionExecutionContextInternal>(body);
+                var contextInternal = Json.PlayFabSimpleJson.DeserializeObject<FunctionContextInternal>(body);
                 var settings = new PlayFabApiSettings
                 {
                     TitleId = contextInternal.TitleAuthenticationContext.Id
@@ -39,7 +46,7 @@ namespace PlayFab.CloudScriptModels
                     EntityToken = contextInternal.TitleAuthenticationContext.EntityToken
                 };
 
-                return new FunctionExecutionContext<TFunctionArgument>()
+                return new FunctionContext<TFunctionArgument>()
                 {
                     ApiSettings = settings,
                     CallerEntityProfile = contextInternal.CallerEntityProfile,
@@ -49,7 +56,7 @@ namespace PlayFab.CloudScriptModels
             }
         }
 
-        private class FunctionExecutionContextInternal
+        private class FunctionContextInternal
         {
             public TitleAuthenticationContext TitleAuthenticationContext { get; set; }
 
@@ -57,15 +64,162 @@ namespace PlayFab.CloudScriptModels
 
             public TFunctionArgument FunctionArgument { get; set; }
         }
+    }
 
-        private class TitleAuthenticationContext
+    public class FunctionContext : FunctionContext<object>
+    {
+    }
+
+    /// <summary>
+    /// Used for extracting the data fields incoming as payload to Azure Functions into their respective objects. 
+    /// Meant to be used with Player PlayStream based Azure Functions
+    /// Provides  fields through ApiSettings and AuthenticationContext, the profile of the caller, as well as the 
+    /// arguments passed to the execution request.
+    /// </summary>
+    /// <typeparam name="TFunctionArgument">Type of FunctionArgument</typeparam>
+    public class FunctionPlayerPlayStreamContext<TFunctionArgument>
+    {
+        public PlayFabApiSettings ApiSettings { get; private set; }
+
+        public PlayFabAuthenticationContext AuthenticationContext { get; set; }
+
+        public PlayStreamEventEnvelope PlayStreamEventEnvelope { get; set; }
+
+        public PlayerProfile PlayerProfile { get; set; }
+
+        public TFunctionArgument FunctionArgument { get; set; }
+
+        protected FunctionPlayerPlayStreamContext() { }
+
+        /// <summary>
+        /// Creates a new <c>FunctionPlayerPlayStreamContext</c> out of the incoming request to an Azure Function.
+        /// </summary>
+        /// <param name="request">The request incoming to an Azure Function from the PlayFab server</param>
+        /// <returns>A new populated <c>FunctionPlayerPlayStreamContext</c> instance</returns>
+        public static async Task<FunctionPlayerPlayStreamContext<TFunctionArgument>> Create(HttpRequestMessage request)
         {
-            public string Id { get; set; }
-            public string EntityToken { get; set; }
+            using (var content = request.Content)
+            {
+                var body = await content.ReadAsStringAsync();
+                var contextInternal = PlayFabSimpleJson.DeserializeObject<FunctionPlayerPlayStreamContextInternal>(body);
+                var settings = new PlayFabApiSettings
+                {
+                    TitleId = contextInternal.TitleAuthenticationContext.Id
+                };
+                var authContext = new PlayFabAuthenticationContext
+                {
+                    EntityToken = contextInternal.TitleAuthenticationContext.EntityToken
+                };
+
+                return new FunctionPlayerPlayStreamContext<TFunctionArgument>()
+                {
+                    ApiSettings = settings,
+                    AuthenticationContext = authContext,
+                    PlayStreamEventEnvelope = contextInternal.PlayStreamEventEnvelope,
+                    PlayerProfile = contextInternal.PlayerProfile,
+                    FunctionArgument = contextInternal.FunctionArgument,
+                };
+            }
+        }
+
+        private class FunctionPlayerPlayStreamContextInternal
+        {
+            public TFunctionArgument FunctionArgument { get; set; }
+
+            public PlayStreamEventEnvelope PlayStreamEventEnvelope { get; set; }
+
+            public PlayerProfile PlayerProfile { get; set; }
+
+            public TitleAuthenticationContext TitleAuthenticationContext { get; set; }
         }
     }
 
-    public class FunctionExecutionContext : FunctionExecutionContext<object>
+    /// <summary>
+    /// Used for extracting the data fields incoming as payload to Azure Functions into their respective objects. 
+    /// Meant to be used with task based Azure Functions.
+    /// Provides  fields through ApiSettings and AuthenticationContext, the profile of the caller, as well as the 
+    /// arguments passed to the execution request.
+    /// </summary>
+    /// <typeparam name="TFunctionArgument">Type of FunctionArgument</typeparam>
+    public class FunctionTaskContext<TFunctionArgument>
     {
+        public PlayFabApiSettings ApiSettings { get; private set; }
+
+        public PlayFabAuthenticationContext AuthenticationContext { get; set; }
+
+        public NameIdentifier ScheduledTaskNameId { get; set; }
+
+        public Stack<PlayStreamEventHistory> EventHistory { get; set; }
+
+        public TFunctionArgument FunctionArgument { get; set; }
+
+        protected FunctionTaskContext() { }
+
+        /// <summary>
+        /// Creates a new <c>FunctionTaskContext</c> out of the incoming request to an Azure Function.
+        /// </summary>
+        /// <param name="request">The request incoming to an Azure Function from the PlayFab server</param>
+        /// <returns>A new populated <c>FunctionTaskContext</c> instance</returns>
+        public static async Task<FunctionTaskContext<TFunctionArgument>> Create(HttpRequestMessage request)
+        {
+            using (var content = request.Content)
+            {
+                var body = await content.ReadAsStringAsync();
+                var contextInternal = PlayFabSimpleJson.DeserializeObject<FunctionTaskContextInternal>(body);
+                var settings = new PlayFabApiSettings
+                {
+                    TitleId = contextInternal.TitleAuthenticationContext.Id
+                };
+                var authContext = new PlayFabAuthenticationContext
+                {
+                    EntityToken = contextInternal.TitleAuthenticationContext.EntityToken
+                };
+
+                return new FunctionTaskContext<TFunctionArgument>()
+                {
+                    ApiSettings = settings,
+                    AuthenticationContext = authContext,
+                    ScheduledTaskNameId = contextInternal.ScheduledTaskNameId,
+                    EventHistory = contextInternal.EventHistory,
+                    FunctionArgument = contextInternal.FunctionArgument
+                };
+            }
+        }
+
+        private class FunctionTaskContextInternal
+        {
+            public NameIdentifier ScheduledTaskNameId { get; set; }
+
+            public Stack<PlayStreamEventHistory> EventHistory { get; set; }
+
+            public TitleAuthenticationContext TitleAuthenticationContext { get; set; }
+
+            public TFunctionArgument FunctionArgument { get; set; }
+        }
+    }
+
+    public class PlayStreamEventEnvelope
+    {
+        public string EntityId { get; set; }
+        public string EntityType { get; set; }
+        public string EventName { get; set; }
+        public string EventNamespace { get; set; }
+        public dynamic EventData { get; set; }
+        public string EventSettings { get; set; }
+    }
+
+    public class PlayStreamEventHistory
+    {
+        public string ParentTriggerId { get; set; }
+
+        public string ParentEventId { get; set; }
+
+        public bool TriggeredEvents { get; set; }
+    }
+
+    internal class TitleAuthenticationContext
+    {
+        public string Id { get; set; }
+        public string EntityToken { get; set; }
     }
 }

--- a/targets/csharp/source/source/Extensions/Models/PlayFabCloudScriptModelsExtensions.cs.ejs
+++ b/targets/csharp/source/source/Extensions/Models/PlayFabCloudScriptModelsExtensions.cs.ejs
@@ -1,4 +1,4 @@
-#if NET45 || NETCOREAPP2_0
+#if NETCOREAPP2_0
 namespace PlayFab.CloudScriptModels
 {
     using PlayFab.Json;

--- a/targets/csharp/source/source/Extensions/Models/PlayFabCloudScriptModelsExtensions.cs.ejs
+++ b/targets/csharp/source/source/Extensions/Models/PlayFabCloudScriptModelsExtensions.cs.ejs
@@ -204,7 +204,11 @@ namespace PlayFab.CloudScriptModels
         public string EntityType { get; set; }
         public string EventName { get; set; }
         public string EventNamespace { get; set; }
+#if NET45 || NETCOREAPP2_0
         public dynamic EventData { get; set; }
+#else
+        public string EventData { get; set; }
+#endif
         public string EventSettings { get; set; }
     }
 

--- a/targets/csharp/source/source/Extensions/Models/PlayFabCloudScriptModelsExtensions.cs.ejs
+++ b/targets/csharp/source/source/Extensions/Models/PlayFabCloudScriptModelsExtensions.cs.ejs
@@ -1,3 +1,4 @@
+#if NET45 || NETCOREAPP2_0
 namespace PlayFab.CloudScriptModels
 {
     using PlayFab.AdminModels;
@@ -204,11 +205,7 @@ namespace PlayFab.CloudScriptModels
         public string EntityType { get; set; }
         public string EventName { get; set; }
         public string EventNamespace { get; set; }
-#if NET45 || NETCOREAPP2_0
         public dynamic EventData { get; set; }
-#else
-        public string EventData { get; set; }
-#endif
         public string EventSettings { get; set; }
     }
 
@@ -227,3 +224,4 @@ namespace PlayFab.CloudScriptModels
         public string EntityToken { get; set; }
     }
 }
+#endif

--- a/targets/csharp/source/source/Extensions/Models/PlayFabCloudScriptModelsExtensions.cs.ejs
+++ b/targets/csharp/source/source/Extensions/Models/PlayFabCloudScriptModelsExtensions.cs.ejs
@@ -1,9 +1,7 @@
 #if NET45 || NETCOREAPP2_0
 namespace PlayFab.CloudScriptModels
 {
-    using PlayFab.AdminModels;
     using PlayFab.Json;
-    using PlayFab.ProfilesModels;
     using System.Collections.Generic;
     using System.Net.Http;
     using System.Threading.Tasks;
@@ -21,7 +19,7 @@ namespace PlayFab.CloudScriptModels
 
         public PlayFabAuthenticationContext AuthenticationContext { get; set; }
 
-        public EntityProfileBody CallerEntityProfile { get; set; }
+        public ProfilesModels.EntityProfileBody CallerEntityProfile { get; set; }
 
         public TFunctionArgument FunctionArgument { get; set; }
 
@@ -86,7 +84,7 @@ namespace PlayFab.CloudScriptModels
 
         public PlayStreamEventEnvelope PlayStreamEventEnvelope { get; set; }
 
-        public PlayerProfile PlayerProfile { get; set; }
+        public AdminModels.PlayerProfile PlayerProfile { get; set; }
 
         public TFunctionArgument FunctionArgument { get; set; }
 
@@ -129,7 +127,7 @@ namespace PlayFab.CloudScriptModels
 
             public PlayStreamEventEnvelope PlayStreamEventEnvelope { get; set; }
 
-            public PlayerProfile PlayerProfile { get; set; }
+            public AdminModels.PlayerProfile PlayerProfile { get; set; }
 
             public TitleAuthenticationContext TitleAuthenticationContext { get; set; }
         }
@@ -148,7 +146,7 @@ namespace PlayFab.CloudScriptModels
 
         public PlayFabAuthenticationContext AuthenticationContext { get; set; }
 
-        public NameIdentifier ScheduledTaskNameId { get; set; }
+        public AdminModels.NameIdentifier ScheduledTaskNameId { get; set; }
 
         public Stack<PlayStreamEventHistory> EventHistory { get; set; }
 
@@ -189,7 +187,7 @@ namespace PlayFab.CloudScriptModels
 
         private class FunctionTaskContextInternal
         {
-            public NameIdentifier ScheduledTaskNameId { get; set; }
+            public AdminModels.NameIdentifier ScheduledTaskNameId { get; set; }
 
             public Stack<PlayStreamEventHistory> EventHistory { get; set; }
 
@@ -205,7 +203,7 @@ namespace PlayFab.CloudScriptModels
         public string EntityType { get; set; }
         public string EventName { get; set; }
         public string EventNamespace { get; set; }
-        public dynamic EventData { get; set; }
+        public string EventData { get; set; }
         public string EventSettings { get; set; }
     }
 

--- a/targets/csharp/source/source/Extensions/Models/PlayFabCloudScriptModelsExtensions.cs.ejs
+++ b/targets/csharp/source/source/Extensions/Models/PlayFabCloudScriptModelsExtensions.cs.ejs
@@ -24,6 +24,8 @@ namespace PlayFab.CloudScriptModels
 
         public TFunctionArgument FunctionArgument { get; set; }
 
+        public string CurrentPlayerId { get; set; }
+
         protected FunctionContext() { }
 
         /// <summary>
@@ -39,10 +41,9 @@ namespace PlayFab.CloudScriptModels
                 var contextInternal = Json.PlayFabSimpleJson.DeserializeObject<FunctionContextInternal>(body);
                 var settings = new PlayFabApiSettings
                 {
-                    TitleId = contextInternal.TitleAuthenticationContext.Id
+                    TitleId = contextInternal.TitleAuthenticationContext.Id,
+                    DeveloperSecretKey = Environment.GetEnvironmentVariable("PLAYFAB_DEV_SECRET_KEY", EnvironmentVariableTarget.Process)
                 };
-
-                FunctionContextUtil.TrySetSecretKey(settings);
 
                 var authContext = new PlayFabAuthenticationContext
                 {
@@ -54,7 +55,8 @@ namespace PlayFab.CloudScriptModels
                     ApiSettings = settings,
                     CallerEntityProfile = contextInternal.CallerEntityProfile,
                     FunctionArgument = contextInternal.FunctionArgument,
-                    AuthenticationContext = authContext
+                    AuthenticationContext = authContext,
+                    CurrentPlayerId = contextInternal.CallerEntityProfile.Lineage.TitlePlayerAccountId
                 };
             }
         }
@@ -92,6 +94,8 @@ namespace PlayFab.CloudScriptModels
 
         public TFunctionArgument FunctionArgument { get; set; }
 
+        public string CurrentPlayerId { get; set; }
+
         protected FunctionPlayerPlayStreamContext() { }
 
         /// <summary>
@@ -107,10 +111,9 @@ namespace PlayFab.CloudScriptModels
                 var contextInternal = PlayFabSimpleJson.DeserializeObject<FunctionPlayerPlayStreamContextInternal>(body);
                 var settings = new PlayFabApiSettings
                 {
-                    TitleId = contextInternal.TitleAuthenticationContext.Id
+                    TitleId = contextInternal.TitleAuthenticationContext.Id,
+                    DeveloperSecretKey = Environment.GetEnvironmentVariable("PLAYFAB_DEV_SECRET_KEY", EnvironmentVariableTarget.Process)
                 };
-
-                FunctionContextUtil.TrySetSecretKey(settings);
 
                 var authContext = new PlayFabAuthenticationContext
                 {
@@ -124,6 +127,7 @@ namespace PlayFab.CloudScriptModels
                     PlayStreamEventEnvelope = contextInternal.PlayStreamEventEnvelope,
                     PlayerProfile = contextInternal.PlayerProfile,
                     FunctionArgument = contextInternal.FunctionArgument,
+                    CurrentPlayerId = contextInternal.PlayerProfile.PlayerId
                 };
             }
         }
@@ -174,10 +178,9 @@ namespace PlayFab.CloudScriptModels
                 var contextInternal = PlayFabSimpleJson.DeserializeObject<FunctionTaskContextInternal>(body);
                 var settings = new PlayFabApiSettings
                 {
-                    TitleId = contextInternal.TitleAuthenticationContext.Id
+                    TitleId = contextInternal.TitleAuthenticationContext.Id,
+                    DeveloperSecretKey = Environment.GetEnvironmentVariable("PLAYFAB_DEV_SECRET_KEY", EnvironmentVariableTarget.Process)
                 };
-
-                FunctionContextUtil.TrySetSecretKey(settings);
 
                 var authContext = new PlayFabAuthenticationContext
                 {
@@ -237,25 +240,6 @@ namespace PlayFab.CloudScriptModels
     {
         public string Id { get; set; }
         public string EntityToken { get; set; }
-    }
-
-    internal static class FunctionContextUtil
-    {
-        internal static void TrySetSecretKey(PlayFabApiSettings apiSettings)
-        {
-            var secretKey = Environment.GetEnvironmentVariable("PLAYFAB_DEV_SECRET_KEY", EnvironmentVariableTarget.Process);
-            if (string.IsNullOrEmpty(apiSettings.DeveloperSecretKey))
-            {
-                if (!string.IsNullOrEmpty(secretKey))
-                {
-                    apiSettings.DeveloperSecretKey = secretKey;
-                }
-                else
-                {
-                    throw new Exception("Please set the value in the PLAYFAB_DEV_SECRET_KEY field of the local.settings.json file, within the Values object.");
-                }
-            }
-        }
     }
 }
 #endif

--- a/targets/csharp/source/source/Extensions/Models/PlayFabCloudScriptModelsExtensions.cs.ejs
+++ b/targets/csharp/source/source/Extensions/Models/PlayFabCloudScriptModelsExtensions.cs.ejs
@@ -1,4 +1,4 @@
-#if NETCOREAPP2_0
+#if NETSTANDARD2_0
 namespace PlayFab.CloudScriptModels
 {
     using PlayFab.Json;


### PR DESCRIPTION
The following PR extends the previous `FunctionExecutionContext` (now renamed to `FunctionContext` to account for creating a similar object for both Player PlayStream and Tasks as they are both freshly added invocation mechanisms for Azure Functions which have existed for the classic version of CloudScript. 

As before, these classes are _convenience_ classes which simplify the process of payload de-serialization and Api and Authentication settings assignment for users.