### PR TITLE
Add AuthenticationContext to make api call in AF local debugging

### DIFF
--- a/targets/unity-v2/make.js
+++ b/targets/unity-v2/make.js
@@ -453,7 +453,7 @@ function getCustomApiLogic(tabbing, apiCall) {
             tabbing + "{\n" +
             tabbing + "    var baseUri = new Uri(localApiServerString);\n" +
             tabbing + "    var fullUri = new Uri(baseUri, \"" + apiCall.url + "\".TrimStart('/'));\n" +
-            tabbing + "    PlayFabHttp.MakeApiCallWithFullUri(fullUri.AbsoluteUri, request, AuthType.EntityToken, resultCallback, errorCallback, customData, extraHeaders);\n" +
+            tabbing + "    PlayFabHttp.MakeApiCallWithFullUri(fullUri.AbsoluteUri, request, AuthType.EntityToken, resultCallback, errorCallback, customData, extraHeaders, context);\n" +
             tabbing + "    return;\n" +
             tabbing + "}\n";
 }


### PR DESCRIPTION
This is a quick fix, there was a bug with the authentication context not being passed to `MakeApiCallWithFullUri` even though it was available to be passed. Was causing issues with missing `X-EntityToken` header as that's where it's being fetched from later down the line.