### PR TITLE
Mimacken/xamarin ios

### DIFF
--- a/SDKBuildScripts/xamarin_buildAppCenterTestIOS.sh
+++ b/SDKBuildScripts/xamarin_buildAppCenterTestIOS.sh
@@ -1,0 +1,193 @@
+#!/bin/bash
+#USAGE: xamarin_buildAppCenterTestIOS.sh 
+#           <path to the root of the xplatcppsdk repo to be built> 
+#           <path to local appcenter test working copy folder> 
+#           <git clone url for the appcenter build>
+#           <git branch name for the appcenter build repo>
+#           <git tag name for the clean branch state>
+#           <path to test xamarin.uitest assemblies that will be uploaded to appcenter>
+
+#PREREQUISITES:
+#1) System must be provisioned with login-free write access to the appcener build git repository.
+#2) System must have jq installed (https://stedolan.github.io/jq)
+#3) System must have the appcenter cli installed
+#4) System must have AppCenter API Credentials configured and installed: (https://docs.microsoft.com/en-us/appcenter/cli/index) using the APPCENTER_ACCESS_TOKEN envvar
+
+#INPUTS
+XPlatWorkspaceDirectory=$1
+AppCenterRepoParentDir=$2
+AppCenterGitRepoURL=$3
+AppCenterGitRepoBranchName=$4
+AppCenterGitRepoCleanTag=$5
+AppCenterTestAssembliesPath=$6
+
+echo $XPlatWorkspaceDirectory
+echo $AppCenterRepoParentDir
+echo $AppCenterGitRepoURL
+echo $AppCenterGitRepoBranchName
+echo $AppCenterGitRepoCleanTag
+
+#DERIVED FROM INPUTS
+ProjectFolderName=$(basename "$XPlatWorkspaceDirectory")
+GitRepoFolderName=$(basename "$AppCenterGitRepoURL" | sed -e 's/.git//g')
+
+echo "Project Folder Name: $ProjectFolderName"
+echo "Git Folder Name: $GitRepoFolderName"
+
+#remove cruft from previous runs, if any.
+InitializeBuildEnvironment() {
+    rm -fdr "$AppCenterRepoParentDir/$GitRepoFolderName"
+    mkdir -p "$AppCenterRepoParentDir/$GitRepoFolderName"
+
+    pushd "$AppCenterRepoParentDir"
+
+    echo "about to clone appcenter build rpo into: $AppCenterRepoParentDir/$GitRepoFolderName"
+
+    #clone the appcenter build repo to our local workspace
+    NewBranch=0
+    git clone "$AppCenterGitRepoURL"
+    cd $GitRepoFolderName 
+    echo "Fetching tags and resetting at $PWD"
+    git fetch --tags 
+    git reset --hard $AppCenterGitRepoCleanTag
+    git push --force
+    git stash --all
+    git stash clear
+
+    echo "About to checkout $AppCenterGitRepoBranchName..."
+
+    git checkout "$AppCenterGitRepoBranchName" || NewBranch=1
+    if [ $NewBranch -ne 0 ]; then
+        echo "Failed to checkout existing branch: $AppCenterGitRepoBranchName. Creating as new branch."
+        git checkout -b "$AppCenterGitRepoBranchName"
+    else 
+        git reset --hard init
+        git stash --all 
+        git stash clear
+        git push --force
+    fi
+
+    #copy the xcode workspace into the appcenter git repo
+    ACB="$AppCenterRepoParentDir/$GitRepoFolderName"
+    pushd "$XPlatWorkspaceDirectory" 
+    echo "Copying project contents from $PWD into $ACB..."
+    cp -rf test "$ACB"
+    cp -rf code "$ACB"
+    cp -rf external "$ACB"
+    mkdir "$ACB/build" || true
+    cp -rf build/iOS "$ACB/build"
+    echo "Loading test title data from $PF_TEST_TITLE_DATA_JSON into $ACB/build/iOS/TestIOSApp/TestTitleData..."
+    cp "$PF_TEST_TITLE_DATA_JSON" "$ACB/build/iOS/TestIOSApp/TestTitleData"
+    popd #$XPlatWorkspaceDirectory
+
+    #create the appcenter prebuild script in the xcode project
+    pushd "$ACB/build/iOS"
+   
+    rm -f appcenter-post-clone.sh
+    echo -e '#!/usr/bin/env bash
+
+    pushd TestIOSApp
+
+    touch Gemfile
+
+    echo -e "source \"https://rubygems.org\"\n\ngem \"calabash-cucumber\", \">= 0.16\", \"< 2.0\"" > Gemfile
+
+    bundle ;
+    bundle exec calabash-ios download
+
+    popd' >> appcenter-post-clone.sh
+
+    popd #$ACB/build/iOS
+
+    pushd "$ACB"
+    git add .
+    git update-index --chmod=+x "$ACB/build/iOS/appcenter-post-clone.sh"
+    git commit -m "add xcode project for appcenter build"
+
+    #if a new branch was created AppCenter needs to be manually configured for this branch.  
+    if [ $NewBranch -eq 1 ]; then
+        git push -u origin "$AppCenterGitRepoBranchName"
+        echo 'ERROR: Unity Job '"$AppCenterGitRepoBranchName"' did not yet exist.'
+        echo "The branch has been created and populated, but must be manually configured in AppCenter."
+        echo "Please try again once the AppCenter build branch has been properly configured."
+        exit 1
+    fi
+
+    git push
+}
+
+#queue the appcenter build
+QueueAppCenterBuild() {
+    appcenter build queue --app "PlayFabSDKTeam/PlayFabXPlatIOS" --branch $AppCenterGitRepoBranchName --quiet -d 
+    if [ $? -ne 0 ]; then
+        echo "Error queueing build!"
+        exit 1
+    fi
+
+    BuildStatusJSON=$(appcenter build branches show -b $AppCenterGitRepoBranchName -a "PlayFabSDKTeam/PlayFabXPlatIOS" --quiet --output json)
+    BuildStatus="\"notStarted\""
+}
+
+#monitor the status of the build and wait until it is complete.
+WaitForAppCenterBuild() {
+    for i in {1..30}
+    do
+        sleep 60
+        BuildStatusJSON=$(appcenter build branches show -b $AppCenterGitRepoBranchName -a "PlayFabSDKTeam/PlayFabXPlatIOS" --quiet --output json)
+        BuildStatus=$(echo "$BuildStatusJSON" | jq .status)
+        echo "WaitForAppCenterBuild check number: $i, Build Status: $BuildStatus"
+        if [ "$BuildStatus" = "\"completed\"" ]; then
+            return 0
+        fi
+    done
+    
+    exit 1
+}
+
+ExtractBuildResults() {
+    #extract the results and build number
+    BuildResult=$(echo "$BuildStatusJSON" | jq .result)
+    BuildNumber=$(echo "$BuildStatusJSON" | jq .buildNumber | sed s/\"//g)
+
+    echo "Build $BuildNumber has $BuildResult."
+}
+
+#Download the build if successful, or print the logs if not.
+DownloadIpa() {
+    if [[ $BuildResult == *"Succeeded"* ]]; then
+        appcenter build download --type build --app "PlayFabSDKTeam/PlayFabXPlatIOS" --id $BuildNumber --file PlayFabIOS.ipa
+    else
+        appcenter build logs --app "PlayFabSDKTeam/PlayFabXPlatIOS" --id $BuildNumber >> "build_logs_${BuildNumber}.txt"
+        exit 1
+    fi
+}
+
+RunAppCenterTest() {
+    appcenter test run uitest --app "PlayFabSDKTeam/PlayFabXPlatIOS" \
+    --devices 3d1d91de \
+    --app-path PlayFabIOS.ipa  \
+    --test-series "master" \
+    --locale "en_US" \
+    --assembly-dir "$AppCenterTestAssembliesPath"  \
+    --uitest-tools-dir "$XAMARIN_UITEST_TOOLS"
+}
+
+CleanUp() {
+    pushd "$AppCenterRepoParentDir/$GitRepoFolderName"
+    #Return the appcenter build repo to a clean state for next time.
+    git reset --hard $AppCenterGitRepoCleanTag
+    git push --force 
+    popd
+}
+
+DoWork() {
+    InitializeBuildEnvironment
+    QueueAppCenterBuild
+    WaitForAppCenterBuild
+    ExtractBuildResults
+    DownloadIpa
+    RunAppCenterTest
+    CleanUp
+}
+
+DoWork

--- a/SDKBuildScripts/xamarin_buildAppCenterTestIOS.sh
+++ b/SDKBuildScripts/xamarin_buildAppCenterTestIOS.sh
@@ -132,7 +132,8 @@ ExtractBuildResults() {
 
 #Download the build if successful, or print the logs if not.
 DownloadIpa() {
-    if [[ $BuildResult == *"Succeeded"* ]]; then
+    shopt -s nocasematch
+    if [[ $BuildResult == *"succeeded"* ]]; then
         appcenter build download --type build --app "$PlayFabApplicationName" --id $BuildNumber --file PlayFabIOS.ipa
     else
         appcenter build logs --app "$PlayFabApplicationName" --id $BuildNumber >> "build_logs_${BuildNumber}.txt"

--- a/SDKBuildScripts/xamarin_buildAppCenterTestIOS.sh
+++ b/SDKBuildScripts/xamarin_buildAppCenterTestIOS.sh
@@ -76,7 +76,9 @@ InitializeBuildEnvironment() {
     echo "Copying $XamarinWorkspaceDirectory into $ACB..."
     cp -rf "$XamarinWorkspaceDirectory" "$ACB"
     echo "Loading test title data from $PF_TEST_TITLE_DATA_JSON into $ACB/XamarinTestRunner/XamarinTestRunner/XamarinTestRunner..."
-    cp "$PF_TEST_TITLE_DATA_JSON" "$ACB/XamarinTestRunner/XamarinTestRunner/XamarinTestRunner"
+    pushd "$ACB/XamarinTestRunner/XamarinTestRunner/XamarinTestRunner"
+    cp -f "$PF_TEST_TITLE_DATA_JSON" .
+    popd
     popd #$XamarinWorkspaceDirectory
 
     pushd "$ACB"

--- a/SDKBuildScripts/xamarin_buildAppCenterTestIOS.sh
+++ b/SDKBuildScripts/xamarin_buildAppCenterTestIOS.sh
@@ -72,16 +72,13 @@ InitializeBuildEnvironment() {
 
     #copy the xamarin workspace into the appcenter git repo
     ACB="$AppCenterRepoParentDir/$GitRepoFolderName"
-    pushd "$XamarinWorkspaceDirectory" 
     echo "Copying $XamarinWorkspaceDirectory into $ACB..."
-    cp -a "$XamarinWorkspaceDirectory/." "$ACB/"
+    cp -a "$XamarinWorkspaceDirectory/." .
     echo "Loading test title data from $PF_TEST_TITLE_DATA_JSON into $ACB/XamarinTestRunner/XamarinTestRunner/XamarinTestRunner..."
-    pushd "$ACB/XamarinTestRunner/XamarinTestRunner/XamarinTestRunner"
+    pushd "XamarinTestRunner/XamarinTestRunner/XamarinTestRunner"
     cp -f "$PF_TEST_TITLE_DATA_JSON" .
     popd
-    popd #$XamarinWorkspaceDirectory
 
-    pushd "$ACB"
     git add .
     git commit -m "add xamarin project for appcenter build"
 

--- a/SDKBuildScripts/xamarin_buildAppCenterTestIOS.sh
+++ b/SDKBuildScripts/xamarin_buildAppCenterTestIOS.sh
@@ -74,7 +74,7 @@ InitializeBuildEnvironment() {
     ACB="$AppCenterRepoParentDir/$GitRepoFolderName"
     pushd "$XamarinWorkspaceDirectory" 
     echo "Copying $XamarinWorkspaceDirectory into $ACB..."
-    cp -rf "$XamarinWorkspaceDirectory/*" "$ACB"
+    cp -a "$XamarinWorkspaceDirectory/." "$ACB/"
     echo "Loading test title data from $PF_TEST_TITLE_DATA_JSON into $ACB/XamarinTestRunner/XamarinTestRunner/XamarinTestRunner..."
     pushd "$ACB/XamarinTestRunner/XamarinTestRunner/XamarinTestRunner"
     cp -f "$PF_TEST_TITLE_DATA_JSON" .

--- a/SDKBuildScripts/xamarin_buildAppCenterTestIOS.sh
+++ b/SDKBuildScripts/xamarin_buildAppCenterTestIOS.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 #USAGE: xamarin_buildAppCenterTestIOS.sh 
-#           <path to the root of the xplatcppsdk repo to be built> 
+#           <path to the root of the xamarin repo to be built> 
 #           <path to local appcenter test working copy folder> 
 #           <git clone url for the appcenter build>
 #           <git branch name for the appcenter build repo>
@@ -74,7 +74,7 @@ InitializeBuildEnvironment() {
     ACB="$AppCenterRepoParentDir/$GitRepoFolderName"
     pushd "$XamarinWorkspaceDirectory" 
     echo "Copying $XamarinWorkspaceDirectory into $ACB..."
-    cp -rf "$XamarinWorkspaceDirectory" "$ACB"
+    cp -rf "$XamarinWorkspaceDirectory/*" "$ACB"
     echo "Loading test title data from $PF_TEST_TITLE_DATA_JSON into $ACB/XamarinTestRunner/XamarinTestRunner/XamarinTestRunner..."
     pushd "$ACB/XamarinTestRunner/XamarinTestRunner/XamarinTestRunner"
     cp -f "$PF_TEST_TITLE_DATA_JSON" .

--- a/SDKBuildScripts/xamarin_buildAppCenterTestIOS.sh
+++ b/SDKBuildScripts/xamarin_buildAppCenterTestIOS.sh
@@ -27,6 +27,23 @@ echo $AppCenterGitRepoURL
 echo $AppCenterGitRepoBranchName
 echo $AppCenterGitRepoCleanTag
 
+Usage="USAGE: ./xamarin_buildAppCenterTestIOS.sh \
+<path to the root of the xamarin repo to be built> \
+<path to local appcenter test working copy folder> \
+<git clone url for the appcenter build> \
+<git branch name for the appcenter build repo> \
+<git tag name for the clean branch state> \
+<path to test xamarin.uitest assemblies that will be uploaded to appcenter>"
+
+NumArgs=$#
+CheckUsage() {
+    if [ $NumArgs -ne 6 ]; then
+        echo "Error: Invalid number of parameters!"
+        echo "$Usage"
+        exit 1
+    fi
+}
+
 #HARD CODED APPCENTER APP NAME
 PlayFabApplicationName="PlayFabSDKTeam/PlayFabXamarinIOS-1"
 
@@ -37,29 +54,12 @@ GitRepoFolderName=$(basename "$AppCenterGitRepoURL" | sed -e 's/.git//g')
 echo "Project Folder Name: $ProjectFolderName"
 echo "Git Folder Name: $GitRepoFolderName"
 
-
 #error checking utility function
 ExitIfError() {
     ErrorStatus=$?
     if [ $ErrorStatus -ne 0 ]; then 
         echo "Exiting with Error Code: $ErrorStatus"
         exit $ErrorStatus
-    fi
-}
-
-Usage="USAGE: ./xamarin_buildAppCenterTestIOS.sh \
-<path to the root of the xamarin repo to be built> \
-<path to local appcenter test working copy folder> \
-<git clone url for the appcenter build> \
-<git branch name for the appcenter build repo> \
-<git tag name for the clean branch state> \
-<path to test xamarin.uitest assemblies that will be uploaded to appcenter>"
-
-CheckUsage() {
-    if [ $# -ne 6 ]; then 
-        echo "Error: Invalid number of parameters!"
-        echo "$Usage"
-        exit 1
     fi
 }
 

--- a/targets/csharp/XamarinTestRunner/XamarinTestRunner/XamarinTestRunner.iOS/AppDelegate.cs
+++ b/targets/csharp/XamarinTestRunner/XamarinTestRunner/XamarinTestRunner.iOS/AppDelegate.cs
@@ -22,6 +22,8 @@ namespace XamarinTestRunner.iOS
         //
         public override bool FinishedLaunching(UIApplication app, NSDictionary options)
         {
+            Xamarin.Calabash.Start();
+
             global::Xamarin.Forms.Forms.Init();
             LoadApplication(new App());
 

--- a/targets/csharp/XamarinTestRunner/XamarinTestRunner/XamarinTestRunner.iOS/XamarinTestRunner.iOS.csproj
+++ b/targets/csharp/XamarinTestRunner/XamarinTestRunner/XamarinTestRunner.iOS/XamarinTestRunner.iOS.csproj
@@ -152,11 +152,14 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Xamarin.Forms" Version="3.4.0.1008975" />
+    <PackageReference Include="Xamarin.TestCloud.Agent">
+      <Version>0.21.8</Version>
+    </PackageReference>
   </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath)\Xamarin\iOS\Xamarin.iOS.CSharp.targets" />
   <ItemGroup>
     <ProjectReference Include="..\XamarinTestRunner\XamarinTestRunner.csproj">
-      <Project>{2E936540-091F-4D00-827C-5B232BBF0728}</Project>
+      <Project>{AB89CB5B-5765-463C-8358-7732D75B53BA}</Project>
       <Name>XamarinTestRunner</Name>
     </ProjectReference>
   </ItemGroup>

--- a/targets/csharp/XamarinTestRunner/XamarinTestRunner/XamarinTestRunner/MainPage.xaml.cs
+++ b/targets/csharp/XamarinTestRunner/XamarinTestRunner/XamarinTestRunner/MainPage.xaml.cs
@@ -18,6 +18,7 @@ namespace XamarinTestRunner
         public MainPage()
         {
             InitializeComponent();
+            RunTests(null, null);
         }
 
         private void RunTests(object sender, EventArgs e)
@@ -66,9 +67,15 @@ namespace XamarinTestRunner
                 Device.BeginInvokeOnMainThread(() =>
                 {
                     WriteConsoleColor("Done!", UUnitIncrementalTestRunner.AllTestsPassed ? Color.Green : Color.Red);
-                    RunTestsButton.Text = originalButtonText;
-                    RunTestsButton.Clicked += RunTests;
                 });
+
+                Thread.Sleep(5000);
+
+                Device.BeginInvokeOnMainThread(() =>
+                {
+                    Thread.CurrentThread.Abort();
+                });
+
             });
         }
 


### PR DESCRIPTION
This PR adds xamarin ios test automation in two parts:
1) Adds a build and test script
2) Modifies the Test App by making it start and kill automatically as well as linking and starting the xamarin test cloud, which is required by AppCenter