### PR TITLE
Unreal: don't reload if the module is already loaded

### DIFF
--- a/targets/UnrealMarketplacePlugin/source/PlayFab/Source/PlayFab/Public/IPlayFab.h.ejs
+++ b/targets/UnrealMarketplacePlugin/source/PlayFab/Source/PlayFab/Public/IPlayFab.h.ejs
@@ -21,6 +21,10 @@ public:
 
     static inline IPlayFab& Get()
     {
+        if (IsAvailable())
+        {
+            return FModuleManager::GetModuleChecked< IPlayFab >("PlayFab");
+        }
         return FModuleManager::LoadModuleChecked< IPlayFab >("PlayFab");
     }
 

--- a/targets/UnrealMarketplacePlugin/source/PlayFab/Source/PlayFabCommon/Public/PlayFabCommon.h.ejs
+++ b/targets/UnrealMarketplacePlugin/source/PlayFab/Source/PlayFabCommon/Public/PlayFabCommon.h.ejs
@@ -19,6 +19,10 @@ public:
     */
     static inline IPlayFabCommonModuleInterface& Get()
     {
+        if (IsAvailable())
+        {
+            return FModuleManager::GetModuleChecked<IPlayFabCommonModuleInterface>("PlayFabCommon");
+        }
         return FModuleManager::LoadModuleChecked<IPlayFabCommonModuleInterface>("PlayFabCommon");
     }
 

--- a/targets/UnrealMarketplacePlugin/source/PlayFab/Source/PlayFabCpp/Public/PlayFab.h.ejs
+++ b/targets/UnrealMarketplacePlugin/source/PlayFab/Source/PlayFabCpp/Public/PlayFab.h.ejs
@@ -44,6 +44,10 @@ public:
     */
     static inline IPlayFabModuleInterface& Get()
     {
+        if (IsAvailable())
+        {
+            return FModuleManager::GetModuleChecked< IPlayFabModuleInterface >("PlayFabCpp");
+        }
         return FModuleManager::LoadModuleChecked< IPlayFabModuleInterface >("PlayFabCpp");
     }
 


### PR DESCRIPTION
This lets PlayFab APIs be called from non-main threads, since LoadModuleChecked will ensure() it is on the game thread but GetModuleChecked does not.

This fixes (for example), a break I was hitting in a call to GetTitleId() for logging.
