### PR TITLE
add appcenter unity cli argument and only link calabsh when active

### DIFF
--- a/SDKBuildScripts/unity_RunAutoTests.sh
+++ b/SDKBuildScripts/unity_RunAutoTests.sh
@@ -187,7 +187,7 @@ TryBuildAndTestiOS() {
             if [[ $? -ne 0 ]]; then return 1; fi
             
             #build the xcode project to prepare for IPA generation
-            $UNITY_VERSION -projectPath "$WORKSPACE/$UNITY_VERSION/${SdkName}_TC" -quit -batchmode -executeMethod PlayFab.Internal.PlayFabPackager.MakeIPhoneBuild -logFile "$WORKSPACE/${SdkName}/buildPackageOutput.txt" || (cat "$WORKSPACE/${SdkName}/buildiPhoneOutput.txt" && return 1)
+            $UNITY_VERSION -projectPath "$WORKSPACE/$UNITY_VERSION/${SdkName}_TC" -quit -batchmode -appcenter -executeMethod PlayFab.Internal.PlayFabPackager.MakeIPhoneBuild -logFile "$WORKSPACE/${SdkName}/buildPackageOutput.txt" || (cat "$WORKSPACE/${SdkName}/buildiPhoneOutput.txt" && return 1)
             if [[ $? -ne 0 ]]; then return 1; fi
             
             pushd "$WORKSPACE/SDKGenerator/SDKBuildScripts"

--- a/targets/unity-v2/Testing/Editor/PlayFabPackager.cs
+++ b/targets/unity-v2/Testing/Editor/PlayFabPackager.cs
@@ -21,6 +21,11 @@ namespace PlayFab.Internal
         private void OnPostprocessBuildiOS(BuildReport report)
         {
 #if UNITY_IOS
+            if(!IsBuiltForAppCenter)
+            {
+                return;
+            }
+
             Debug.Log("TestAppPostBuildProcessor.OnPostprocessBuild for target " + report.summary.platform + " at path " + report.summary.outputPath);
             BuildTarget buildTarget = report.summary.platform;
             string path = report.summary.outputPath;
@@ -45,6 +50,15 @@ namespace PlayFab.Internal
 
             File.WriteAllText(projectPath, proj.WriteToString());
 #endif
+        }
+
+        private static bool IsBuiltForAppCenter 
+        {
+            get 
+            {
+                var args = new System.Collections.Generic.List<string>(Environment.GetCommandLineArgs());
+                return args.Contains("-appcenter");
+            }
         }
     }
 


### PR DESCRIPTION
Adds a CLI argument for unity to flag a built as being intended for appcenter.  This prevents the postprocessor from trying to link calabash when it's not needed.