### PR TITLE
remove quotes from expression to become compatible with macos terminal

### DIFF
--- a/JenkinsConsoleUtility/JenkinsScripts/util.sh
+++ b/JenkinsConsoleUtility/JenkinsScripts/util.sh
@@ -82,7 +82,7 @@ CleanCurrentRepo () {
 # USAGE: _CleanCurrentRepo <retryCounter> <gitBranchName>
 _CleanCurrentRepo () {
     # Increment the retryCounter
-    set -- $(("$1+1")) $2
+    set -- $(($1+1)) $2
     if [ "$1" -gt "10" ]; then
         exit 10 # Timeout
     fi


### PR DESCRIPTION
The quotes were problematic for MacOS.  They resulted in a syntax error pasted below.  I tested the un-quoted expression on both Windows and MacOS.

` syntax error: operand expected (error token is ""0+1"")`