### PR TITLE
Mimacken/appcenter unreal ios

### DIFF
--- a/targets/UnrealMarketplacePlugin/examplesource/ExampleProject/BuildAndRunTestsIOS.sh
+++ b/targets/UnrealMarketplacePlugin/examplesource/ExampleProject/BuildAndRunTestsIOS.sh
@@ -39,7 +39,7 @@ ios-deploy -b  Payload/ExampleProject.app -I -r
 deployResult=$?
 
 #if the deploy failed, log it out and exit
-if[ $deployResult -ne 0 ]; then
+if[ "$deployResult" -ne 0 ]; then
     echo "DEPLOY FAILED!" 
     exit 1
 fi

--- a/targets/UnrealMarketplacePlugin/examplesource/ExampleProject/BuildAndRunTestsIOS.sh
+++ b/targets/UnrealMarketplacePlugin/examplesource/ExampleProject/BuildAndRunTestsIOS.sh
@@ -31,7 +31,7 @@ fi
 
 cd $archivePath/IOS
 
-#remove a preexisting payload folder from a prior unqip if it exists (it really shouldn't tho)
+#remove a preexisting payload folder from a prior unzip if it exists (it really shouldn't tho)
 rm -fdr Payload
 
 #unzip the ipa archive in preparation of deployment

--- a/targets/UnrealMarketplacePlugin/examplesource/ExampleProject/BuildAndRunTestsIOS.sh
+++ b/targets/UnrealMarketplacePlugin/examplesource/ExampleProject/BuildAndRunTestsIOS.sh
@@ -39,7 +39,7 @@ ios-deploy -b  Payload/ExampleProject.app -I -r
 deployResult=$?
 
 #if the deploy failed, log it out and exit
-if[ "$deployResult" -ne 0 ]; then
+if [ "$deployResult" -ne 0 ]; then
     echo "DEPLOY FAILED!" 
     exit 1
 fi

--- a/targets/UnrealMarketplacePlugin/examplesource/ExampleProject/BuildAndRunTestsIOS.sh
+++ b/targets/UnrealMarketplacePlugin/examplesource/ExampleProject/BuildAndRunTestsIOS.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+usage="./BuildAndRunTestsIOS.sh <target ipa directory path> <path to project>"
+
+archivePath=$1
+projectPath=$2
+
+if [ "$#" -ne 2 ]; then 
+    echo $usage
+    exit 1
+fi
+
+cp $(PF_TEST_TITLE_DATA_JSON) $projectPath/Content/TestTitleData
+
+./BuildIOS.sh $archivePath $projectPath
+
+pushd $archivePath/IOS
+unzip ExampleProject.ipa
+ios-deploy -b  Payload/ExampleProject.app -I -r
+popd
+

--- a/targets/UnrealMarketplacePlugin/examplesource/ExampleProject/BuildAndRunTestsIOS.sh
+++ b/targets/UnrealMarketplacePlugin/examplesource/ExampleProject/BuildAndRunTestsIOS.sh
@@ -13,8 +13,25 @@ cp $(PF_TEST_TITLE_DATA_JSON) $projectPath/Content/TestTitleData
 
 ./BuildIOS.sh $archivePath $projectPath
 
-pushd $archivePath/IOS
+buildResult=$?
+
+rm -f $projectPath/Content/TestTitleData/testTitleData.json
+
+if [ $buildResult -ne 0 ]; then 
+    echo "BUILD FAILED!"
+    exit 1
+fi
+
+cd $archivePath/IOS
+
 unzip ExampleProject.ipa
+
 ios-deploy -b  Payload/ExampleProject.app -I -r
-popd
+
+deployResult=$?
+
+if[ $deployResult -ne 0 ]; then
+    echo "DEPLOY FAILED!" 
+    exit 1
+fi
 

--- a/targets/UnrealMarketplacePlugin/examplesource/ExampleProject/BuildAndRunTestsIOS.sh
+++ b/targets/UnrealMarketplacePlugin/examplesource/ExampleProject/BuildAndRunTestsIOS.sh
@@ -17,7 +17,7 @@ rm -fdr $archivePath/IOS
 cp $PF_TEST_TITLE_DATA_JSON $projectPath/Content/TestTitleData
 
 #build the archive
