### PR TITLE
Update PlayFabCommon.Build.cs

### DIFF
--- a/targets/UnrealMarketplacePlugin/source/PlayFab/Source/PlayFabCommon/PlayFabCommon.Build.cs
+++ b/targets/UnrealMarketplacePlugin/source/PlayFab/Source/PlayFabCommon/PlayFabCommon.Build.cs
@@ -37,8 +37,8 @@ public class PlayFabCommon : ModuleRules
         BuildVersion Version;
         BuildVersion.TryRead(BuildVersion.GetDefaultFileName(), out Version);
         System.Console.WriteLine("MAJOR VERSION {0} MINOR VERSION {1}", Version.MajorVersion, Version.MinorVersion);
-        Definitions.Add(string.Format("ENGINE_MAJOR_VERSION={0}", Version.MajorVersion));
-        Definitions.Add(string.Format("ENGINE_MINOR_VERSION={0}", Version.MinorVersion));
+        PublicDefinitions.Add(string.Format("ENGINE_MAJOR_VERSION={0}", Version.MajorVersion));
+        PublicDefinitions.Add(string.Format("ENGINE_MINOR_VERSION={0}", Version.MinorVersion));
 
     }
 }


### PR DESCRIPTION
Fix for warning CS0618: 'UnrealBuildTool.ModuleRules.Definitions' is obsolete: 'The 'Definitions' property has been deprecated. Please use 'PublicDefinitions' instead.'