### PR TITLE
Switch CSPlugin target to netcoreapp2.0

### DIFF
--- a/targets/csharp/source/Plugins/CloudScript/source/PlayFabCloudScriptPlugin.csproj.ejs
+++ b/targets/csharp/source/Plugins/CloudScript/source/PlayFabCloudScriptPlugin.csproj.ejs
@@ -8,7 +8,7 @@
     <FileAlignment>512</FileAlignment>
 
     <PackageId>PlayFabCloudScriptPlugin</PackageId>
-    <Version><%- sdkVersion %></Version>
+    <Version><%- sdkVersion %>-alpha</Version>
     <Title>PlayFab CSharp CloudScript Plugin</Title>
     <Authors>PlayFab Inc.</Authors>
     <Owners>PlayFab Inc.</Owners>

--- a/targets/csharp/source/Plugins/CloudScript/source/PlayFabCloudScriptPlugin.csproj.ejs
+++ b/targets/csharp/source/Plugins/CloudScript/source/PlayFabCloudScriptPlugin.csproj.ejs
@@ -1,7 +1,7 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp2.0</TargetFrameworks>
     <RootNamespace>PlayFabCloudScriptPlugin</RootNamespace>
     <AssemblyName>PlayFabCloudScriptPlugin</AssemblyName>
     <DefaultLanguage>en-US</DefaultLanguage>

--- a/targets/csharp/source/Plugins/CloudScript/source/PlayFabFunctionContexts.cs
+++ b/targets/csharp/source/Plugins/CloudScript/source/PlayFabFunctionContexts.cs
@@ -3,7 +3,7 @@
 /// DO NOT RELY ON THE FOLLOWING CODE FOR USE ALONGSIDE PRODUCTION READY CODE.
 /// THIS FILE IS SUBJECT TO CHANGE AT ANY TIME.
 /////////////////////////////////////////////////////////////////////////////////////////////////
-#if NETSTANDARD2_0
+#if NETCOREAPP2_0
 namespace PlayFab.Plugins.CloudScript
 {
     using PlayFab.Json;


### PR DESCRIPTION
This fixes a bug in my previous changes. I made the mistake of assuming Azure Functions runtime was net standard instead of net core app.