-./BuildIOS.sh $archivePath $projectPath
+. ./BuildIOS.sh $archivePath $projectPath
 buildResult=$?
 
 #remove the testTitleData from the project now that the build is finished

--- a/targets/UnrealMarketplacePlugin/examplesource/ExampleProject/BuildAndRunTestsIOS.sh
+++ b/targets/UnrealMarketplacePlugin/examplesource/ExampleProject/BuildAndRunTestsIOS.sh
@@ -31,16 +31,15 @@ fi
 
 cd $archivePath/IOS
 
+#remove a preexisting payload folder from a prior unqip if it exists (it really shouldn't tho)
+rm -fdr Payload
+
 #unzip the ipa archive in preparation of deployment
 unzip ExampleProject.ipa
 
 #deploy the project (todo: add support for multiple test devices)
 ios-deploy -b  Payload/ExampleProject.app -I -r
-deployResult=$?
 
-#if the deploy failed, log it out and exit
-if [ "$deployResult" -ne 0 ]; then
-    echo "DEPLOY FAILED!" 
-    exit 1
-fi
+#self termination of the app tells ios-deploy that there was a failure.  this failure must be ignored.  we rely on cloudscript to validate test results.
+exit 0
 

--- a/targets/UnrealMarketplacePlugin/examplesource/ExampleProject/BuildAndRunTestsIOS.sh
+++ b/targets/UnrealMarketplacePlugin/examplesource/ExampleProject/BuildAndRunTestsIOS.sh
@@ -4,19 +4,26 @@ usage="./BuildAndRunTestsIOS.sh <target ipa directory path> <path to project>"
 archivePath=$1
 projectPath=$2
 
+#verify inputs
 if [ "$#" -ne 2 ]; then 
     echo $usage
     exit 1
 fi
 
+#be safe and clean up old archives
+rm -fdr $archivePath/IOS
+
+#inject the testTitleData into the project prior to build
 cp $PF_TEST_TITLE_DATA_JSON $projectPath/Content/TestTitleData
 
+#build the archive
 ./BuildIOS.sh $archivePath $projectPath
-
 buildResult=$?
 
+#remove the testTitleData from the project now that the build is finished
 rm -f $projectPath/Content/TestTitleData/testTitleData.json
 
+#exit if the build failed
 if [ $buildResult -ne 0 ]; then 
     echo "BUILD FAILED!"
     exit 1
@@ -24,12 +31,14 @@ fi
 
 cd $archivePath/IOS
 
+#unzip the ipa archive in preparation of deployment
 unzip ExampleProject.ipa
 
+#deploy the project (todo: add support for multiple test devices)
 ios-deploy -b  Payload/ExampleProject.app -I -r
-
 deployResult=$?
 
+#if the deploy failed, log it out and exit
 if[ $deployResult -ne 0 ]; then
     echo "DEPLOY FAILED!" 
     exit 1

--- a/targets/UnrealMarketplacePlugin/examplesource/ExampleProject/BuildAndRunTestsIOS.sh
+++ b/targets/UnrealMarketplacePlugin/examplesource/ExampleProject/BuildAndRunTestsIOS.sh
@@ -9,7 +9,7 @@ if [ "$#" -ne 2 ]; then
     exit 1
 fi
 
-cp $(PF_TEST_TITLE_DATA_JSON) $projectPath/Content/TestTitleData
+cp $PF_TEST_TITLE_DATA_JSON $projectPath/Content/TestTitleData
 
 ./BuildIOS.sh $archivePath $projectPath
 

--- a/targets/UnrealMarketplacePlugin/examplesource/ExampleProject/BuildIOS.sh.ejs
+++ b/targets/UnrealMarketplacePlugin/examplesource/ExampleProject/BuildIOS.sh.ejs
@@ -1,6 +1,16 @@
 #!/bin/bash
 echo ========== BUILDING MAC ==========
 
+Usage="./BuildAndRunTestsIOS.sh <target ipa directory path> <path to project>"
+
+archivePath=$1
+projectPath=$2
+
+if [ "$#" -ne 2 ]; then
+    echo $usage
+    exit 1
+fi
+ 
 # Unreal Path, to change depending on your workspace setup.
 uePath="/Users/Shared/Epic Games"
 
@@ -8,20 +18,15 @@ uePath="/Users/Shared/Epic Games"
 ueVersion="<%- ueTargetVersion %>"
 
 # Full Path. In theory it should not be edited (the engine path/version are the only ones that should be edited).
