### PR TITLE
Change AzureRegions to strings

### DIFF
--- a/targets/csharp/source/PlayFabSDK/source/Qos/PlayFabQosApi.cs
+++ b/targets/csharp/source/PlayFabSDK/source/Qos/PlayFabQosApi.cs
@@ -11,7 +11,7 @@ namespace PlayFab.QoS
     public class PlayFabQosApi
     {
         private const int DefaultTimeoutMs = 250;
-        private readonly Dictionary<AzureRegion, string> _dataCenterMap = new Dictionary<AzureRegion, string>();
+        private readonly Dictionary<string, string> _dataCenterMap = new Dictionary<string, string>();
 
         public async Task<QosResult> GetQosResultAsync(int timeoutMs = DefaultTimeoutMs)
         {
@@ -71,19 +71,19 @@ namespace PlayFab.QoS
 
             foreach (QosServer qosServer in response.Result.QosServers)
             {
-                if (!qosServer.Region.HasValue)
+                if (string.IsNullOrEmpty(qosServer.Region))
                 {
                     continue;
                 }
 
-                _dataCenterMap[qosServer.Region.Value] = qosServer.ServerUrl;
+                _dataCenterMap[qosServer.Region] = qosServer.ServerUrl;
             }
         }
 
         private async Task<List<QosRegionResult>> GetSortedRegionLatencies(int timeoutMs)
         {
             var asyncPingResults = new List<Task<QosRegionResult>>(_dataCenterMap.Count);
-            foreach (KeyValuePair<AzureRegion, string> datacenter in _dataCenterMap)
+            foreach (KeyValuePair<string, string> datacenter in _dataCenterMap)
             {
                 var regionPinger = new RegionPinger(datacenter.Value, datacenter.Key);
                 Task<QosRegionResult> pingResult = regionPinger.PingAsync(timeoutMs);

--- a/targets/csharp/source/PlayFabSDK/source/Qos/QosRegionResult.cs
+++ b/targets/csharp/source/PlayFabSDK/source/Qos/QosRegionResult.cs
@@ -5,7 +5,7 @@ namespace PlayFab.QoS
 
     public class QosRegionResult
     {
-        public AzureRegion Region;
+        public string Region;
 
         public int LatencyMs;
 
@@ -29,7 +29,7 @@ namespace PlayFab.QoS
             };
         }
 
-        public AzureRegion Region;
+        public string Region;
 
         public int LatencyMs;
 

--- a/targets/csharp/source/PlayFabSDK/source/Qos/RegionPinger.cs
+++ b/targets/csharp/source/PlayFabSDK/source/Qos/RegionPinger.cs
@@ -18,9 +18,9 @@ namespace PlayFab.QoS
         private readonly byte[] _initialHeader = { 0xFF, 0xFF };
         private readonly byte[] _subsequentHeader = { 0x00, 0x00 };
         private readonly string _hostNameOrAddress;
-        private readonly AzureRegion _region;
+        private readonly string _region;
 
-        public RegionPinger(string hostNameOrAddress, AzureRegion region)
+        public RegionPinger(string hostNameOrAddress, string region)
         {
             _hostNameOrAddress = hostNameOrAddress;
             _region = region;


### PR DESCRIPTION
AzureRegions must be treated as strings in our QoS C# code