### PR TITLE
spawn uploader instead of instantiating so as to give it world access

### DIFF
--- a/targets/UnrealMarketplacePlugin/examplesource/ExampleProject/Source/ExampleProject/ACLoudScriptTestResultUploader.h.ejs
+++ b/targets/UnrealMarketplacePlugin/examplesource/ExampleProject/Source/ExampleProject/ACLoudScriptTestResultUploader.h.ejs
@@ -20,9 +20,9 @@ public:
     void UploadToCloudscript(const TArray<class UPlayFabTestContext*>& SuiteTests);
 
 private:
-    void SuccessfulUpload(const PlayFab::ClientModels::FExecuteCloudScriptResult& result) const;
+    void SuccessfulUpload(const PlayFab::ClientModels::FExecuteCloudScriptResult& result);
 
-    void UploadErrored(const PlayFab::FPlayFabCppError& error) const;
+    void UploadErrored(const PlayFab::FPlayFabCppError& error);
 
     bool ShouldQuitOnCompletion() const;
 };

--- a/targets/UnrealMarketplacePlugin/examplesource/ExampleProject/Source/ExampleProject/ACloudScriptTestResultUploader.cpp.ejs
+++ b/targets/UnrealMarketplacePlugin/examplesource/ExampleProject/Source/ExampleProject/ACloudScriptTestResultUploader.cpp.ejs
@@ -74,6 +74,7 @@ void ACloudScriptTestResultUploader::SuccessfulUpload(const PlayFab::ClientModel
     if(ShouldQuitOnCompletion()) {
         FGenericPlatformMisc::RequestExit(true);
     }
+    Destroy();
 }
 
 void ACloudScriptTestResultUploader::UploadErrored(const PlayFab::FPlayFabCppError& error) const
