### PR TITLE
XPlat: removed wrong header include in LibUnitTest project that was not needed but required a specific dependency

### DIFF
--- a/targets/XPlatCppSdk/source/test/LibUnitTest/stdafx.h
+++ b/targets/XPlatCppSdk/source/test/LibUnitTest/stdafx.h
@@ -1,7 +1,6 @@
 #pragma once
 
-// Headers for CppUnitTest
-#include <CppUnitTest.h>
+#include <string>
 
 inline std::wstring U(std::string input)
 {


### PR DESCRIPTION
- Removed wrong header include which "worked" when building LibUnitTest on a local PC but failed when building on a Jenkins slave which happened not to have a specific dependency lib