### PR TITLE
Mimacken/sdkbuildscripts unity bash

### DIFF
--- a/SDKBuildScripts/runAppCenterTest.sh
+++ b/SDKBuildScripts/runAppCenterTest.sh
@@ -31,6 +31,7 @@ Devices=f749a00a
 else #invalid platform
 echo "Error: invalid platform entry!"
 echo $Usage
+exit
 fi
 
 echo "=== Starting AppCenter Test Run with Params: ==="

--- a/SDKBuildScripts/unity_RunAutoTests.sh
+++ b/SDKBuildScripts/unity_RunAutoTests.sh
@@ -134,7 +134,7 @@ ExecXboxOnConsole() {
 
 TryBuildAndTestAndroid() {
     echo "TestAndroid: $TestAndroid"
-    if [ "$TestAndroid" = "true"]; then
+    if [ "$TestAndroid" = "true" ]; then
         echo === Build and Test Android ===
         pushd "${ProjRootPath}/${SdkName}_TC"
             pushd "$WORKSPACE/SDKGenerator/SDKBuildScripts"
@@ -157,7 +157,7 @@ TryBuildAndTestAndroid() {
 
 TryBuildAndTestiOS() {
     echo "TestiPhone: $TestiPhone"
-    if [ "$TestiPhone" = "true"]; then
+    if [ "$TestiPhone" = "true" ]; then
         echo === Build and Test iOS ===
         pushd "${ProjRootPath}/${SdkName}_TC"
 

--- a/SDKBuildScripts/unity_RunAutoTests.sh
+++ b/SDKBuildScripts/unity_RunAutoTests.sh
@@ -139,16 +139,16 @@ TryBuildAndTestAndroid() {
             pushd "$WORKSPACE/SDKGenerator/SDKBuildScripts"
                 ./unity_copyTestTitleData.sh "$WORKSPACE/sdks/UnitySDK/Testing/Resources" copy
             popd
-            if [[ $? -ne 0 ]]; then return 1
+            if [[ $? -ne 0 ]]; then return 1; fi
             
             $UNITY_VERSION -projectPath "$WORKSPACE/$UNITY_VERSION/${SdkName}_TC" -quit -batchmode -executeMethod PlayFab.Internal.PlayFabPackager.MakeAndroidBuild -logFile "$WORKSPACE/${SdkName}/buildPackageOutput.txt" || (cat "$WORKSPACE/${SdkName}/buildAndroidOutput.txt" && return 1)
-            if [[ $? -ne 0 ]]; then return 1
+            if [[ $? -ne 0 ]]; then return 1; fi
             
             pushd "$WORKSPACE/SDKGenerator/SDKBuildScripts"
                 ./unity_copyTestTitleData.sh "$WORKSPACE/sdks/UnitySDK/Testing/Resources" delete
-                if [[ $? -ne 0 ]]; then return 1
+                if [[ $? -ne 0 ]]; then return 1; fi
                 ./runAppCenterTest.sh "$ProjRootPath/${SdkName}_TC/testBuilds/PlayFabAndroid.apk" "$WORKSPACE/SDKGenerator/SDKBuildScripts/AppCenterUITestLauncher/AppCenterUITestLauncher/debugassemblies" unity-android
-                if [[ $? -ne 0 ]]; then return 1
+                if [[ $? -ne 0 ]]; then return 1; fi
             popd
         popd
     fi

--- a/SDKBuildScripts/unity_RunAutoTests.sh
+++ b/SDKBuildScripts/unity_RunAutoTests.sh
@@ -97,7 +97,7 @@ RunClientJenkernaught() {
         echo === Run the $UNITY_VERSION Client UnitTests ===
         pushd "${ProjRootPath}/${SdkName}_TC/testBuilds"
         ls
-        cmd <<< "Win32test.exe -batchmode -nographics -logFile \"${ProjRootPath}/clientTestOutput.txt" || (cat "${ProjRootPath}/clientTestOutput.txt" && return 1)
+        cmd <<< "Win32test.exe -batchmode -nographics -logFile \"${ProjRootPath}/clientTestOutput.txt\" || (cat "${ProjRootPath}/clientTestOutput.txt" && return 1)
         popd
 
         echo === Save test results to Jenkernaught ===
@@ -133,6 +133,7 @@ ExecXboxOnConsole() {
 }
 
 TryBuildAndTestAndroid() {
+    echo "TestAndroid: $TestAndroid"
     if [ "$TestAndroid" = "true"]; then
         echo === Build and Test Android ===
         pushd "${ProjRootPath}/${SdkName}_TC"
@@ -155,6 +156,7 @@ TryBuildAndTestAndroid() {
 }
 
 TryBuildAndTestiOS() {
+    echo "TestiPhone: $TestiPhone"
     if [ "$TestiPhone" = "true"]; then
         echo === Build and Test iOS ===
         pushd "${ProjRootPath}/${SdkName}_TC"

--- a/SDKBuildScripts/unity_RunAutoTests.sh
+++ b/SDKBuildScripts/unity_RunAutoTests.sh
@@ -227,7 +227,7 @@ DoWork() {
 
     KillUnityProcesses
 
-    exit $(EC $(($AndroidResult + bg$iOSResult + $Wp8Result + $PS4Result + $SwitchResult + $XBoxResult)))
+    exit $(EC $(($AndroidResult + $iOSResult + $Wp8Result + $PS4Result + $SwitchResult + $XBoxResult)))
 }
 
 DoWork

--- a/SDKBuildScripts/unity_RunAutoTests.sh
+++ b/SDKBuildScripts/unity_RunAutoTests.sh
@@ -26,10 +26,10 @@ if [ -z $2 ]; then
 else
     SdkName=$2
 fi
-if [ -z $3 ]; then
+if [ -z "$3" ]; then
     ProjRootPath="${WORKSPACE}/${UNITY_VERSION}"
 else
-    ProjRootPath=$3
+    ProjRootPath="$3"
 fi
 if [ -z $4 ]; then
     BuildIdentifier=JBuild_${SdkName}_${EXECUTOR_NUMBER}

--- a/SDKBuildScripts/unity_RunAutoTests.sh
+++ b/SDKBuildScripts/unity_RunAutoTests.sh
@@ -108,6 +108,7 @@ RunClientJenkernaught() {
         popd
 
         JenkernaughtSaveCloudScriptResults
+        if [[ $? -ne 0 ]]; then return 1; fi
     fi
 }
 
@@ -121,8 +122,6 @@ BuildClientByFunc() {
         if [ ! -z "$3" ]; then
             $3
         fi
-    else
-        return 2
     fi
 }
 
@@ -159,10 +158,7 @@ TryBuildAndTestAndroid() {
             popd
 
             JenkernaughtSaveCloudScriptResults
-            if [[ $? -ne 0 ]]; then return 1; fi
         popd
-    else 
-        return 2
     fi
 }
 
@@ -193,8 +189,6 @@ TryBuildAndTestiOS() {
             JenkernaughtSaveCloudScriptResults
             if [[ $? -ne 0 ]]; then return 1; fi
         popd
-    else 
-        return 2
     fi
 }
 
@@ -207,14 +201,13 @@ BuildMainPackage() {
 }
 
 EM() {
-    if [ $1 -eq 2 ]; then echo "N/A"
+    if [ "$2" != "true" ]; then echo "N/A"
     elif [ $1 -ne 0 ]; then echo FAIL
     else echo PASS
     fi
 }
 
 EC() {
-    if [ $1 -eq 2 ]; then return 0; fi
     if [ $1 -ne 0 ]; then return 1; else return 0; fi
 }
 
@@ -230,12 +223,12 @@ DoWork() {
     BuildClientByFunc "$TestXbox" "MakeXboxOneBuild" "ExecXboxOnConsole"; XBoxResult=$?
     BuildMainPackage
 
-    echo -e "Android Result:\t$(EM $AndroidResult)"
-    echo -e "iOS Result:\t\t$(EM $iOSResult)"
-    echo -e "Wp8 Result:\t\t$(EM $Wp8Result)"
-    echo -e "PS4 Result:\t\t$(EM $PS4Result)"
-    echo -e "Switch Result:\t\t$(EM $SwitchResult)"
-    echo -e "XBox Result:\t\t$(EM $XBoxResult)"
+    echo -e "Android Result:\t$(EM $AndroidResult $TestAndroid)"
+    echo -e "iOS Result:\t\t$(EM $iOSResult $TestiPhone)"
+    echo -e "Wp8 Result:\t\t$(EM $Wp8Result $TestWp8)"
+    echo -e "PS4 Result:\t\t$(EM $PS4Result $TestPS4)"
+    echo -e "Switch Result:\t\t$(EM $SwitchResult $TestSwitch)"
+    echo -e "XBox Result:\t\t$(EM $XBoxResult $TestXbox)"
 
     KillUnityProcesses
 

--- a/SDKBuildScripts/unity_RunAutoTests.sh
+++ b/SDKBuildScripts/unity_RunAutoTests.sh
@@ -172,7 +172,7 @@ TryBuildAndTestiOS() {
             popd
             if [[ $? -ne 0 ]]; then return 1; fi
             
-            $UNITY_VERSION -projectPath "$WORKSPACE/$UNITY_VERSION/${SdkName}_TC" -quit -batchmode -executeMethod PlayFab.Internal.PlayFabPackager.MakeAndroidBuild -logFile "$WORKSPACE/${SdkName}/buildPackageOutput.txt" || (cat "$WORKSPACE/${SdkName}/buildiPhoneOutput.txt" && return 1)
+            $UNITY_VERSION -projectPath "$WORKSPACE/$UNITY_VERSION/${SdkName}_TC" -quit -batchmode -executeMethod PlayFab.Internal.PlayFabPackager.MakeIPhoneBuild -logFile "$WORKSPACE/${SdkName}/buildPackageOutput.txt" || (cat "$WORKSPACE/${SdkName}/buildiPhoneOutput.txt" && return 1)
             if [[ $? -ne 0 ]]; then return 1; fi
             
             pushd "$WORKSPACE/SDKGenerator/SDKBuildScripts"

--- a/SDKBuildScripts/unity_RunAutoTests.sh
+++ b/SDKBuildScripts/unity_RunAutoTests.sh
@@ -218,10 +218,10 @@ DoWork() {
     BuildClientByFunc "$TestXbox" "MakeXboxOneBuild" "ExecXboxOnConsole"; XBoxResult=$?
     BuildMainPackage
 
-    echo -e "Android Result:\t\t$(EM $AndroidResult)"
+    echo -e "Android Result:\t$(EM $AndroidResult)"
     echo -e "iOS Result:\t\t$(EM $iOSResult)"
     echo -e "Wp8 Result:\t\t$(EM $Wp8Result)"
-    echo -e "PS4 Result:\t\t$(EM $PS4dResult)"
+    echo -e "PS4 Result:\t\t$(EM $PS4Result)"
     echo -e "Switch Result:\t\t$(EM $SwitchResult)"
     echo -e "XBox Result:\t\t$(EM $XBoxResult)"
 

--- a/SDKBuildScripts/unity_RunAutoTests.sh
+++ b/SDKBuildScripts/unity_RunAutoTests.sh
@@ -234,6 +234,11 @@ EC() {
     if [ $1 -ne 0 ]; then return 1; else return 0; fi
 }
 
+KillUnityProcesses() {
+    pushd "$WORKSPACE/SDKGenerator/JenkinsConsoleUtility/bin/Debug"
+    cmd <<< "JenkinsConsoleUtility --kill -taskName $UNITY_VERSION"
+}
+
 DoWork() {
     CheckVars
     SetProjDefines

--- a/SDKBuildScripts/unity_RunAutoTests.sh
+++ b/SDKBuildScripts/unity_RunAutoTests.sh
@@ -97,7 +97,7 @@ RunClientJenkernaught() {
         echo === Run the $UNITY_VERSION Client UnitTests ===
         pushd "${ProjRootPath}/${SdkName}_TC/testBuilds"
         ls
-        cmd <<< "Win32test.exe -batchmode -nographics -logFile \"${ProjRootPath}/clientTestOutput.txt\" || (cat "${ProjRootPath}/clientTestOutput.txt" && return 1)
+        cmd <<< "Win32test.exe -batchmode -nographics -logFile \"${ProjRootPath}/clientTestOutput.txt\"" || (cat "${ProjRootPath}/clientTestOutput.txt" && return 1)
         popd
 
         echo === Save test results to Jenkernaught ===

--- a/SDKBuildScripts/unity_RunAutoTests.sh
+++ b/SDKBuildScripts/unity_RunAutoTests.sh
@@ -182,7 +182,7 @@ TryBuildAndTestiOS() {
                 ./unity_buildAppCenterTestIOS.sh "$ProjRootPath/${SdkName}_TC/testBuilds/PlayFabIOS" "$WORKSPACE/vso" 'git@ssh.dev.azure.com:v3/playfab/Playfab%20SDK%20Automation/UnitySDK_XCode_AppCenterBuild' $JOB_NAME init
                 if [[ $? -ne 0 ]]; then return 1; fi
 
-                ./runAppCenterTest.sh "$ProjRootPath/${SdkName}_TC/testBuilds/PlayFabAndroid.apk" "$WORKSPACE/SDKGenerator/SDKBuildScripts/AppCenterUITestLauncher/AppCenterUITestLauncher/debugassemblies" ios
+                ./runAppCenterTest.sh "$WORKSPACE/SDKGenerator/SDKBuildScripts/PlayFabIOS.ipa" "$WORKSPACE/SDKGenerator/SDKBuildScripts/AppCenterUITestLauncher/AppCenterUITestLauncher/debugassemblies" ios
                 if [[ $? -ne 0 ]]; then return 1; fi
             popd
 

--- a/SDKBuildScripts/unity_RunAutoTests.sh
+++ b/SDKBuildScripts/unity_RunAutoTests.sh
@@ -121,6 +121,8 @@ BuildClientByFunc() {
         if [ ! -z "$3" ]; then
             $3
         fi
+    else
+        return 2
     fi
 }
 
@@ -159,6 +161,8 @@ TryBuildAndTestAndroid() {
             JenkernaughtSaveCloudScriptResults
             if [[ $? -ne 0 ]]; then return 1; fi
         popd
+    else 
+        return 2
     fi
 }
 
@@ -189,6 +193,8 @@ TryBuildAndTestiOS() {
             JenkernaughtSaveCloudScriptResults
             if [[ $? -ne 0 ]]; then return 1; fi
         popd
+    else 
+        return 2
     fi
 }
 
@@ -200,9 +206,15 @@ BuildMainPackage() {
     fi
 }
 
+EM() {
+    if [ $1 -eq 2 ]; then echo "N/A"
+    elif [ $1 -ne 0 ]; then echo FAIL
+    else echo PASS
+    fi
 }
-    cmd <<< "JenkinsConsoleUtility --kill -taskName $UNITY_VERSION"
+
 EC() {
+    if [ $1 -eq 2 ]; then return 0; fi
     if [ $1 -ne 0 ]; then return 1; else return 0; fi
 }
 

--- a/SDKBuildScripts/unity_RunAutoTests.sh
+++ b/SDKBuildScripts/unity_RunAutoTests.sh
@@ -148,7 +148,7 @@ TryBuildAndTestAndroid() {
             pushd "$WORKSPACE/SDKGenerator/SDKBuildScripts"
                 ./unity_copyTestTitleData.sh "$WORKSPACE/sdks/UnitySDK/Testing/Resources" delete
                 if [[ $? -ne 0 ]]; then return 1; fi
-                ./runAppCenterTest.sh "$ProjRootPath/${SdkName}_TC/testBuilds/PlayFabAndroid.apk" "$WORKSPACE/SDKGenerator/SDKBuildScripts/AppCenterUITestLauncher/AppCenterUITestLauncher/debugassemblies" unity-android
+                ./runAppCenterTest.sh "$ProjRootPath/${SdkName}_TC/testBuilds/PlayFabAndroid.apk" "$WORKSPACE/SDKGenerator/SDKBuildScripts/AppCenterUITestLauncher/AppCenterUITestLauncher/debugassemblies" android
                 if [[ $? -ne 0 ]]; then return 1; fi
             popd
         popd

--- a/SDKBuildScripts/unity_RunAutoTests.sh
+++ b/SDKBuildScripts/unity_RunAutoTests.sh
@@ -220,7 +220,7 @@ DoWork() {
 
     echo -e "Android Result:\t\t$(EM $AndroidResult)"
     echo -e "iOS Result:\t\t$(EM $iOSResult)"
-    echo -e"Wp8 Result:\t\t$(EM $Wp8Result)"
+    echo -e "Wp8 Result:\t\t$(EM $Wp8Result)"
     echo -e "PS4 Result:\t\t$(EM $PS4dResult)"
     echo -e "Switch Result:\t\t$(EM $SwitchResult)"
     echo -e "XBox Result:\t\t$(EM $XBoxResult)"


### PR DESCRIPTION
- Reintegrates iOS and Android unity appcenter work into the runautotests.sh.

- Adds some summarized output to the console log of the jenkins job to make for an easier time figuring where failure might have occurred in what is a very large Jenkins job.