-uatPath="$uePath"/UE_"$ueVersion"/Engine/Build/BatchFiles/
+uatPath="$uePath/UE_${ueVersion}/Engine/Build/BatchFiles/"
 
 # Target Platform
 targetPlatform=iOS
 
-currentdir=`pwd`
+uprojdir="$projectPath/ExampleProject.uproject"
 
-uprojdir="$currentdir"/ExampleProject.uproject
-
-currentdir=`pwd`
-
-# Destination Path, where the build will end up (relative to active directory).
-archivePath=Build/"$targetPlatform"
 pushd "$uatPath"
 # The actual build command. To adapt depending on the needs.
-. RunUAT.sh BuildCookRun -clean -rocket -installed -nop4 -nocompile -project="$uprojdir" -cook -stage -archive -archivedirectory="$archivePath" -package -clientconfig=Development -Platform="$targetPlatform" -compressed -CookAll -pak -prereqs -build -utf8output -editorrecompile
+./RunUAT.sh -ScriptsForProject="$uprojdir" BuildCookRun -nocompile -editorrecompile -installed -nop4 -project="$uprojdir" -cook -stage -archive -archivedirectory="$archivePath" -package -clientconfig=Development -ue4exe=UE4Editor -pak -prereqs -nodebuginfo -targetplatform=IOS -build -utf8output
+
 popd

--- a/targets/UnrealMarketplacePlugin/examplesource/ExampleProject/BuildIOS.sh.ejs
+++ b/targets/UnrealMarketplacePlugin/examplesource/ExampleProject/BuildIOS.sh.ejs
@@ -28,5 +28,5 @@ uprojdir="$projectPath/ExampleProject.uproject"
 cd "$uatPath"
 
 # The actual build command. To adapt depending on the needs.
-./RunUAT.sh -ScriptsForProject="$uprojdir" BuildCookRun -nocompile -editorrecompile -installed -nop4 -project="$uprojdir" -cook -stage -archive -archivedirectory="$archivePath" -package -clientconfig=Development -ue4exe=UE4Editor -pak -prereqs -nodebuginfo -targetplatform=IOS -build -utf8output
+. ./RunUAT.sh -ScriptsForProject="$uprojdir" BuildCookRun -nocompile -editorrecompile -installed -nop4 -project="$uprojdir" -cook -stage -archive -archivedirectory="$archivePath" -package -clientconfig=Development -ue4exe=UE4Editor -pak -prereqs -nodebuginfo -targetplatform=IOS -build -utf8output
 

--- a/targets/UnrealMarketplacePlugin/examplesource/ExampleProject/BuildIOS.sh.ejs
+++ b/targets/UnrealMarketplacePlugin/examplesource/ExampleProject/BuildIOS.sh.ejs
@@ -25,8 +25,8 @@ targetPlatform=iOS
 
 uprojdir="$projectPath/ExampleProject.uproject"
 
-pushd "$uatPath"
+cd "$uatPath"
+
 # The actual build command. To adapt depending on the needs.
 ./RunUAT.sh -ScriptsForProject="$uprojdir" BuildCookRun -nocompile -editorrecompile -installed -nop4 -project="$uprojdir" -cook -stage -archive -archivedirectory="$archivePath" -package -clientconfig=Development -ue4exe=UE4Editor -pak -prereqs -nodebuginfo -targetplatform=IOS -build -utf8output
 
-popd

--- a/targets/UnrealMarketplacePlugin/examplesource/ExampleProject/BuildIOS.sh.ejs
+++ b/targets/UnrealMarketplacePlugin/examplesource/ExampleProject/BuildIOS.sh.ejs
@@ -1,5 +1,5 @@
 #!/bin/bash
-echo ========== BUILDING MAC ==========
+echo ========== BUILDING iOS ==========
 
 Usage="./BuildAndRunTestsIOS.sh <target ipa directory path> <path to project>"
 

--- a/targets/UnrealMarketplacePlugin/examplesource/ExampleProject/Config/DefaultEngine.ini
+++ b/targets/UnrealMarketplacePlugin/examplesource/ExampleProject/Config/DefaultEngine.ini
@@ -59,3 +59,12 @@ AppliedDefaultGraphicsPerformance=Maximum
 
 [/Script/Engine.NetworkSettings]
 n.VerifyPeer=true
