### PR TITLE
Unity instance authentication

### DIFF
--- a/SDKGenerator.njsproj
+++ b/SDKGenerator.njsproj
@@ -142,7 +142,6 @@
     <Compile Include="targets\postman\make.js" />
     <Compile Include="targets\PythonSdk\make.js" />
     <Compile Include="targets\SdkTestingCloudScript\make.js" />
-    <Compile Include="targets\unity-v2\make.js" />
     <Compile Include="targets\UnrealMarketplacePlugin\make.js" />
     <Compile Include="targets\UnrealMarketplacePlugin\makeBp.js" />
     <Compile Include="targets\UnrealMarketplacePlugin\makeCpp.js" />
@@ -465,6 +464,7 @@
     <Content Include="targets\SdkTestingCloudScript\templates\Enum.d.ts.ejs" />
     <Content Include="targets\SdkTestingCloudScript\source\package.json.ejs" />
     <Content Include="targets\SdkTestingCloudScript\source\Scripts\typings\PlayFab\PlayStream.d.ts.ejs" />
+    <Content Include="targets\unity-v2\make.js" />
     <Content Include="targets\unity-v2\source\Client\PlayFabDeviceUtil.cs" />
     <Content Include="targets\unity-v2\source\Entity\ScreenTimeTracker.cs" />
     <Content Include="targets\unity-v2\source\link.xml" />
@@ -577,6 +577,8 @@
     <Content Include="targets\unity-v2\Testing\Tests\Client\ClientApiTests.cs" />
     <Content Include="targets\unity-v2\Testing\Tests\Client\ClientEventTests.cs" />
     <Content Include="targets\unity-v2\Testing\Tests\Client\ClientMultiUserTests.cs" />
+    <Content Include="targets\unity-v2\Testing\Tests\Client\InstanceAuthTests.cs" />
+    <Content Include="targets\unity-v2\Testing\Tests\Client\StaticAuthTests.cs" />
     <Content Include="targets\unity-v2\Testing\Tests\Entity\EntityApiTests.cs" />
     <Content Include="targets\unity-v2\Testing\Tests\PersistentSockets\PubSubTest.cs" />
     <Content Include="targets\unity-v2\Testing\Tests\Server\ServerApiTests.cs" />

