### PR TITLE
Mimacken/xamarin pathlengthfix

### DIFF
--- a/SDKBuildScripts/xamarin_buildAppCenterTestAndroid.sh
+++ b/SDKBuildScripts/xamarin_buildAppCenterTestAndroid.sh
@@ -1,20 +1,19 @@
 #!/bin/bash
-pushd ../../sdks/CSharpSdk/XamarinTestRunner
-AndroidProjectPath=$PWD
-popd
-
-apkPath=$AndroidProjectPath/XamarinTestRunner/XamarinTestRunner.Android/bin/Debug/com.companyname.XamarinTestRunner-Signed.apk
-testAssemblyDir="$1"
-
 Usage="./xamarin_BuildAndTestAndroid.sh <path to test assemblies>"
 ArgCount=$#
 CheckParameters() {
-    if [ $ArgCount -ne 1 ]; then
+    if [ $ArgCount -ne 2 ]; then
         echo "ERROR Incorrect number of parameters!"
         echo "$Usage"
         exit 1
     fi
 }
+CheckParameters
+
+testAssemblyDir="$1"
+AndroidProjectPath="$2"
+
+apkPath=$AndroidProjectPath/XamarinTestRunner/XamarinTestRunner.Android/bin/Debug/com.companyname.XamarinTestRunner-Signed.apk
 
 ExitIfError() {
     ErrorStatus=$?

--- a/SDKBuildScripts/xamarin_buildAppCenterTestAndroid.sh
+++ b/SDKBuildScripts/xamarin_buildAppCenterTestAndroid.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-Usage="./xamarin_BuildAndTestAndroid.sh <path to test assemblies>"
+Usage="./xamarin_BuildAndTestAndroid.sh <path to test assemblies> <path to XamarinTestRunner project>"
 ArgCount=$#
 CheckParameters() {
     if [ $ArgCount -ne 2 ]; then
@@ -32,7 +32,7 @@ BuildAPK() {
     pushd "$AndroidProjectPath"
     ExitIfError
 
-    cmd <<< "call build_Android.cmd"
+    cmd <<< "call ${AndroidProjectPath}\build_Android.cmd"
     ExitIfError
 
     popd

--- a/SDKBuildScripts/xamarin_buildAppCenterTestIOS.sh
+++ b/SDKBuildScripts/xamarin_buildAppCenterTestIOS.sh
@@ -99,7 +99,9 @@ InitializeBuildEnvironment() {
     #copy the xamarin workspace into the appcenter git repo
     ACB="$AppCenterRepoParentDir/$GitRepoFolderName"
     echo "Copying $XamarinWorkspaceDirectory into $ACB..."
-    cp -a "$XamarinWorkspaceDirectory/." .
+    cp -r "$XamarinWorkspaceDirectory/PlayFabSDK" .
+    cp -r "$XamarinWorkspaceDirectory/Plugins" .
+    cp -r "$XamarinWorkspaceDirectory/XamarinTestRunner" .
     echo "Loading test title data from $PF_TEST_TITLE_DATA_JSON into $ACB/XamarinTestRunner/XamarinTestRunner/XamarinTestRunner..."
     pushd "XamarinTestRunner/XamarinTestRunner/XamarinTestRunner"
     cp -f "$PF_TEST_TITLE_DATA_JSON" .

--- a/targets/csharp/make.js
+++ b/targets/csharp/make.js
@@ -31,9 +31,6 @@ exports.makeCombinedAPI = function (apis, sourceDir, apiOutputDir) {
     templatizeTree(locals, path.resolve(sourceDir, "source"), rootOutputDir);
     templatizeTree(locals, path.resolve(sourceDir, "UnittestRunner"), path.resolve(apiOutputDir, "UnittestRunner")); // Copy the actual unittest project in the CombinedAPI
     makeDatatypes(apis, sourceDir, apiOutputDir);
-    const xamarinOutputDir = path.join(rootOutputDir, "XamarinTestRunner");
-    templatizeTree(locals, path.resolve(sourceDir, "XamarinTestRunner"), xamarinOutputDir);
-    templatizeTree(locals, path.join(apiOutputDir, "source"), path.join(xamarinOutputDir, "XamarinTestRunner", "PlayFabSDK"));
 
     for (var i = 0; i < apis.length; i++) {
         var apiAuths = getAuthMechanisms([apis[i]]);
@@ -42,6 +39,10 @@ exports.makeCombinedAPI = function (apis, sourceDir, apiOutputDir) {
         locals.hasServerOptions = apiAuths.includes("SecretKey");
         makeApi(apis[i], sourceDir, apiOutputDir);
     }
+
+    const xamarinOutputDir = path.join(rootOutputDir, "XamarinTestRunner");
+    templatizeTree(locals, path.resolve(sourceDir, "XamarinTestRunner"), xamarinOutputDir);
+    templatizeTree(locals, path.join(apiOutputDir, "source"), path.join(xamarinOutputDir, "XamarinTestRunner", "PlayFabSDK"));
 };
 
 function getBaseTypeSyntax(datatype) {


### PR DESCRIPTION
1) improves build script error handling/messaging
2) buildscript copies more selectively so as to avoid things like .git folders
3) victor helped me fix the make.js for this one. thanks victor!