### PR TITLE
Update PlayFabCommmonUtils.cpp.ejs

### DIFF
--- a/targets/UnrealMarketplacePlugin/source/PlayFab/Source/PlayFabCommon/PlayFabCommon.Build.cs
+++ b/targets/UnrealMarketplacePlugin/source/PlayFab/Source/PlayFabCommon/PlayFabCommon.Build.cs
@@ -33,5 +33,12 @@ public class PlayFabCommon : ModuleRules
                 "Settings"
             });
         }
+
+        BuildVersion Version;
+        BuildVersion.TryRead(BuildVersion.GetDefaultFileName(), out Version);
+        System.Console.WriteLine("MAJOR VERSION {0} MINOR VERSION {1}", Version.MajorVersion, Version.MinorVersion);
+        Definitions.Add(string.Format("ENGINE_MAJOR_VERSION={0}", Version.MajorVersion));
+        Definitions.Add(string.Format("ENGINE_MINOR_VERSION={0}", Version.MinorVersion));
+
     }
 }

--- a/targets/UnrealMarketplacePlugin/source/PlayFab/Source/PlayFabCommon/Private/PlayFabCommmonUtils.cpp.ejs
+++ b/targets/UnrealMarketplacePlugin/source/PlayFab/Source/PlayFabCommon/Private/PlayFabCommmonUtils.cpp.ejs
@@ -1,9 +1,27 @@
-﻿<%- copyright %>
+<%- copyright %>
 
 #include "PlayFabCommonUtils.h"
 
 using namespace PlayFabCommon;
 
+// see {your unreal root folder}\Engine\Source\Runtime\Launch\Resources\Version.h for more preprocessor defines
+#if ENGINE_MINOR_VERSION==20
+FString PlayFabCommonUtils::GetTempDir()
+{
+    FString vars[] = { TEXT("TEMPDIR"), TEXT("TEMP"), TEXT("TMP") };
+    TCHAR FileSystemPath[256];
+    for (FString& envVar : vars)
+    {
+       FileSystemPath[0] = 0;
+        FPlatformMisc::GetEnvironmentVariable(*envVar, FileSystemPath, 256);
+        if (FileSystemPath[0])
+        {
+            return FString(256, FileSystemPath);
+        }
+    }
+    return FString();
+}
+#else
 FString PlayFabCommonUtils::GetTempDir()
 {
     FString vars[] = { TEXT("TEMPDIR"), TEXT("TEMP"), TEXT("TMP") };
@@ -17,6 +35,7 @@ FString PlayFabCommonUtils::GetTempDir()
     }
     return FString();
 }
+#endif
 
 FString PlayFabCommonUtils::GetLocalSettingsFileContent()
 {

--- a/targets/UnrealMarketplacePlugin/source/PlayFab/Source/PlayFabCommon/Private/PlayFabCommmonUtils.cpp.ejs
+++ b/targets/UnrealMarketplacePlugin/source/PlayFab/Source/PlayFabCommon/Private/PlayFabCommmonUtils.cpp.ejs
@@ -4,19 +4,24 @@
 
 using namespace PlayFabCommon;
 
+// GetEnvironmentVariable with 3 parameters is considered deprecated:
+// http://api.unrealengine.com/INT/API/Runtime/Core/GenericPlatform/FGenericPlatformMisc/GetEnvironmentVariable/2/index.html
+// The newer version of GetEnvironmentVariable with a single parameter broke our 4.20 plugin build for the Epic Store
+// 
 // see {your unreal root folder}\Engine\Source\Runtime\Launch\Resources\Version.h for more preprocessor defines
 #if ENGINE_MINOR_VERSION==20
 FString PlayFabCommonUtils::GetTempDir()
 {
     FString vars[] = { TEXT("TEMPDIR"), TEXT("TEMP"), TEXT("TMP") };
-    TCHAR FileSystemPath[256];
+    const int expectedPathSize = 256;
+    TCHAR FileSystemPath[expectedSize];
     for (FString& envVar : vars)
     {
-       FileSystemPath[0] = 0;
-        FPlatformMisc::GetEnvironmentVariable(*envVar, FileSystemPath, 256);
+        FileSystemPath[0] = 0;
+        FPlatformMisc::GetEnvironmentVariable(*envVar, FileSystemPath, expectedPathSize);
         if (FileSystemPath[0])
         {
-            return FString(256, FileSystemPath);
+            return FString(expectedPathSize, FileSystemPath);
         }
     }
     return FString();


### PR DESCRIPTION
adding in a deprecated unreal call to just 4.20 logic paths.