### PR TITLE
Revert "Update unity_RunAutoTests.bat"

### DIFF
--- a/SDKBuildScripts/unity_RunAutoTests.bat
+++ b/SDKBuildScripts/unity_RunAutoTests.bat
@@ -138,13 +138,7 @@ goto :EOF
 :BuildPS4
 echo === Build PS4 Target ===
 cd "%ProjRootPath%\%SdkName%_TC"
-pushd "%WORKSPACE%/SDKGenerator/SDKBuildScripts"
-sh unity_copyTestTitleData.sh "%WORKSPACE%/sdks/UnitySDK/Testing/Resources" copy
-popd
 %UnityExe% -projectPath="%ProjRootPath%\%SdkName%_TC" -quit -batchmode -executeMethod PlayFab.Internal.PlayFabPackager.MakePS4Build -logFile "%ProjRootPath%\buildPS4Output.txt"
-pushd "%WORKSPACE%/SDKGenerator/SDKBuildScripts"
-sh unity_copyTestTitleData.sh "%WORKSPACE%/sdks/UnitySDK/Testing/Resources" delete
-popd
 if %errorLevel% NEQ 0 (
     type "%ProjRootPath%\buildPS4Output.txt"
     exit /b %errorLevel%


### PR DESCRIPTION
Reverts PlayFab/SDKGenerator#511 - Jenkins Setup command is no longer working, so we are seeing an error:

Aborting batchmode due to failure:
21:46:21 executeMethod class 'PlayFabPackager' could not be found.
21:46:21 Argument was -executeMethod PlayFab.Internal.PlayFabPackager.MakeWin32TestingBuild

I saw this last time when unity_setupTestProjects was not ran correctly, so we may have jumped to the wrong directory with this commit.