### PR TITLE
Add ifdef on private localApiServer field

### DIFF
--- a/targets/csharp/source/source/PlayFabSettings.cs.ejs
+++ b/targets/csharp/source/source/PlayFabSettings.cs.ejs
@@ -50,7 +50,7 @@ namespace PlayFab
 #endif
 <% } %>        #endregion Deprecated staticSettingsredirect properties
 
-#if !NET45 && !NETCOREAPP2_0
+#if !NET45 && !NETSTANDARD2_0
         private static string _localApiServer;
 #endif
 
@@ -58,13 +58,13 @@ namespace PlayFab
         {
             get
             {
-#if NET45 || NETCOREAPP2_0
+#if NET45 || NETSTANDARD2_0
                 return PlayFabUtil.GetLocalSettingsFileProperty("LocalApiServer");
 #else
                 return _localApiServer;
 #endif
             }
-#if !NET45 && !NETCOREAPP2_0
+#if !NET45 && !NETSTANDARD2_0
             set
             {
                 _localApiServer = value;

--- a/targets/csharp/source/source/PlayFabSettings.cs.ejs
+++ b/targets/csharp/source/source/PlayFabSettings.cs.ejs
@@ -50,7 +50,9 @@ namespace PlayFab
 #endif
 <% } %>        #endregion Deprecated staticSettingsredirect properties
 
+#if !NET45 && !NETCOREAPP2_0
         private static string _localApiServer;
+#endif
 
         public static string LocalApiServer
         {

--- a/targets/csharp/templates/PlayFabUtil.cs.ejs
+++ b/targets/csharp/templates/PlayFabUtil.cs.ejs
@@ -26,7 +26,7 @@ namespace PlayFab
 
     public static partial class PlayFabUtil
     {
-#if NET45 || NETCOREAPP2_0
+#if NET45 || NETSTANDARD2_0
         private static string _localSettingsFileName = "playfab.local.settings.json";
 #endif
         public static readonly string[] DefaultDateTimeFormats = { // All parseable ISO 8601 formats for DateTime.[Try]ParseExact - Lets us deserialize any legacy timestamps in one of these formats
@@ -54,7 +54,7 @@ namespace PlayFab
             return error.GenerateErrorReport();
         }
 
-#if NET45 || NETCOREAPP2_0
+#if NET45 || NETSTANDARD2_0
         [ThreadStatic]
         private static StringBuilder _sb;
         /// <summary>

--- a/targets/csharp/templates/PlayFabUtil.cs.ejs
+++ b/targets/csharp/templates/PlayFabUtil.cs.ejs
@@ -26,7 +26,9 @@ namespace PlayFab
 
     public static partial class PlayFabUtil
     {
+#if NET45 || NETCOREAPP2_0
         private static string _localSettingsFileName = "playfab.local.settings.json";
+#endif
         public static readonly string[] DefaultDateTimeFormats = { // All parseable ISO 8601 formats for DateTime.[Try]ParseExact - Lets us deserialize any legacy timestamps in one of these formats
             // These are the standard format with ISO 8601 UTC markers (T/Z)
             "yyyy-MM-ddTHH:mm:ss.FFFFFFZ",

--- a/targets/csharp/templates/PlayFabUtil.cs.ejs
+++ b/targets/csharp/templates/PlayFabUtil.cs.ejs
@@ -113,7 +113,7 @@ namespace PlayFab
             if (!string.IsNullOrEmpty(envFileContent))
             {
                 var jsonPlugin = PluginManager.GetPlugin<ISerializerPlugin>(PluginContract.PlayFab_Serializer);
-                dynamic envJson = jsonPlugin.DeserializeObject(envFileContent);
+                JsonObject envJson = (JsonObject) jsonPlugin.DeserializeObject(envFileContent);
                 string result = string.Empty;
                 try
                 {


### PR DESCRIPTION
The `_localApiServer` field is only used if the target framework is not net45 and not core20, and hence can itself also be placed under such an `#if` block.