+
+[/Script/IOSRuntimeSettings.IOSRuntimeSettings]
+BundleIdentifier=com.playfab.service
+bSupportsPortraitOrientation=False
+bSupportsUpsideDownOrientation=False
+bSupportsLandscapeLeftOrientation=True
+PreferredLandscapeOrientation=LandscapeLeft
+bGeneratedSYMFile=True
+

--- a/targets/UnrealMarketplacePlugin/examplesource/ExampleProject/Config/DefaultEngine.ini
+++ b/targets/UnrealMarketplacePlugin/examplesource/ExampleProject/Config/DefaultEngine.ini
@@ -66,5 +66,4 @@ bSupportsPortraitOrientation=False
 bSupportsUpsideDownOrientation=False
 bSupportsLandscapeLeftOrientation=True
 PreferredLandscapeOrientation=LandscapeLeft
-bGeneratedSYMFile=True
 

--- a/targets/UnrealMarketplacePlugin/examplesource/ExampleProject/Source/ExampleProject/PfTestActor.cpp.ejs
+++ b/targets/UnrealMarketplacePlugin/examplesource/ExampleProject/Source/ExampleProject/PfTestActor.cpp.ejs
@@ -1,6 +1,5 @@
 <%- copyright %>
 
-
 #include "PfTestActor.h"
 
 #include "Tests/PlayFabCppTests.h"

--- a/targets/UnrealMarketplacePlugin/examplesource/ExampleProject/Source/ExampleProject/PfTestActor.cpp.ejs
+++ b/targets/UnrealMarketplacePlugin/examplesource/ExampleProject/Source/ExampleProject/PfTestActor.cpp.ejs
@@ -1,4 +1,7 @@
-<%- copyright %>
+//////////////////////////////////////////////////////
+// Copyright (C) Microsoft. 2018. All rights reserved.
+//////////////////////////////////////////////////////
+
 
 #include "PfTestActor.h"
 
@@ -25,10 +28,10 @@ void APfTestActor::BeginPlay()
 }
 
 ACloudScriptTestResultUploader* SpawnUploader(UWorld* world) {
-    FActorSpawnParameters spawnParams;
-    FVector loc(0, 0, 0);
-    FRotator rot(0, 0, 0);
-    return world->SpawnActor<ACloudScriptTestResultUploader>(loc, rot, spawnParams);
+       FActorSpawnParameters spawnParams;
+       FVector loc(0, 0, 0);
+       FRotator rot(0, 0, 0);
+       return world->SpawnActor<ACloudScriptTestResultUploader>(loc, rot, spawnParams);
 }
 
 void APfTestActor::Tick(float DeltaTime)

--- a/targets/UnrealMarketplacePlugin/examplesource/ExampleProject/Source/ExampleProject/PfTestActor.cpp.ejs
+++ b/targets/UnrealMarketplacePlugin/examplesource/ExampleProject/Source/ExampleProject/PfTestActor.cpp.ejs
@@ -1,6 +1,4 @@
-//////////////////////////////////////////////////////
-// Copyright (C) Microsoft. 2018. All rights reserved.
-//////////////////////////////////////////////////////
+<%- copyright %>
 
 
 #include "PfTestActor.h"
@@ -28,10 +26,10 @@ void APfTestActor::BeginPlay()
 }
 
 ACloudScriptTestResultUploader* SpawnUploader(UWorld* world) {
-       FActorSpawnParameters spawnParams;
-       FVector loc(0, 0, 0);
-       FRotator rot(0, 0, 0);
-       return world->SpawnActor<ACloudScriptTestResultUploader>(loc, rot, spawnParams);
+    FActorSpawnParameters spawnParams;
+    FVector loc(0, 0, 0);
+    FRotator rot(0, 0, 0);
+    return world->SpawnActor<ACloudScriptTestResultUploader>(loc, rot, spawnParams);
 }
 
 void APfTestActor::Tick(float DeltaTime)


### PR DESCRIPTION
These changes facilitate the activation of the Unreal iOS test on the Jenkins Mac Node.  The changes consist two basic compnents: 

1) Build scripts for generating an IPA from the command line and deploying the generated IPA to an attached device.  (note that ios-deploy is an open source 3rd party device used by appium)
2) iOS project definitions to configure the bundle id and some other relatively inert Unreal generated fields.  