--- a/targets/unity-v2/Testing/Tests/Client/InstanceAuthTests.cs
+++ b/targets/unity-v2/Testing/Tests/Client/InstanceAuthTests.cs
@@ -1,0 +1,140 @@
+#if !DISABLE_PLAYFABCLIENT_API && !DISABLE_PLAYFABENTITY_API
+
+using PlayFab.ClientModels;
+
+namespace PlayFab.UUnit
+{
+    public class InstanceAuthTests : UUnitTestCase
+    {
+        private TestTitleDataLoader.TestTitleData titleData;
+        private PlayFabAuthenticationContext player1 = new PlayFabAuthenticationContext();
+        private PlayFabAuthenticationContext player2 = new PlayFabAuthenticationContext();
+        private PlayFabClientInstanceAPI client1;
+        private PlayFabClientInstanceAPI client2;
+        private PlayFabAuthenticationInstanceAPI auth1;
+        private PlayFabAuthenticationInstanceAPI auth2;
+
+        public override void ClassSetUp()
+        {
+            titleData = TestTitleDataLoader.LoadTestTitleData();
+            PlayFabSettings.staticSettings.TitleId = titleData.titleId;
+
+            client1 = new PlayFabClientInstanceAPI(player1);
+            client2 = new PlayFabClientInstanceAPI(player2);
+            auth1 = new PlayFabAuthenticationInstanceAPI(player1);
+            auth2 = new PlayFabAuthenticationInstanceAPI(player2);
+
+            PlayFabSettings.staticPlayer.ForgetAllCredentials();
+        }
+
+        public override void SetUp(UUnitTestContext testContext)
+        {
+            VerifyCleanCreds(testContext);
+        }
+
+        public override void Tick(UUnitTestContext testContext)
+        {
+            // Tests are all async, no need to tick
+        }
+
+        public override void TearDown(UUnitTestContext testContext)
+        {
+            player1.ForgetAllCredentials();
+            player2.ForgetAllCredentials();
+
+            VerifyCleanCreds(testContext);
+        }
+
+        private void VerifyCleanCreds(UUnitTestContext testContext)
+        {
+            testContext.False(client1.IsClientLoggedIn(), "Client1 login did not clean up properly.");
+            testContext.False(client2.IsClientLoggedIn(), "Client2 login did not clean up properly.");
+            testContext.False(auth1.IsEntityLoggedIn(), "Entity1 login did not clean up properly.");
+            testContext.False(auth2.IsEntityLoggedIn(), "Entity2 login did not clean up properly.");
+            testContext.False(PlayFabClientAPI.IsClientLoggedIn(), "Static client login did not clean up properly.");
+            testContext.False(PlayFabAuthenticationAPI.IsEntityLoggedIn(), "Static entity login did not clean up properly.");
+        }
+
+        private void SharedErrorCallback(PlayFabError error)
+        {
+            // This error was not expected.  Report it and fail.
+            ((UUnitTestContext)error.CustomData).Fail(error.GenerateErrorReport());
+        }
+
+        [UUnitTest]
+        public void Instance1Login(UUnitTestContext testContext)
+        {
+            var loginRequest = new LoginWithCustomIDRequest
+            {
+                CustomId = PlayFabSettings.BuildIdentifier,
+                CreateAccount = true,
+            };
+            client1.LoginWithCustomID(loginRequest, PlayFabUUnitUtils.ApiActionWrapper<LoginResult>(testContext, Instance1Callback), PlayFabUUnitUtils.ApiActionWrapper<PlayFabError>(testContext, SharedErrorCallback), testContext);
+        }
+        private void Instance1Callback(LoginResult result)
+        {
+            var testContext = (UUnitTestContext)result.CustomData;
+            testContext.True(player1.IsClientLoggedIn(), "player1 client login failed, ");
+            testContext.True(client1.IsClientLoggedIn(), "client1 client login failed");
+            testContext.True(player1.IsEntityLoggedIn(), "player1 entity login failed");
+            testContext.True(auth1.IsEntityLoggedIn(), "auth1 entity login failed");
+
+            testContext.False(PlayFabClientAPI.IsClientLoggedIn(), "p1 client context leaked to static context");
+            testContext.False(PlayFabAuthenticationAPI.IsEntityLoggedIn(), "p1 entity context leaked to static context");
+
+            testContext.EndTest(UUnitFinishState.PASSED, PlayFabSettings.staticSettings.TitleId + ", " + result.PlayFabId);
+        }
+
+        [UUnitTest]
+        public void Instance2Login(UUnitTestContext testContext)
+        {
+            var loginRequest = new LoginWithCustomIDRequest
+            {
+                CustomId = PlayFabSettings.BuildIdentifier,
+                CreateAccount = true,
+            };
+            client2.LoginWithCustomID(loginRequest, PlayFabUUnitUtils.ApiActionWrapper<LoginResult>(testContext, Instance2Callback), PlayFabUUnitUtils.ApiActionWrapper<PlayFabError>(testContext, SharedErrorCallback), testContext);
+        }
+        private void Instance2Callback(LoginResult result)
+        {
+            var testContext = (UUnitTestContext)result.CustomData;
+            testContext.True(player2.IsClientLoggedIn(), "player2 client login failed, ");
+            testContext.True(client2.IsClientLoggedIn(), "client2 client login failed");
+            testContext.True(player2.IsEntityLoggedIn(), "player2 entity login failed");
+            testContext.True(auth2.IsEntityLoggedIn(), "auth2 entity login failed");
+
+            testContext.False(PlayFabClientAPI.IsClientLoggedIn(), "p2 client context leaked to static context");
+            testContext.False(PlayFabAuthenticationAPI.IsEntityLoggedIn(), "p2 entity context leaked to static context");
+
+            testContext.EndTest(UUnitFinishState.PASSED, PlayFabSettings.staticSettings.TitleId + ", " + result.PlayFabId);
+        }
+
+        [UUnitTest]
+        public void StaticLogin(UUnitTestContext testContext)
+        {
+            var loginRequest = new LoginWithCustomIDRequest
+            {
+                CustomId = PlayFabSettings.BuildIdentifier,
+                CreateAccount = true,
+            };
+            PlayFabClientAPI.LoginWithCustomID(loginRequest, PlayFabUUnitUtils.ApiActionWrapper<LoginResult>(testContext, StaticCallback), PlayFabUUnitUtils.ApiActionWrapper<PlayFabError>(testContext, SharedErrorCallback), testContext);
+        }
+        private void StaticCallback(LoginResult result)
+        {
+            var testContext = (UUnitTestContext)result.CustomData;
+            testContext.True(PlayFabClientAPI.IsClientLoggedIn(), "p2 client context leaked to static context");
+            testContext.True(PlayFabAuthenticationAPI.IsEntityLoggedIn(), "p2 entity context leaked to static context");
+
+            testContext.False(client1.IsClientLoggedIn(), "Static login leaked to Client1");
+            testContext.False(client2.IsClientLoggedIn(), "tatic login leaked to Client2");
+            testContext.False(auth1.IsEntityLoggedIn(), "Static login leaked to Auth1");
+            testContext.False(auth2.IsEntityLoggedIn(), "Static login leaked to Auth2");
+
+            PlayFabClientAPI.ForgetAllCredentials();
+
+            testContext.EndTest(UUnitFinishState.PASSED, PlayFabSettings.staticSettings.TitleId + ", " + result.PlayFabId);
+        }
+    }
+}
+
+#endif