@@ -82,6 +83,7 @@ void ACloudScriptTestResultUploader::UploadErrored(const PlayFab::FPlayFabCppErr
     if(ShouldQuitOnCompletion()) {
         FGenericPlatformMisc::RequestExit(true);
     }
+    Destroy();
 }
 
 bool ACloudScriptTestResultUploader::ShouldQuitOnCompletion() const {

--- a/targets/UnrealMarketplacePlugin/examplesource/ExampleProject/Source/ExampleProject/ACloudScriptTestResultUploader.cpp.ejs
+++ b/targets/UnrealMarketplacePlugin/examplesource/ExampleProject/Source/ExampleProject/ACloudScriptTestResultUploader.cpp.ejs
@@ -80,6 +80,9 @@ void ACloudScriptTestResultUploader::SuccessfulUpload(const PlayFab::ClientModel
 void ACloudScriptTestResultUploader::UploadErrored(const PlayFab::FPlayFabCppError& error) const
 {
     UE_LOG(LogTestResults, Error, TEXT("Cloud Upload Error: \n%s"), *error.GenerateErrorReport());
+    if(ShouldQuitOnCompletion()) {
+        FGenericPlatformMisc::RequestExit(true);
+    }
 }
 
 bool ACloudScriptTestResultUploader::ShouldQuitOnCompletion() const {

--- a/targets/UnrealMarketplacePlugin/examplesource/ExampleProject/Source/ExampleProject/ACloudScriptTestResultUploader.cpp.ejs
+++ b/targets/UnrealMarketplacePlugin/examplesource/ExampleProject/Source/ExampleProject/ACloudScriptTestResultUploader.cpp.ejs
@@ -68,7 +68,7 @@ void ACloudScriptTestResultUploader::UploadToCloudscript(const TArray<class UPla
     );
 }
 
-void ACloudScriptTestResultUploader::SuccessfulUpload(const PlayFab::ClientModels::FExecuteCloudScriptResult& result) const
+void ACloudScriptTestResultUploader::SuccessfulUpload(const PlayFab::ClientModels::FExecuteCloudScriptResult& result)
 {
     UE_LOG(LogTestResults, Log, TEXT("Cloud Upload Success: \n%s"), *result.toJSONString());
     if(ShouldQuitOnCompletion()) {
@@ -77,7 +77,7 @@ void ACloudScriptTestResultUploader::SuccessfulUpload(const PlayFab::ClientModel
     Destroy();
 }
 
-void ACloudScriptTestResultUploader::UploadErrored(const PlayFab::FPlayFabCppError& error) const
+void ACloudScriptTestResultUploader::UploadErrored(const PlayFab::FPlayFabCppError& error)
 {
     UE_LOG(LogTestResults, Error, TEXT("Cloud Upload Error: \n%s"), *error.GenerateErrorReport());
     if(ShouldQuitOnCompletion()) {

--- a/targets/UnrealMarketplacePlugin/examplesource/ExampleProject/Source/ExampleProject/ACloudScriptTestResultUploader.cpp.ejs
+++ b/targets/UnrealMarketplacePlugin/examplesource/ExampleProject/Source/ExampleProject/ACloudScriptTestResultUploader.cpp.ejs
@@ -11,7 +11,6 @@
 
 #include "Runtime/Engine/Classes/Engine/World.h"
 
-
 DEFINE_LOG_CATEGORY(LogTestResults);
 
 void ACloudScriptTestResultUploader::UploadToCloudscript(const TArray<class UPlayFabTestContext*>& SuiteTests)

--- a/targets/UnrealMarketplacePlugin/examplesource/ExampleProject/Source/ExampleProject/ACloudScriptTestResultUploader.cpp.ejs
+++ b/targets/UnrealMarketplacePlugin/examplesource/ExampleProject/Source/ExampleProject/ACloudScriptTestResultUploader.cpp.ejs
@@ -8,6 +8,10 @@
 #include "Core/PlayFabClientAPI.h"
 #include "PlayFabTestContext.h"
 #include "GenericPlatformMisc.h"
+
+#include "Runtime/Engine/Classes/Engine/World.h"
+
+
 DEFINE_LOG_CATEGORY(LogTestResults);
 
 void ACloudScriptTestResultUploader::UploadToCloudscript(const TArray<class UPlayFabTestContext*>& SuiteTests)

--- a/targets/UnrealMarketplacePlugin/examplesource/ExampleProject/Source/ExampleProject/PfTestActor.cpp.ejs
+++ b/targets/UnrealMarketplacePlugin/examplesource/ExampleProject/Source/ExampleProject/PfTestActor.cpp.ejs
@@ -1,6 +1,4 @@
-//////////////////////////////////////////////////////
-// Copyright (C) Microsoft. 2018. All rights reserved.
-//////////////////////////////////////////////////////
+<%- copyright %>
 
 
 #include "PfTestActor.h"
@@ -29,10 +27,10 @@ void APfTestActor::BeginPlay()
 }
 
 ACloudScriptTestResultUploader* SpawnUploader(UWorld* world) {
-       FActorSpawnParameters spawnParams;
-       FVector loc(0, 0, 0);
-       FRotator rot(0, 0, 0);
-       return world->SpawnActor<ACloudScriptTestResultUploader>(loc, rot, spawnParams);
+    FActorSpawnParameters spawnParams;
+    FVector loc(0, 0, 0);
+    FRotator rot(0, 0, 0);
+    return world->SpawnActor<ACloudScriptTestResultUploader>(loc, rot, spawnParams);
 }
 
 void APfTestActor::Tick(float DeltaTime)

--- a/targets/UnrealMarketplacePlugin/examplesource/ExampleProject/Source/ExampleProject/PfTestActor.cpp.ejs
+++ b/targets/UnrealMarketplacePlugin/examplesource/ExampleProject/Source/ExampleProject/PfTestActor.cpp.ejs
@@ -48,10 +48,6 @@ void APfTestActor::Tick(float DeltaTime)
 void APfTestActor::EndPlay(const EEndPlayReason::Type reason)
 {
     Super::EndPlay(reason);
-    if(pUploader != nullptr)
-    {
-        delete pUploader;
-    }
 }
 
 bool APfTestActor::TestsAreComplete() const {

--- a/targets/UnrealMarketplacePlugin/examplesource/ExampleProject/Source/ExampleProject/PfTestActor.cpp.ejs
+++ b/targets/UnrealMarketplacePlugin/examplesource/ExampleProject/Source/ExampleProject/PfTestActor.cpp.ejs
@@ -1,9 +1,15 @@
-<%- copyright %>
+//////////////////////////////////////////////////////
+// Copyright (C) Microsoft. 2018. All rights reserved.
+//////////////////////////////////////////////////////
+
 
 #include "PfTestActor.h"
 
 #include "Tests/PlayFabCppTests.h"
 #include "Tests/PlayFabBlueprintTests.h"
+
+#include "Runtime/Engine/Classes/Engine/World.h"
+
 
 // Sets default values
 APfTestActor::APfTestActor()
@@ -22,7 +28,13 @@ void APfTestActor::BeginPlay()
     _submitCloudScript = false;
 }
 
-// Called every frame
+ACloudScriptTestResultUploader* SpawnUploader(UWorld* world) {
+       FActorSpawnParameters spawnParams;
+       FVector loc(0, 0, 0);
+       FRotator rot(0, 0, 0);
+       return world->SpawnActor<ACloudScriptTestResultUploader>(loc, rot, spawnParams);
+}
+
 void APfTestActor::Tick(float DeltaTime)
 {
     Super::Tick(DeltaTime);
@@ -31,8 +43,8 @@ void APfTestActor::Tick(float DeltaTime)
 
     if (TestsAreComplete() && !_submitCloudScript)
     {
+        pUploader = SpawnUploader(GetWorld());
         _submitCloudScript = true;
-        pUploader = NewObject<ACloudScriptTestResultUploader>();
         pUploader->UploadToCloudscript(SuiteTests);
     }
 }

--- a/targets/UnrealMarketplacePlugin/examplesource/ExampleProject/Source/ExampleProject/PfTestActor.cpp.ejs
+++ b/targets/UnrealMarketplacePlugin/examplesource/ExampleProject/Source/ExampleProject/PfTestActor.cpp.ejs
@@ -1,13 +1,11 @@
 <%- copyright %>
 
-
 #include "PfTestActor.h"
 
 #include "Tests/PlayFabCppTests.h"
 #include "Tests/PlayFabBlueprintTests.h"
 
 #include "Runtime/Engine/Classes/Engine/World.h"
-
 
 // Sets default values
 APfTestActor::APfTestActor()

--- a/targets/UnrealMarketplacePlugin/examplesource/ExampleProject/Source/ExampleProject/PfTestActor.cpp.ejs
+++ b/targets/UnrealMarketplacePlugin/examplesource/ExampleProject/Source/ExampleProject/PfTestActor.cpp.ejs
@@ -39,7 +39,7 @@ void APfTestActor::Tick(float DeltaTime)
 
     if (TestsAreComplete() && !_submitCloudScript)
     {
-        pUploader = SpawnUploader(GetWorld());
+        auto pUploader = SpawnUploader(GetWorld());
         _submitCloudScript = true;
         pUploader->UploadToCloudscript(SuiteTests);
     }

--- a/targets/UnrealMarketplacePlugin/examplesource/ExampleProject/Source/ExampleProject/PfTestActor.h.ejs
+++ b/targets/UnrealMarketplacePlugin/examplesource/ExampleProject/Source/ExampleProject/PfTestActor.h.ejs
@@ -25,9 +25,6 @@ private:
     UPROPERTY()
     bool _submitCloudScript;
 
-    UPROPERTY()
-    ACloudScriptTestResultUploader* pUploader;
-
     UFUNCTION()
     bool TestsAreComplete() const;
 };


### PR DESCRIPTION
The uploader was not spawned in the scene so it didn't have access to the world instance, hence it would never terminate.  This replaces the instantiation with spawning, fixing that issue.   A consequence of this is that the test actor is no longer the owner of the uploader- the world is. Hence, the uploader now calls destroy on itself when it's work is complete and lets the garbage collector do the rest .