--- a/targets/unity-v2/Testing/Tests/Client/StaticAuthTests.cs
+++ b/targets/unity-v2/Testing/Tests/Client/StaticAuthTests.cs
@@ -1,0 +1,69 @@
+#if !DISABLE_PLAYFABCLIENT_API && !DISABLE_PLAYFABENTITY_API
+
+using PlayFab.ClientModels;
+
+namespace PlayFab.UUnit
+{
+    public class StaticAuthTests : UUnitTestCase
+    {
+        private TestTitleDataLoader.TestTitleData titleData;
+
+        public override void ClassSetUp()
+        {
+            titleData = TestTitleDataLoader.LoadTestTitleData();
+            PlayFabSettings.staticSettings.TitleId = titleData.titleId;
+            PlayFabSettings.staticPlayer.ForgetAllCredentials();
+        }
+
+        public override void SetUp(UUnitTestContext testContext)
+        {
+            VerifyCleanCreds(testContext);
+        }
+
+        public override void Tick(UUnitTestContext testContext)
+        {
+            // Tests are all async, no need to tick
+        }
+
+        public override void TearDown(UUnitTestContext testContext)
+        {
+            VerifyCleanCreds(testContext);
+        }
+
+        private void VerifyCleanCreds(UUnitTestContext testContext)
+        {
+            testContext.False(PlayFabClientAPI.IsClientLoggedIn(), "Static client login did not clean up properly.");
+            testContext.False(PlayFabAuthenticationAPI.IsEntityLoggedIn(), "Static entity login did not clean up properly.");
+        }
+
+        private void SharedErrorCallback(PlayFabError error)
+        {
+            // This error was not expected.  Report it and fail.
+            ((UUnitTestContext)error.CustomData).Fail(error.GenerateErrorReport());
+        }
+
+        [UUnitTest]
+        public void BasicStaticLogin(UUnitTestContext testContext)
+        {
+            var loginRequest = new LoginWithCustomIDRequest
+            {
+                CustomId = PlayFabSettings.BuildIdentifier,
+                CreateAccount = true,
+            };
+            PlayFabClientAPI.LoginWithCustomID(loginRequest, PlayFabUUnitUtils.ApiActionWrapper<LoginResult>(testContext, StaticLoginCallback), PlayFabUUnitUtils.ApiActionWrapper<PlayFabError>(testContext, SharedErrorCallback), testContext);
+        }
+        private void StaticLoginCallback(LoginResult result)
+        {
+            var testContext = (UUnitTestContext)result.CustomData;
+
+            testContext.True(PlayFabClientAPI.IsClientLoggedIn(), "static client login failed");
+            testContext.True(PlayFabAuthenticationAPI.IsEntityLoggedIn(), "static entity login failed");
+
+            PlayFabClientAPI.ForgetAllCredentials();
+
+            testContext.EndTest(UUnitFinishState.PASSED, PlayFabSettings.staticSettings.TitleId + ", " + result.PlayFabId);
+        }
+    }
+}
+
+#endif

--- a/targets/unity-v2/make.js
+++ b/targets/unity-v2/make.js
@@ -440,7 +440,7 @@ function getRequestActions(tabbing, apiCall, isApiInstance = false) {
     if ((apiCall.result === "LoginResult" || apiCall.request === "RegisterPlayFabUserRequest") && isApiInstance === false)
         return tabbing + "request.TitleId = request.TitleId ?? PlayFabSettings.TitleId;\n";
     if ((apiCall.result === "LoginResult" || apiCall.request === "RegisterPlayFabUserRequest") && isApiInstance === true)
-        return tabbing + "request.TitleId = request.TitleId ?? apiSettings.TitleId;\n";
+        return tabbing + "request.TitleId = request.TitleId ?? callSettings.TitleId;\n";
     if (apiCall.auth === "SessionTicket" && isApiInstance === true)
         return tabbing + "if (string.IsNullOrEmpty(context.ClientSessionTicket)) throw new PlayFabException(PlayFabExceptionCode.NotLoggedIn,\"Must be logged in to call this method\");\n";
     if (apiCall.auth === "SessionTicket" && isApiInstance === false)

--- a/targets/unity-v2/templates/InstanceAPI.cs.ejs
+++ b/targets/unity-v2/templates/InstanceAPI.cs.ejs
@@ -74,7 +74,8 @@ namespace PlayFab
 %>        public void <%- apiCall.name %>(<%- apiCall.request %> request, Action<<%- apiCall.result %>> resultCallback, Action<PlayFabError> errorCallback, object customData = null, Dictionary<string, string> extraHeaders = null)
         {
             var context = (request == null ? null : request.AuthenticationContext) ?? authenticationContext;
-<%- getRequestActions("            ", apiCall, true) %>            PlayFabHttp.MakeApiCall("<%- apiCall.url %>", request, <%- getAuthParams(apiCall) %>, resultCallback, errorCallback, customData, extraHeaders, context, apiSettings, this);
+            var callSettings = apiSettings ?? PlayFabSettings.staticSettings;
+<%- getRequestActions("            ", apiCall, true) %>            PlayFabHttp.MakeApiCall("<%- apiCall.url %>", request, <%- getAuthParams(apiCall) %>, resultCallback, errorCallback, customData, extraHeaders, context, callSettings, this);
         }<%- getCustomApiFunction("        ", api, apiCall, true) %>
 <% } %>
     }


### PR DESCRIPTION
Fixed an issue where titleID wasn't picking up properly from staticSettings.
Added tests to verify that clientSessionTicket and entityToken were populated and saved properly for expected login patterns.