### PR TITLE
Add a new BBL Check-Standby command, for alerting

### DIFF
--- a/JenkinsConsoleUtility/JenkinsConsoleUtility.csproj
+++ b/JenkinsConsoleUtility/JenkinsConsoleUtility.csproj
@@ -9,7 +9,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>JenkinsConsoleUtility</RootNamespace>
     <AssemblyName>JenkinsConsoleUtility</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
     <TargetFrameworkProfile />
@@ -69,6 +69,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="jcuSrc\AssemblyInfo.cs" />
+    <Compile Include="jcuSrc\Commands\CheckBblStandby.cs" />
     <Compile Include="jcuSrc\Commands\CloudScriptListener.cs" />
     <Compile Include="jcuSrc\Commands\GitApiCommand.cs" />
     <Compile Include="jcuSrc\Commands\KillTaskCommand.cs" />

--- a/JenkinsConsoleUtility/JenkinsConsoleUtility.csproj
+++ b/JenkinsConsoleUtility/JenkinsConsoleUtility.csproj
@@ -41,10 +41,24 @@
       <HintPath>packages\Octokit.0.32.0\lib\net45\Octokit.dll</HintPath>
     </Reference>
     <Reference Include="PlayFabAllSDK, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>packages\PlayFabAllSDK.1.38.181001\lib\portable45-net45+win8+wpa81\PlayFabAllSDK.dll</HintPath>
+      <HintPath>packages\PlayFabAllSDK.1.57.190903\lib\net45\PlayFabAllSDK.dll</HintPath>
     </Reference>
     <Reference Include="System" />
+    <Reference Include="System.Collections" />
+    <Reference Include="System.ComponentModel" />
     <Reference Include="System.Core" />
+    <Reference Include="System.Diagnostics.Tools" />
+    <Reference Include="System.Globalization" />
+    <Reference Include="System.Linq" />
+    <Reference Include="System.Net.Primitives" />
+    <Reference Include="System.Reflection" />
+    <Reference Include="System.Reflection.Extensions" />
+    <Reference Include="System.Resources.ResourceManager" />
+    <Reference Include="System.Runtime" />
+    <Reference Include="System.Runtime.Extensions" />
+    <Reference Include="System.Text.Encoding" />
+    <Reference Include="System.Threading" />
+    <Reference Include="System.Threading.Tasks" />
     <Reference Include="System.Web" />
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />

--- a/JenkinsConsoleUtility/JenkinsConsoleUtility.csproj
+++ b/JenkinsConsoleUtility/JenkinsConsoleUtility.csproj
@@ -80,6 +80,7 @@
     <Compile Include="jcuSrc\Commands\TestingCommand.cs" />
     <Compile Include="jcuSrc\Testing\TestJsonReportSyntax.cs" />
     <Compile Include="jcuSrc\Testing\XmlTests.cs" />
+    <Compile Include="jcuSrc\Util\Util.cs" />
     <Compile Include="jcuSrc\Util\TestTitleDataLoader.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/JenkinsConsoleUtility/app.config
+++ b/JenkinsConsoleUtility/app.config
@@ -1,3 +1,3 @@
 <?xml version="1.0" encoding="utf-8"?>
 <configuration>
-<startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5"/></startup></configuration>
+<startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.7.2"/></startup></configuration>

--- a/JenkinsConsoleUtility/jcuSrc/Commands/CheckBblStandby.cs
+++ b/JenkinsConsoleUtility/jcuSrc/Commands/CheckBblStandby.cs
@@ -1,10 +1,10 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Threading;
 using JenkinsConsoleUtility.Util;
 using PlayFab;
 using PlayFab.MultiplayerModels;
-using System.Windows;
+using System.Linq;
 
 namespace JenkinsConsoleUtility.Commands
 {
@@ -24,21 +24,21 @@ namespace JenkinsConsoleUtility.Commands
 
         private static readonly string[] MyCommandKeys = { "CheckBbl", "BblStandby" };
         public string[] CommandKeys => MyCommandKeys;
-        private static readonly string[] MyMandatoryArgKeys = { "BBL_VERSIONS" };
-        public string[] MandatoryArgKeys => MyMandatoryArgKeys;
+        public string[] MandatoryArgKeys => null;
 
         private PlayFabAuthenticationContext context;
         private PlayFabApiSettings settings;
         private PlayFabAuthenticationInstanceAPI authApi;
         private PlayFabMultiplayerInstanceAPI multiplayerApi;
 
-        private readonly TimeSpan cycleDuration = TimeSpan.FromMinutes(0.5);
-        private readonly TimeSpan cyclePeriod = TimeSpan.FromSeconds(10);
-        private readonly TimeSpan retryDelay = TimeSpan.FromSeconds(10);
-        private const int retryCount = 5;
-        private readonly int[] GAP_THRESHOLDS = new[] { 10000, 10000, 1000, 400, 200, 100 };
-        private readonly int[] MAX_PERCENT_THRESHOLDS = new[] { 1000, 1000, 100, 95, 80, 75 };
-        private readonly int[] STANDBY_THRESHOLDS = new[] { -1, -1, 0, 6, 9, 11 };
+        // "Constants" defined by program inputs (vars or cmd-line)
+        private TimeSpan CYCLE_DURATION_MINS = TimeSpan.FromMinutes(10);
+        private TimeSpan CYCLE_PERIOD_SEC = TimeSpan.FromSeconds(30);
+        private TimeSpan RETRY_DELAY_SEC = TimeSpan.FromSeconds(10);
+        private int RETRY_COUNT = 5;
+        private int[] GAP_THRESHOLDS = new[] { 10000, 10000, 1000, 400, 200, 100 };
+        private int[] MAX_CAPACITY_PERCENT_THRESHOLDS = new[] { 1000, 1000, 100, 95, 80, 75 };
+        private int[] STANDBY_THRESHOLDS = new[] { -1, -1, 0, 6, 9, 11 };
 
         private DateTime endOfCycle;
         private string bblVersions;
@@ -55,7 +55,7 @@ namespace JenkinsConsoleUtility.Commands
 
         public int Execute(Dictionary<string, string> argsLc, Dictionary<string, string> argsCased)
         {
-            bblVersions = JenkinsConsoleUtility.GetArgVar(argsLc, "BBL_VERSIONS");
+            ParseInputs(argsLc);
 
             var setupCode = LoginToPlayfab(argsLc);
             if (setupCode != 0)
@@ -63,7 +63,7 @@ namespace JenkinsConsoleUtility.Commands
 
             var cumulativeResult = new Tuple<int, Severity>(0, Severity.SEV_0);
 
-            endOfCycle = DateTime.UtcNow + cycleDuration;
+            endOfCycle = DateTime.UtcNow + CYCLE_DURATION_MINS;
             while (endOfCycle > DateTime.UtcNow)
             {
                 var eachSummary = GetBuildSummaryFromPlayfab();
@@ -75,7 +75,7 @@ namespace JenkinsConsoleUtility.Commands
                     (Severity)Math.Max((byte)cumulativeResult.Item2, (byte)eachResult.Item2) // Least Error Seen
                 );
 
-                Thread.Sleep((int)cyclePeriod.TotalMilliseconds);
+                Thread.Sleep((int)CYCLE_PERIOD_SEC.TotalMilliseconds);
             }
 
             JcuUtil.FancyWriteToConsole("Finished Query Cycle");
@@ -84,6 +84,28 @@ namespace JenkinsConsoleUtility.Commands
             MakeAlert(null, cumulativeResult.Item2, " <- Typical Error Level. Total Number of Alerts: " + cumulativeResult.Item1);
 
             return (cumulativeResult.Item2 <= Severity.SEV_3) ? cumulativeResult.Item1 : 0;
+        }
+
+        private void ParseInputs(Dictionary<string, string> argsLc)
+        {
+            if (!JenkinsConsoleUtility.TryGetArgVar(out bblVersions, argsLc, "BBL_VERSIONS"))
+                bblVersions = "3.0.0;2.0.1";
+
+            if (JenkinsConsoleUtility.TryGetArgVar(out string tempGapThresholds, argsLc, "GAP_THRESHOLDS"))
+                try { GAP_THRESHOLDS = tempGapThresholds.Split(';').Select(s => int.Parse(s)).ToArray(); } catch (Exception) { }
+            if (JenkinsConsoleUtility.TryGetArgVar(out string tempStandby, argsLc, "STANDBY_THRESHOLDS"))
+                try { STANDBY_THRESHOLDS = tempGapThresholds.Split(';').Select(s => int.Parse(s)).ToArray(); } catch (Exception) { }
+            if (JenkinsConsoleUtility.TryGetArgVar(out string tempMaxCap, argsLc, "MAX_CAPACITY_PERCENT_THRESHOLDS"))
+                try { MAX_CAPACITY_PERCENT_THRESHOLDS = tempGapThresholds.Split(';').Select(s => int.Parse(s)).ToArray(); } catch (Exception) { }
+
+            if (JenkinsConsoleUtility.TryGetArgVar(out string tempCycleDuration, argsLc, "CYCLE_DURATION_MINS"))
+                try { CYCLE_DURATION_MINS = TimeSpan.FromMinutes(double.Parse(tempCycleDuration)); } catch (Exception) { }
+            if (JenkinsConsoleUtility.TryGetArgVar(out string tempCyclePeriod, argsLc, "CYCLE_PERIOD_SEC"))
+                try { CYCLE_PERIOD_SEC = TimeSpan.FromSeconds(double.Parse(tempCyclePeriod)); } catch (Exception) { }
+            if (JenkinsConsoleUtility.TryGetArgVar(out string tempRetryDelay, argsLc, "RETRY_DELAY_SEC"))
+                try { RETRY_DELAY_SEC = TimeSpan.FromSeconds(double.Parse(tempRetryDelay)); } catch (Exception) { }
+            if (JenkinsConsoleUtility.TryGetArgVar(out string tempRetryCount, argsLc, "RETRY_COUNT"))
+                try { RETRY_COUNT = int.Parse(tempRetryCount); } catch (Exception) { }
         }
 
         private int LoginToPlayfab(Dictionary<string, string> argsLc)
@@ -107,7 +129,7 @@ namespace JenkinsConsoleUtility.Commands
             settings.DeveloperSecretKey = testTitleData.developerSecretKey;
 
             // Perform PlayFab Login
-            for (int i = 0; i < retryCount; i++)
+            for (int i = 0; i < RETRY_COUNT; i++)
             {
                 var tokenTask = authApi.GetEntityTokenAsync(null);
                 tokenTask.Wait();
@@ -115,7 +137,7 @@ namespace JenkinsConsoleUtility.Commands
                 if (string.IsNullOrEmpty(context.EntityToken))
                 {
                     JcuUtil.FancyWriteToConsole(ConsoleColor.Red, "ERROR: CheckBblStandby was not able to authenticate as expected, sleeping...");
-                    Thread.Sleep((int)retryDelay.TotalMilliseconds);
+                    Thread.Sleep((int)RETRY_DELAY_SEC.TotalMilliseconds);
                 }
                 else
                 {
@@ -136,7 +158,7 @@ namespace JenkinsConsoleUtility.Commands
         {
             var listBuildsRequest = new ListBuildSummariesRequest { PageSize = 100 };
 
-            for (int i = 0; i < retryCount; i++)
+            for (int i = 0; i < RETRY_COUNT; i++)
             {
                 var listBuildsTask = multiplayerApi.ListBuildSummariesAsync(listBuildsRequest);
                 listBuildsTask.Wait();
@@ -144,7 +166,7 @@ namespace JenkinsConsoleUtility.Commands
                 if (buildSummaries == null)
                 {
                     JcuUtil.FancyWriteToConsole(ConsoleColor.Red, "ERROR: Was unable to list build summaries, sleeping...");
-                    Thread.Sleep((int)retryDelay.TotalMilliseconds);
+                    Thread.Sleep((int)RETRY_DELAY_SEC.TotalMilliseconds);
                 }
                 else
                 {
@@ -201,11 +223,11 @@ namespace JenkinsConsoleUtility.Commands
                         }
                     }
 
-                    for (var i = 0; i < MAX_PERCENT_THRESHOLDS.Length; i++)
+                    for (var i = 0; i < MAX_CAPACITY_PERCENT_THRESHOLDS.Length; i++)
                     {
-                        if (each.CurrentServerStats.Active >= (each.MaxServers * MAX_PERCENT_THRESHOLDS[i] / 100))
+                        if (each.CurrentServerStats.Active >= (each.MaxServers * MAX_CAPACITY_PERCENT_THRESHOLDS[i] / 100))
                         {
-                            MakeAlert(bblAlerts, (Severity)i, versionString + ", " + eachSummary.BuildId + " - " + MAX_PERCENT_THRESHOLDS[i] + "% (" + each.CurrentServerStats.Active + "/" + each.MaxServers + ") Max Servers reached in region:" + each.Region);
+                            MakeAlert(bblAlerts, (Severity)i, versionString + ", " + eachSummary.BuildId + " - " + MAX_CAPACITY_PERCENT_THRESHOLDS[i] + "% (" + each.CurrentServerStats.Active + "/" + each.MaxServers + ") Max Servers reached in region:" + each.Region);
                             worstBblSeverity = (Severity)Math.Min((byte)worstBblSeverity, i);
                             worstTickSeverity = (Severity)Math.Min((byte)worstTickSeverity, i);
                             break;

--- a/JenkinsConsoleUtility/jcuSrc/Commands/CheckBblStandby.cs
+++ b/JenkinsConsoleUtility/jcuSrc/Commands/CheckBblStandby.cs
@@ -8,6 +8,18 @@ namespace JenkinsConsoleUtility.Commands
 {
     public class CheckBblStandby : ICommand
     {
+        private enum Severity
+        {
+            SEV_0, // Wake up everyone
+            SEV_1, // Wake up team
+            SEV_2, // Wake up on-call
+            SEV_3, // Send an email
+            SEV_4, // File a bug
+            SEV_5, // Follow up if there's lots of them
+
+            NONE, // No issue
+        }
+
         private static readonly string[] MyCommandKeys = { "CheckBbl", "BblStandby" };
         public string[] CommandKeys => MyCommandKeys;
         private static readonly string[] MyMandatoryArgKeys = { "BBL_VERSIONS" };
@@ -18,11 +30,9 @@ namespace JenkinsConsoleUtility.Commands
         private PlayFabAuthenticationInstanceAPI authApi;
         private PlayFabMultiplayerInstanceAPI multiplayerApi;
 
-        private const int S2_MAX_THRESHHOLD_PERCENT = 90;
-        private const int S3_MAX_THRESHHOLD_PERCENT = 75;
-
-        private const int S1_LOW_STANDBY_THRESHHOLD = 3;
-        private const int S2_LOW_STANDBY_THRESHHOLD = 11;
+        private readonly int[] GAP_THRESHOLDS = new[] { 10000, 10000, 1000, 400, 200, 100 };
+        private readonly int[] MAX_PERCENT_THRESHOLDS = new[] { 1000, 1000, 100, 95, 80, 75 };
+        private readonly int[] STANDBY_THRESHOLDS = new[] { -1, -1, 0, 6, 9, 11 };
 
         public CheckBblStandby()
         {
@@ -71,8 +81,18 @@ namespace JenkinsConsoleUtility.Commands
                 return 1;
             }
 
-            List<string> alerts = new List<string>();
+            var buildResults = EvaluateBuildSummaries(bblVersions, buildSummaries);
+
+            return (buildResults.Item2 <= Severity.SEV_3) ? buildResults.Item1 : 0;
+        }
+
+        private Tuple<int, Severity> EvaluateBuildSummaries(string bblVersions, List<BuildSummary> buildSummaries)
+        {
+            List<string> bblAlerts = new List<string>();
+            List<string> thAlerts = new List<string>();
             HashSet<string> completedVersions = new HashSet<string>();
+
+            Severity worstSeverity = Severity.NONE;
             foreach (var eachSummary in buildSummaries)
             {
                 if (!eachSummary.Metadata.TryGetValue("Version", out string versionString))
@@ -83,49 +103,81 @@ namespace JenkinsConsoleUtility.Commands
                 bool isDeployed = true;
                 foreach (var eachRegionConfig in eachSummary.RegionConfigurations)
                     isDeployed &= eachRegionConfig.Status == "Deployed";
-                if (!isDeployed)
+                if (!isDeployed || eachSummary.RegionConfigurations.Count == 0)
                     continue;
-
-                Action<string> makeAlert = (msg) =>
-                {
-                    ConsoleColor alertColor;
-                    switch (msg.Substring(0, 4))
-                    {
-                        case "SEV1": alertColor = ConsoleColor.Magenta; break;
-                        case "SEV2": alertColor = ConsoleColor.Red; break;
-                        case "SEV3": alertColor = ConsoleColor.Yellow; break;
-                        default: alertColor = ConsoleColor.White; break;
-                    }
-                    JcuUtil.FancyWriteToConsole(alertColor, msg);
-                    alerts.Add(msg);
-                };
 
                 JcuUtil.FancyWriteToConsole("Found Version: " + versionString + ",  BuildId: " + eachSummary.BuildId);
                 foreach (var each in eachSummary.RegionConfigurations)
                 {
-                    JcuUtil.FancyWriteToConsole(" - " + each.Region + ", (sby:" + each.CurrentServerStats.StandingBy + "/prp:" + each.CurrentServerStats.Propping + "/act:" + each.CurrentServerStats.Active + "/max:" + each.MaxServers + ")");
+                    JcuUtil.FancyWriteToConsole(" - " + each.Region + ", (sby:" + each.StandbyServers + "/max:" + each.MaxServers + ")(sby:" + each.CurrentServerStats.StandingBy + "/prp:" + each.CurrentServerStats.Propping + "/act:" + each.CurrentServerStats.Active + "/max:" + each.MaxServers + ")");
 
-                    if (each.CurrentServerStats.Active >= each.MaxServers)
-                        makeAlert("SEV1: " + versionString + ", " + eachSummary.BuildId + " - Max Servers reached in region:" + each.Region);
-                    else if (each.CurrentServerStats.Active >= (each.MaxServers * S2_MAX_THRESHHOLD_PERCENT / 100))
-                        makeAlert("SEV2: " + versionString + ", " + eachSummary.BuildId + " - " + S2_MAX_THRESHHOLD_PERCENT + "% (" + each.CurrentServerStats.Active + "/" + each.MaxServers + ") Max Servers reached in region:" + each.Region);
-                    else if (each.CurrentServerStats.Active >= (each.MaxServers * S3_MAX_THRESHHOLD_PERCENT / 100))
-                        makeAlert("SEV3: " + versionString + ", " + eachSummary.BuildId + " - " + S3_MAX_THRESHHOLD_PERCENT + "% (" + each.CurrentServerStats.Active + "/" + each.MaxServers + ") Max Servers reached in region:" + each.Region);
+                    if (each.CurrentServerStats.StandingBy == 0 && each.CurrentServerStats.Active == 0 && each.CurrentServerStats.Propping == 0)
+                    {
+                        MakeAlert(thAlerts, Severity.SEV_4, "Bad region numbers detected");
+                        worstSeverity = Severity.SEV_4;
+                        continue; // All hell will break loose below, with these numbers, but they're not legit, so skip it
+                    }
 
-                    if (each.CurrentServerStats.StandingBy <= S1_LOW_STANDBY_THRESHHOLD)
-                        makeAlert("SEV1: " + versionString + ", " + eachSummary.BuildId + " - Standby == 0 for region:" + each.Region + ", " + each.CurrentServerStats.StandingBy + "<=" + S1_LOW_STANDBY_THRESHHOLD);
-                    else if (each.CurrentServerStats.StandingBy <= S2_LOW_STANDBY_THRESHHOLD)
-                        makeAlert("SEV2: " + versionString + ", " + eachSummary.BuildId + " - Low Standby in region:" + each.Region + ", " + each.CurrentServerStats.StandingBy + "<=" + S2_LOW_STANDBY_THRESHHOLD);
+                    var gap = each.StandbyServers - each.CurrentServerStats.StandingBy - each.CurrentServerStats.Propping;
+                    for (var i = 0; i < GAP_THRESHOLDS.Length; i++)
+                    {
+                        if (gap >= GAP_THRESHOLDS[i])
+                        {
+                            MakeAlert(thAlerts, (Severity)i, versionString + ", " + eachSummary.BuildId + " - High (StandBy + Propping) Gap in region:" + gap);
+                            worstSeverity = (Severity)i;
+                            break;
+                        }
+                    }
+
+                    for (var i = 0; i < MAX_PERCENT_THRESHOLDS.Length; i++)
+                    {
+                        if (each.CurrentServerStats.Active >= (each.MaxServers * MAX_PERCENT_THRESHOLDS[i] / 100))
+                        {
+                            MakeAlert(bblAlerts, (Severity)i, versionString + ", " + eachSummary.BuildId + " - " + MAX_PERCENT_THRESHOLDS[i] + "% (" + each.CurrentServerStats.Active + "/" + each.MaxServers + ") Max Servers reached in region:" + each.Region);
+                            worstSeverity = (Severity)i;
+                            break;
+                        }
+                    }
+
+                    for (var i = 0; i < STANDBY_THRESHOLDS.Length; i++)
+                    {
+                        if (each.CurrentServerStats.StandingBy <= STANDBY_THRESHOLDS[i])
+                        {
+                            MakeAlert(bblAlerts, (Severity)i, versionString + ", " + eachSummary.BuildId + " - Low Standby in region:" + each.Region + ", " + each.CurrentServerStats.StandingBy + "<=" + STANDBY_THRESHOLDS[i]);
+                            worstSeverity = (Severity)i;
+                            break;
+                        }
+                    }
                 }
 
                 JcuUtil.FancyWriteToConsole(null);
                 completedVersions.Add(versionString);
             }
 
-            if (alerts.Count > 0)
-                JcuUtil.FancyWriteToConsole(ConsoleColor.Yellow, "Alert list:", ConsoleColor.Red, null, alerts, null);
+            if (bblAlerts.Count > 0)
+                JcuUtil.FancyWriteToConsole(ConsoleColor.Yellow, "Bumblelion alert list:", ConsoleColor.Red, null, bblAlerts, null);
+            if (thAlerts.Count > 0)
+                JcuUtil.FancyWriteToConsole(ConsoleColor.Yellow, "Thunderhead alert list:", ConsoleColor.Blue, null, thAlerts, null);
 
-            return alerts.Count;
+            return new Tuple<int, Severity>(bblAlerts.Count + thAlerts.Count, worstSeverity);
+        }
+
+        private void MakeAlert(List<string> alertList, Severity severity, string msg)
+        {
+            ConsoleColor alertColor;
+            switch (severity)
+            {
+                case Severity.SEV_0: alertColor = ConsoleColor.Magenta; break;
+                case Severity.SEV_1: alertColor = ConsoleColor.Magenta; break;
+                case Severity.SEV_2: alertColor = ConsoleColor.Red; break;
+                case Severity.SEV_3: alertColor = ConsoleColor.Yellow; break;
+                case Severity.SEV_4: alertColor = ConsoleColor.Yellow; break;
+                case Severity.SEV_5: alertColor = ConsoleColor.DarkGray; break;
+                default: alertColor = ConsoleColor.White; break;
+            }
+            JcuUtil.FancyWriteToConsole(alertColor, severity + " " + msg);
+            if (severity <= Severity.SEV_4)
+                alertList.Add(msg);
         }
     }
 }

--- a/JenkinsConsoleUtility/jcuSrc/Commands/CheckBblStandby.cs
+++ b/JenkinsConsoleUtility/jcuSrc/Commands/CheckBblStandby.cs
@@ -1,0 +1,62 @@
+﻿using System.Collections.Generic;
+using JenkinsConsoleUtility.Util;
+using PlayFab;
+using PlayFab.MultiplayerModels;
+
+namespace JenkinsConsoleUtility.Commands
+{
+    public class CheckBblStandby : ICommand
+    {
+        private static readonly string[] MyCommandKeys = { "CheckBbl", "BblStandby" };
+        public string[] CommandKeys => MyCommandKeys;
+        private static readonly string[] MyMandatoryArgKeys = { "buildidentifier" };
+        public string[] MandatoryArgKeys => MyMandatoryArgKeys;
+
+        private PlayFabAuthenticationContext context;
+        private PlayFabApiSettings settings;
+        private PlayFabAuthenticationInstanceAPI authApi;
+        private PlayFabMultiplayerInstanceAPI multiplayerApi;
+
+        public CheckBblStandby()
+        {
+            context = new PlayFabAuthenticationContext();
+            settings = new PlayFabApiSettings();
+            authApi = new PlayFabAuthenticationInstanceAPI(settings, context);
+            multiplayerApi = new PlayFabMultiplayerInstanceAPI(settings, context);
+        }
+
+        public int Execute(Dictionary<string, string> argsLc, Dictionary<string, string> argsCased)
+        {
+
+            var testTitleData = TestTitleDataLoader.Load(argsLc);
+            if (string.IsNullOrEmpty(context.EntityToken))
+            {
+                JenkinsConsoleUtility.FancyWriteToConsole(System.ConsoleColor.Red, "ERROR: Could not load testTitleData.");
+                return 1;
+            }
+
+            settings.TitleId = testTitleData.titleId;
+            settings.DeveloperSecretKey = testTitleData.developerSecretKey;
+
+            var tokenTask = authApi.GetEntityTokenAsync(null);
+            tokenTask.Wait();
+            if (string.IsNullOrEmpty(context.EntityToken))
+            {
+                JenkinsConsoleUtility.FancyWriteToConsole(System.ConsoleColor.Red, "ERROR: CheckBblStandby was not able to authenticate as expected.");
+                return 1;
+            }
+
+            var listBuildsRequest = new ListBuildSummariesRequest();
+            var listBuildsTask = multiplayerApi.ListBuildSummariesAsync(listBuildsRequest);
+            listBuildsTask.Wait();
+            var buildSummaries = listBuildsTask?.Result?.Result?.BuildSummaries;
+            if (buildSummaries == null)
+            {
+                JenkinsConsoleUtility.FancyWriteToConsole(System.ConsoleColor.Red, "ERROR: Was unable to list build summaries.");
+                return 1;
+            }
+
+            return 0;
+        }
+    }
+}

--- a/JenkinsConsoleUtility/jcuSrc/Commands/CheckBblStandby.cs
+++ b/JenkinsConsoleUtility/jcuSrc/Commands/CheckBblStandby.cs
@@ -15,9 +15,9 @@ namespace JenkinsConsoleUtility.Commands
             SEV_0, // Wake up everyone
             SEV_1, // Wake up team
             SEV_2, // Wake up on-call
-            SEV_3, // Send an email
-            SEV_4, // File a bug
-            SEV_5, // Follow up if there's lots of them
+            SEV_3, // Send an email for morning
+            SEV_4, // File a bug for next sprint
+            SEV_5, // Follow up someday if I feel like it
 
             NONE, // No issue
         }

--- a/JenkinsConsoleUtility/jcuSrc/Commands/CheckBblStandby.cs
+++ b/JenkinsConsoleUtility/jcuSrc/Commands/CheckBblStandby.cs
@@ -94,9 +94,9 @@ namespace JenkinsConsoleUtility.Commands
             if (JenkinsConsoleUtility.TryGetArgVar(out string tempGapThresholds, argsLc, "GAP_THRESHOLDS"))
                 try { GAP_THRESHOLDS = tempGapThresholds.Split(';').Select(s => int.Parse(s)).ToArray(); } catch (Exception) { }
             if (JenkinsConsoleUtility.TryGetArgVar(out string tempStandby, argsLc, "STANDBY_THRESHOLDS"))
-                try { STANDBY_THRESHOLDS = tempGapThresholds.Split(';').Select(s => int.Parse(s)).ToArray(); } catch (Exception) { }
+                try { STANDBY_THRESHOLDS = tempStandby.Split(';').Select(s => int.Parse(s)).ToArray(); } catch (Exception e) { JcuUtil.FancyWriteToConsole(e); }
             if (JenkinsConsoleUtility.TryGetArgVar(out string tempMaxCap, argsLc, "MAX_CAPACITY_PERCENT_THRESHOLDS"))
-                try { MAX_CAPACITY_PERCENT_THRESHOLDS = tempGapThresholds.Split(';').Select(s => int.Parse(s)).ToArray(); } catch (Exception) { }
+                try { MAX_CAPACITY_PERCENT_THRESHOLDS = tempMaxCap.Split(';').Select(s => int.Parse(s)).ToArray(); } catch (Exception) { }
 
             if (JenkinsConsoleUtility.TryGetArgVar(out string tempCycleDuration, argsLc, "CYCLE_DURATION_MINS"))
                 try { CYCLE_DURATION_MINS = TimeSpan.FromMinutes(double.Parse(tempCycleDuration)); } catch (Exception) { }

--- a/JenkinsConsoleUtility/jcuSrc/Commands/CloudScriptListener.cs
+++ b/JenkinsConsoleUtility/jcuSrc/Commands/CloudScriptListener.cs
@@ -50,18 +50,18 @@ namespace JenkinsConsoleUtility.Commands
             verbose = bool.Parse(JenkinsConsoleUtility.GetArgVar(argsLc, "verbose", "false"));
             _getRequest = new CsGetRequest { customId = buildIdentifier };
 
-            JenkinsConsoleUtility.FancyWriteToConsole("Begin CloudScriptListener", null, ConsoleColor.Gray);
+            JenkinsConsoleUtility.FancyWriteToConsole(ConsoleColor.Gray, "Begin CloudScriptListener");
             var returnCode = Login(testTitleData.titleId, buildIdentifier, testTitleData);
             if (returnCode != 0)
                 return returnCode;
             returnCode = WaitForTestResult(timeout, testTitleData);
             if (returnCode != 0)
                 return returnCode;
-            JenkinsConsoleUtility.FancyWriteToConsole("Test data found", null, ConsoleColor.Gray);
+            JenkinsConsoleUtility.FancyWriteToConsole(ConsoleColor.Gray, "Test data found");
             returnCode = FetchTestResult(buildIdentifier, workspacePath, testTitleData);
             if (returnCode != 0)
                 return returnCode;
-            JenkinsConsoleUtility.FancyWriteToConsole("Test data received", null, ConsoleColor.Green);
+            JenkinsConsoleUtility.FancyWriteToConsole(ConsoleColor.Green, "Test data received");
 
             return 0;
         }
@@ -74,12 +74,12 @@ namespace JenkinsConsoleUtility.Commands
             var returnCode = PlayFabClientAPI.IsClientLoggedIn() ? 0 : 1;
             if (returnCode != 0)
             {
-                JenkinsConsoleUtility.FancyWriteToConsole("Failed to log in using CustomID: " + titleId + ", " + buildIdentifier, null, ConsoleColor.Red);
-                JenkinsConsoleUtility.FancyWriteToConsole(task.Result.Error?.GenerateErrorReport(), null, ConsoleColor.Red);
+                JenkinsConsoleUtility.FancyWriteToConsole(ConsoleColor.Red, "Failed to log in using CustomID: " + titleId + ", " + buildIdentifier);
+                JenkinsConsoleUtility.FancyWriteToConsole(ConsoleColor.Red, task.Result.Error?.GenerateErrorReport());
             }
             else
             {
-                JenkinsConsoleUtility.FancyWriteToConsole("Login successful, PlayFabId: " + task.Result.Result.PlayFabId, null, ConsoleColor.Gray);
+                JenkinsConsoleUtility.FancyWriteToConsole(ConsoleColor.Gray, "Login successful, PlayFabId: " + task.Result.Result.PlayFabId);
             }
             return returnCode;
         }
@@ -101,7 +101,7 @@ namespace JenkinsConsoleUtility.Commands
                     return 1; // The cloudscript call failed
                 Thread.Sleep(TestDataExistsSleepTime);
                 now = DateTime.UtcNow;
-                JenkinsConsoleUtility.FancyWriteToConsole("Test results ready: " + resultsReady, null, ConsoleColor.Gray);
+                JenkinsConsoleUtility.FancyWriteToConsole(ConsoleColor.Gray, "Test results ready: " + resultsReady);
             }
 
             return resultsReady ? 0 : 1;

--- a/JenkinsConsoleUtility/jcuSrc/Commands/CloudScriptListener.cs
+++ b/JenkinsConsoleUtility/jcuSrc/Commands/CloudScriptListener.cs
@@ -52,18 +52,18 @@ namespace JenkinsConsoleUtility.Commands
             verbose = bool.Parse(JenkinsConsoleUtility.GetArgVar(argsLc, "verbose", "false"));
             _getRequest = new CsGetRequest { customId = buildIdentifier };
 
-            JenkinsConsoleUtility.FancyWriteToConsole(ConsoleColor.Gray, "Begin CloudScriptListener");
+            JcuUtil.FancyWriteToConsole(ConsoleColor.Gray, "Begin CloudScriptListener");
             var returnCode = Login(testTitleData.titleId, buildIdentifier, testTitleData);
             if (returnCode != 0)
                 return returnCode;
             returnCode = WaitForTestResult(timeout, testTitleData);
             if (returnCode != 0)
                 return returnCode;
-            JenkinsConsoleUtility.FancyWriteToConsole(ConsoleColor.Gray, "Test data found");
+            JcuUtil.FancyWriteToConsole(ConsoleColor.Gray, "Test data found");
             returnCode = FetchTestResult(buildIdentifier, workspacePath, testTitleData);
             if (returnCode != 0)
                 return returnCode;
-            JenkinsConsoleUtility.FancyWriteToConsole(ConsoleColor.Green, "Test data received");
+            JcuUtil.FancyWriteToConsole(ConsoleColor.Green, "Test data received");
 
             return 0;
         }
@@ -76,12 +76,12 @@ namespace JenkinsConsoleUtility.Commands
             var returnCode = clientApi.IsClientLoggedIn() ? 0 : 1;
             if (returnCode != 0)
             {
-                JenkinsConsoleUtility.FancyWriteToConsole(ConsoleColor.Red, "Failed to log in using CustomID: " + titleId + ", " + buildIdentifier);
-                JenkinsConsoleUtility.FancyWriteToConsole(ConsoleColor.Red, task.Result.Error?.GenerateErrorReport());
+                JcuUtil.FancyWriteToConsole(ConsoleColor.Red, "Failed to log in using CustomID: " + titleId + ", " + buildIdentifier);
+                JcuUtil.FancyWriteToConsole(ConsoleColor.Red, task.Result.Error?.GenerateErrorReport());
             }
             else
             {
-                JenkinsConsoleUtility.FancyWriteToConsole(ConsoleColor.Gray, "Login successful, PlayFabId: " + task.Result.Result.PlayFabId);
+                JcuUtil.FancyWriteToConsole(ConsoleColor.Gray, "Login successful, PlayFabId: " + task.Result.Result.PlayFabId);
             }
             return returnCode;
         }
@@ -103,7 +103,7 @@ namespace JenkinsConsoleUtility.Commands
                     return 1; // The cloudscript call failed
                 Thread.Sleep(TestDataExistsSleepTime);
                 now = DateTime.UtcNow;
-                JenkinsConsoleUtility.FancyWriteToConsole(ConsoleColor.Gray, "Test results ready: " + resultsReady);
+                JcuUtil.FancyWriteToConsole(ConsoleColor.Gray, "Test results ready: " + resultsReady);
             }
 
             return resultsReady ? 0 : 1;

--- a/JenkinsConsoleUtility/jcuSrc/Commands/CloudScriptListener.cs
+++ b/JenkinsConsoleUtility/jcuSrc/Commands/CloudScriptListener.cs
@@ -30,9 +30,9 @@ namespace JenkinsConsoleUtility.Commands
         private const int TestDataExistsSleepTime = 4500;
 
         private static readonly string[] MyCommandKeys = { "ListenCS" };
-        public string[] CommandKeys { get { return MyCommandKeys; } }
+        public string[] CommandKeys => MyCommandKeys;
         private static readonly string[] MyMandatoryArgKeys = { "buildidentifier" };
-        public string[] MandatoryArgKeys { get { return MyMandatoryArgKeys; } }
+        public string[] MandatoryArgKeys => MyMandatoryArgKeys;
 
         public const string CsFuncTestDataExists = "TestDataExists";
         public const string CsFuncGetTestData = "GetTestData";

--- a/JenkinsConsoleUtility/jcuSrc/Commands/GitApiCommand.cs
+++ b/JenkinsConsoleUtility/jcuSrc/Commands/GitApiCommand.cs
@@ -40,12 +40,12 @@ namespace JenkinsConsoleUtility.Commands
                     return 1;
 
                 var sdkRepo = client.Repository.Get(GitOwner, sdkName).Result;
-                JenkinsConsoleUtility.FancyWriteToConsole(sdkRepo.CloneUrl, null, ConsoleColor.Green);
+                JenkinsConsoleUtility.FancyWriteToConsole(ConsoleColor.Green, sdkRepo.CloneUrl);
             }
             catch (AggregateException agEx)
             {
                 foreach (var e in agEx.InnerExceptions)
-                    JenkinsConsoleUtility.FancyWriteToConsole(e.ToString(), null, ConsoleColor.Red);
+                    JenkinsConsoleUtility.FancyWriteToConsole(ConsoleColor.Red, e.ToString());
                 return 1;
             }
 
@@ -76,7 +76,9 @@ namespace JenkinsConsoleUtility.Commands
 
         private class GitHubCredentials
         {
+#pragma warning disable 0649
             public string token;
+#pragma warning restore 0649
         }
 
         private class GitHubReleaseRequest : NewRelease

--- a/JenkinsConsoleUtility/jcuSrc/Commands/GitApiCommand.cs
+++ b/JenkinsConsoleUtility/jcuSrc/Commands/GitApiCommand.cs
@@ -1,8 +1,9 @@
-using Octokit;
-using PlayFab.Json;
 using System;
 using System.Collections.Generic;
 using System.IO;
+using JenkinsConsoleUtility.Util;
+using Octokit;
+using PlayFab.Json;
 
 namespace JenkinsConsoleUtility.Commands
 {
@@ -40,12 +41,12 @@ namespace JenkinsConsoleUtility.Commands
                     return 1;
 
                 var sdkRepo = client.Repository.Get(GitOwner, sdkName).Result;
-                JenkinsConsoleUtility.FancyWriteToConsole(ConsoleColor.Green, sdkRepo.CloneUrl);
+                JcuUtil.FancyWriteToConsole(ConsoleColor.Green, sdkRepo.CloneUrl);
             }
             catch (AggregateException agEx)
             {
                 foreach (var e in agEx.InnerExceptions)
-                    JenkinsConsoleUtility.FancyWriteToConsole(ConsoleColor.Red, e.ToString());
+                    JcuUtil.FancyWriteToConsole(ConsoleColor.Red, e.ToString());
                 return 1;
             }
 

--- a/JenkinsConsoleUtility/jcuSrc/Commands/GitApiCommand.cs
+++ b/JenkinsConsoleUtility/jcuSrc/Commands/GitApiCommand.cs
@@ -13,11 +13,11 @@ namespace JenkinsConsoleUtility.Commands
 
         // TODO: Validate this
         //private readonly Type[] _commandDependency = { typeof(VersionVarWriter) };
-        //public Type[] CommandDependency { get { return _commandDependency; } }
+        //public Type[] CommandDependency => _commandDependency;
         private readonly string[] _commandKeys = { "GitApi" };
-        public string[] CommandKeys { get { return _commandKeys; } }
+        public string[] CommandKeys => _commandKeys;
         private readonly string[] _mandatoryArgKeys = { "sdkName", "GITHUB_CREDENTIALS_FILE" };
-        public string[] MandatoryArgKeys { get { return _mandatoryArgKeys; } }
+        public string[] MandatoryArgKeys => _mandatoryArgKeys;
 
         public int Execute(Dictionary<string, string> argsLc, Dictionary<string, string> argsCased)
         {

--- a/JenkinsConsoleUtility/jcuSrc/Commands/KillTaskCommand.cs
+++ b/JenkinsConsoleUtility/jcuSrc/Commands/KillTaskCommand.cs
@@ -11,9 +11,9 @@ namespace JenkinsConsoleUtility.Commands
         private const int TASK_KILL_SLEEP_MS = 500;
 
         private static readonly string[] MyCommandKeys = { "kill" };
-        public string[] CommandKeys { get { return MyCommandKeys; } }
+        public string[] CommandKeys => MyCommandKeys;
         private static readonly string[] MyMandatoryArgKeys = { "taskName" };
-        public string[] MandatoryArgKeys { get { return MyMandatoryArgKeys; } }
+        public string[] MandatoryArgKeys => MyMandatoryArgKeys;
 
         public int Execute(Dictionary<string, string> argsLc, Dictionary<string, string> argsCased)
         {

--- a/JenkinsConsoleUtility/jcuSrc/Commands/KillTaskCommand.cs
+++ b/JenkinsConsoleUtility/jcuSrc/Commands/KillTaskCommand.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Threading;
+using JenkinsConsoleUtility.Util;
 
 namespace JenkinsConsoleUtility.Commands
 {
@@ -32,7 +33,7 @@ namespace JenkinsConsoleUtility.Commands
                 hitList.AddRange(eachHitList);
                 foreach (var eachProcess in eachHitList)
                 {
-                    JenkinsConsoleUtility.FancyWriteToConsole(ConsoleColor.Yellow, "Closing task: " + eachProcess.ProcessName);
+                    JcuUtil.FancyWriteToConsole(ConsoleColor.Yellow, "Closing task: " + eachProcess.ProcessName);
                     eachProcess.CloseMainWindow(); // Gently close the target so they don't throw error codes 
                 }
             }
@@ -56,12 +57,12 @@ namespace JenkinsConsoleUtility.Commands
             {
                 if (eachProcess.HasExited)
                     continue; // Finished skip it
-                JenkinsConsoleUtility.FancyWriteToConsole(ConsoleColor.Red, "Killing task: " + eachProcess.ProcessName);
+                JcuUtil.FancyWriteToConsole(ConsoleColor.Red, "Killing task: " + eachProcess.ProcessName);
                 eachProcess.Kill(); // If it didn't close gently, then close it better.
             }
 
             if (hitList.Count == 0)
-                JenkinsConsoleUtility.FancyWriteToConsole(ConsoleColor.Red, "No tasks to kill: " + taskNames);
+                JcuUtil.FancyWriteToConsole(ConsoleColor.Red, "No tasks to kill: " + taskNames);
             return hitList.Count > 0 ? 0 : 1;
         }
     }

--- a/JenkinsConsoleUtility/jcuSrc/Commands/KillTaskCommand.cs
+++ b/JenkinsConsoleUtility/jcuSrc/Commands/KillTaskCommand.cs
@@ -32,7 +32,7 @@ namespace JenkinsConsoleUtility.Commands
                 hitList.AddRange(eachHitList);
                 foreach (var eachProcess in eachHitList)
                 {
-                    JenkinsConsoleUtility.FancyWriteToConsole("Closing task: " + eachProcess.ProcessName, null, ConsoleColor.Yellow);
+                    JenkinsConsoleUtility.FancyWriteToConsole(ConsoleColor.Yellow, "Closing task: " + eachProcess.ProcessName);
                     eachProcess.CloseMainWindow(); // Gently close the target so they don't throw error codes 
                 }
             }
@@ -56,12 +56,12 @@ namespace JenkinsConsoleUtility.Commands
             {
                 if (eachProcess.HasExited)
                     continue; // Finished skip it
-                JenkinsConsoleUtility.FancyWriteToConsole("Killing task: " + eachProcess.ProcessName, null, ConsoleColor.Red);
+                JenkinsConsoleUtility.FancyWriteToConsole(ConsoleColor.Red, "Killing task: " + eachProcess.ProcessName);
                 eachProcess.Kill(); // If it didn't close gently, then close it better.
             }
 
             if (hitList.Count == 0)
-                JenkinsConsoleUtility.FancyWriteToConsole("No tasks to kill: " + taskNames, null, ConsoleColor.Red);
+                JenkinsConsoleUtility.FancyWriteToConsole(ConsoleColor.Red, "No tasks to kill: " + taskNames);
             return hitList.Count > 0 ? 0 : 1;
         }
     }

--- a/JenkinsConsoleUtility/jcuSrc/Commands/TestingCommand.cs
+++ b/JenkinsConsoleUtility/jcuSrc/Commands/TestingCommand.cs
@@ -25,7 +25,7 @@ namespace JenkinsConsoleUtility.Commands
             foreach (var eachLine in summaryLines)
             {
                 ConsoleColor color = eachLine.Contains("FAILED") ? ConsoleColor.Red : eachLine.Contains("PASSED") ? ConsoleColor.White : ConsoleColor.Yellow;
-                JenkinsConsoleUtility.FancyWriteToConsole(color, eachLine);
+                JcuUtil.FancyWriteToConsole(color, eachLine);
             }
             Console.WriteLine();
             return UUnitIncrementalTestRunner.AllTestsPassed ? 0 : 1;

--- a/JenkinsConsoleUtility/jcuSrc/Commands/TestingCommand.cs
+++ b/JenkinsConsoleUtility/jcuSrc/Commands/TestingCommand.cs
@@ -1,6 +1,7 @@
 using PlayFab.UUnit;
 using System;
 using System.Collections.Generic;
+using JenkinsConsoleUtility.Util;
 
 namespace JenkinsConsoleUtility.Commands
 {
@@ -13,11 +14,19 @@ namespace JenkinsConsoleUtility.Commands
 
         public int Execute(Dictionary<string, string> argsLc, Dictionary<string, string> argsCased)
         {
-            UUnitIncrementalTestRunner.Start(false, null, null, null);
+            var testTitleData = TestTitleDataLoader.Load(null);
+            UUnitIncrementalTestRunner.Start(false, null, testTitleData, null);
+            // TODO: UUnitIncrementalTestRunner.AddAssembly();
+
             while (!UUnitIncrementalTestRunner.SuiteFinished)
                 UUnitIncrementalTestRunner.Tick();
 
-            Console.WriteLine(UUnitIncrementalTestRunner.Summary);
+            var summaryLines = UUnitIncrementalTestRunner.Summary.Split('\n');
+            foreach (var eachLine in summaryLines)
+            {
+                ConsoleColor color = eachLine.Contains("FAILED") ? ConsoleColor.Red : eachLine.Contains("PASSED") ? ConsoleColor.White : ConsoleColor.Yellow;
+                JenkinsConsoleUtility.FancyWriteToConsole(color, eachLine);
+            }
             Console.WriteLine();
             return UUnitIncrementalTestRunner.AllTestsPassed ? 0 : 1;
         }

--- a/JenkinsConsoleUtility/jcuSrc/Commands/TestingCommand.cs
+++ b/JenkinsConsoleUtility/jcuSrc/Commands/TestingCommand.cs
@@ -8,9 +8,9 @@ namespace JenkinsConsoleUtility.Commands
     public class TestingCommand : ICommand
     {
         private static readonly string[] MyCommandKeys = { "Test", "RunTests" };
-        public string[] CommandKeys { get { return MyCommandKeys; } }
+        public string[] CommandKeys => MyCommandKeys;
         private static readonly string[] MyMandatoryArgKeys = { };
-        public string[] MandatoryArgKeys { get { return MyMandatoryArgKeys; } }
+        public string[] MandatoryArgKeys => MyMandatoryArgKeys;
 
         public int Execute(Dictionary<string, string> argsLc, Dictionary<string, string> argsCased)
         {

--- a/JenkinsConsoleUtility/jcuSrc/Commands/VersionVarWriter.cs
+++ b/JenkinsConsoleUtility/jcuSrc/Commands/VersionVarWriter.cs
@@ -1,8 +1,9 @@
-using PlayFab.Json;
 using System.Collections.Generic;
 using System.IO;
 using System.Net.Http;
 using System.Threading.Tasks;
+using JenkinsConsoleUtility.Util;
+using PlayFab.Json;
 
 namespace JenkinsConsoleUtility.Commands
 {
@@ -41,7 +42,7 @@ namespace JenkinsConsoleUtility.Commands
                 _apiSpecPfUrl = JenkinsConsoleUtility.GetArgVar(argsLc, "apiSpecPfUrl");
             else
             {
-                JenkinsConsoleUtility.FancyWriteToConsole("Api-Spec input not defined.  Please input one of: apiSpecPath, apiSpecGitUrl, apiSpecPfUrl");
+                JcuUtil.FancyWriteToConsole("Api-Spec input not defined.  Please input one of: apiSpecPath, apiSpecGitUrl, apiSpecPfUrl");
                 return 1;
             }
 
@@ -49,8 +50,8 @@ namespace JenkinsConsoleUtility.Commands
             var sdkNotes = JsonWrapper.DeserializeObject<SdkManualNotes>(versionJson);
             if (!sdkNotes.sdkVersion.TryGetValue(sdkGenKey, out sdkVersionString))
             {
-                JenkinsConsoleUtility.FancyWriteToConsole("SdkManualNotes.json does not contain: " + sdkGenKey);
-                JenkinsConsoleUtility.FancyWriteToConsole("SdkManualNotes.json:\n" + versionJson);
+                JcuUtil.FancyWriteToConsole("SdkManualNotes.json does not contain: " + sdkGenKey);
+                JcuUtil.FancyWriteToConsole("SdkManualNotes.json:\n" + versionJson);
                 return 1;
             }
 
@@ -65,8 +66,8 @@ namespace JenkinsConsoleUtility.Commands
                 {
                     outputFile.WriteLine("sdkVersion = " + sdkVersionString);
                     outputFile.WriteLine("sdkDate = " + date);
-                    JenkinsConsoleUtility.FancyWriteToConsole("sdkVersion = " + sdkVersionString);
-                    JenkinsConsoleUtility.FancyWriteToConsole("sdkDate = " + date);
+                    JcuUtil.FancyWriteToConsole("sdkVersion = " + sdkVersionString);
+                    JcuUtil.FancyWriteToConsole("sdkDate = " + date);
                 }
             }
             return 0;

--- a/JenkinsConsoleUtility/jcuSrc/Commands/VersionVarWriter.cs
+++ b/JenkinsConsoleUtility/jcuSrc/Commands/VersionVarWriter.cs
@@ -184,9 +184,11 @@ namespace JenkinsConsoleUtility.Commands
         /// </summary>
         private class SdkManualNotes
         {
+#pragma warning disable 0649
             public string description;
             public Dictionary<string, string> sdkVersion;
             public Dictionary<string, string> links;
+#pragma warning restore 0649
         }
     }
 }

--- a/JenkinsConsoleUtility/jcuSrc/Commands/VersionVarWriter.cs
+++ b/JenkinsConsoleUtility/jcuSrc/Commands/VersionVarWriter.cs
@@ -14,9 +14,9 @@ namespace JenkinsConsoleUtility.Commands
         private string _apiSpecPath, _apiSpecGitUrl, _apiSpecPfUrl; // Exactly one of these is expected to be set
 
         private static readonly string[] MyCommandKeys = { "versionVarWriter", "version" };
-        public string[] CommandKeys { get { return MyCommandKeys; } }
+        public string[] CommandKeys => MyCommandKeys;
         private static readonly string[] MyMandatoryArgKeys = { "sdkName" };
-        public string[] MandatoryArgKeys { get { return MyMandatoryArgKeys; } }
+        public string[] MandatoryArgKeys => MyMandatoryArgKeys;
 
         // If this command runs, make the results accessible to other modules
         public static string sdkVersionString;

--- a/JenkinsConsoleUtility/jcuSrc/JUnitXml.cs
+++ b/JenkinsConsoleUtility/jcuSrc/JUnitXml.cs
@@ -1,11 +1,12 @@
-using PlayFab;
-using PlayFab.UUnit;
 using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Text;
 using System.Web;
 using System.Xml;
+using JenkinsConsoleUtility.Util;
+using PlayFab;
+using PlayFab.UUnit;
 
 namespace JenkinsConsoleUtility
 {
@@ -175,7 +176,7 @@ namespace JenkinsConsoleUtility
                 tabbing = tabbing.Substring(2);
                 sb.Append(tabbing).Append("</testsuites>\n");
 
-                JenkinsConsoleUtility.FancyWriteToConsole(ConsoleColor.Gray, "Write test results: " + destinationFile);
+                JcuUtil.FancyWriteToConsole(ConsoleColor.Gray, "Write test results: " + destinationFile);
                 using (var output = File.Open(destinationFile, FileMode.Create))
                 {
                     byte[] buffer = Encoding.UTF8.GetBytes(sb.ToString());
@@ -185,7 +186,7 @@ namespace JenkinsConsoleUtility
             }
             catch (Exception e)
             {
-                JenkinsConsoleUtility.FancyWriteToConsole(ConsoleColor.Red, "Failure writing xml:\n" + e);
+                JcuUtil.FancyWriteToConsole(ConsoleColor.Red, "Failure writing xml:\n" + e);
                 return 1; // Fail
             }
             return 0; // Success

--- a/JenkinsConsoleUtility/jcuSrc/JUnitXml.cs
+++ b/JenkinsConsoleUtility/jcuSrc/JUnitXml.cs
@@ -175,7 +175,7 @@ namespace JenkinsConsoleUtility
                 tabbing = tabbing.Substring(2);
                 sb.Append(tabbing).Append("</testsuites>\n");
 
-                JenkinsConsoleUtility.FancyWriteToConsole("Write test results: " + destinationFile, null, ConsoleColor.Gray);
+                JenkinsConsoleUtility.FancyWriteToConsole(ConsoleColor.Gray, "Write test results: " + destinationFile);
                 using (var output = File.Open(destinationFile, FileMode.Create))
                 {
                     byte[] buffer = Encoding.UTF8.GetBytes(sb.ToString());
@@ -185,7 +185,7 @@ namespace JenkinsConsoleUtility
             }
             catch (Exception e)
             {
-                JenkinsConsoleUtility.FancyWriteToConsole("Failure writing xml:\n" + e, null, ConsoleColor.Red);
+                JenkinsConsoleUtility.FancyWriteToConsole(ConsoleColor.Red, "Failure writing xml:\n" + e);
                 return 1; // Fail
             }
             return 0; // Success

--- a/JenkinsConsoleUtility/jcuSrc/JenkinsConsoleUtility.cs
+++ b/JenkinsConsoleUtility/jcuSrc/JenkinsConsoleUtility.cs
@@ -1,6 +1,6 @@
 using System;
-using System.Collections;
 using System.Collections.Generic;
+using JenkinsConsoleUtility.Util;
 
 public interface ICommand
 {
@@ -30,20 +30,20 @@ namespace JenkinsConsoleUtility
                     if (!commandLookup.TryGetValue(key, out tempCommand))
                     {
                         success = false;
-                        FancyWriteToConsole(ConsoleColor.Red, "Unexpected command: " + key);
+                        JcuUtil.FancyWriteToConsole(ConsoleColor.Red, "Unexpected command: " + key);
                     }
                 }
 
                 if (orderedCommands.Count == 0)
-                    FancyWriteToConsole(ConsoleColor.DarkYellow, "No commands given, no work will be done");
+                    JcuUtil.FancyWriteToConsole(ConsoleColor.DarkYellow, "No commands given, no work will be done");
                 if (!success || orderedCommands.Count == 0)
                     throw new Exception("Commands not input correctly");
             }
             catch (Exception)
             {
-                FancyWriteToConsole(ConsoleColor.Yellow, "Run a sequence of ordered commands --<command> [--<command> ...] [-<argKey> <argValue> ...]\nValid commands:", ConsoleColor.Gray, commandLookup.Keys);
-                FancyWriteToConsole(ConsoleColor.Yellow, "argValues can have spaces.  Dashes in argValues can cause problems, and are not recommended.");
-                FancyWriteToConsole(ConsoleColor.Yellow, "Quotes are considered part of the argKey or argValue, and are not parsed as tokens.");
+                JcuUtil.FancyWriteToConsole(ConsoleColor.Yellow, "Run a sequence of ordered commands --<command> [--<command> ...] [-<argKey> <argValue> ...]\nValid commands:", ConsoleColor.Gray, commandLookup.Keys);
+                JcuUtil.FancyWriteToConsole(ConsoleColor.Yellow, "argValues can have spaces.  Dashes in argValues can cause problems, and are not recommended.");
+                JcuUtil.FancyWriteToConsole(ConsoleColor.Yellow, "Quotes are considered part of the argKey or argValue, and are not parsed as tokens.");
                 // TODO: Report list of available commands and valid/required args for commands
                 return Pause(1);
             }
@@ -59,7 +59,7 @@ namespace JenkinsConsoleUtility
                 }
                 if (returnCode != 0)
                 {
-                    FancyWriteToConsole(ConsoleColor.Yellow, key + " command returned error code: " + returnCode);
+                    JcuUtil.FancyWriteToConsole(ConsoleColor.Yellow, key + " command returned error code: " + returnCode);
                     return Pause(returnCode);
                 }
             }
@@ -82,12 +82,12 @@ namespace JenkinsConsoleUtility
 
             if (getDefault != null) // Don't use string.IsNullOrEmpty() here, because there's a distinction between "undefined" and "empty"
             {
-                FancyWriteToConsole(ConsoleColor.DarkYellow, "GetArgVar: " + key + " not defined, reverting to: " + getDefault);
+                JcuUtil.FancyWriteToConsole(ConsoleColor.DarkYellow, "GetArgVar: " + key + " not defined, reverting to: " + getDefault);
                 return getDefault;
             }
 
             var msg = "ERROR: Required parameter: " + key + " not found";
-            FancyWriteToConsole(ConsoleColor.Red, msg);
+            JcuUtil.FancyWriteToConsole(ConsoleColor.Red, msg);
             throw new Exception(msg);
         }
 
@@ -144,31 +144,13 @@ namespace JenkinsConsoleUtility
             }
 
             foreach (var eachCmdKey in missingArgKeys)
-                FancyWriteToConsole(ConsoleColor.Yellow, cmd.CommandKeys[0] + " - Missing argument: " + eachCmdKey);
+                JcuUtil.FancyWriteToConsole(ConsoleColor.Yellow, cmd.CommandKeys[0] + " - Missing argument: " + eachCmdKey);
             return missingArgKeys.Count;
-        }
-
-        public static void FancyWriteToConsole(params object[] lines)
-        {
-            Console.ForegroundColor = ConsoleColor.White;
-            foreach (var each in lines)
-            {
-                if (each is ConsoleColor)
-                    Console.ForegroundColor = (ConsoleColor)each;
-                else if (each is string)
-                    Console.WriteLine(each);
-                else if (each is IEnumerable)
-                    foreach (var intEach in (IEnumerable)each)
-                        FancyWriteToConsole(intEach);
-                else
-                    Console.WriteLine(each);
-            }
-            Console.ForegroundColor = ConsoleColor.White;
         }
 
         private static int Pause(int code)
         {
-            FancyWriteToConsole(code == 0 ? ConsoleColor.Green : ConsoleColor.DarkRed, "Done! Press any key to close");
+            JcuUtil.FancyWriteToConsole(code == 0 ? ConsoleColor.Green : ConsoleColor.DarkRed, "Done! Press any key to close");
             try
             {
                 Console.ReadKey();

--- a/JenkinsConsoleUtility/jcuSrc/JenkinsConsoleUtility.cs
+++ b/JenkinsConsoleUtility/jcuSrc/JenkinsConsoleUtility.cs
@@ -76,8 +76,7 @@ namespace JenkinsConsoleUtility
         /// <returns>The string associated with this key</returns>
         public static string GetArgVar(Dictionary<string, string> args, string key, string getDefault = null)
         {
-            string output;
-            if (TryGetArgVar(out output, args, key, getDefault))
+            if (TryGetArgVar(out string output, args, key, getDefault))
                 return output;
 
             if (getDefault != null) // Don't use string.IsNullOrEmpty() here, because there's a distinction between "undefined" and "empty"

--- a/JenkinsConsoleUtility/jcuSrc/Util/TestTitleDataLoader.cs
+++ b/JenkinsConsoleUtility/jcuSrc/Util/TestTitleDataLoader.cs
@@ -1,8 +1,8 @@
-using PlayFab.Json;
-using PlayFab.UUnit;
 using System;
 using System.Collections.Generic;
 using System.IO;
+using PlayFab.Json;
+using PlayFab.UUnit;
 
 namespace JenkinsConsoleUtility.Util
 {
@@ -42,7 +42,7 @@ namespace JenkinsConsoleUtility.Util
             if (string.IsNullOrEmpty(eachFilepath))
                 return;
             if (!File.Exists(eachFilepath))
-                eachFilepath = eachFilepath.Replace("%WORKSPACE%", workspacePath);
+                eachFilepath = eachFilepath.Replace("%workspace%", workspacePath);
             if (File.Exists(eachFilepath))
                 validFilepaths.Add(eachFilepath);
         }

--- a/JenkinsConsoleUtility/jcuSrc/Util/Util.cs
+++ b/JenkinsConsoleUtility/jcuSrc/Util/Util.cs
@@ -1,0 +1,36 @@
+﻿using System;
+using System.Collections;
+
+namespace JenkinsConsoleUtility.Util
+{
+    public static class JcuUtil
+    {
+        public static void FancyWriteToConsole(params object[] lines)
+        {
+            Console.ForegroundColor = ConsoleColor.White;
+            _FancyWriteToConsole(lines);
+            Console.ForegroundColor = ConsoleColor.White;
+        }
+
+        private static void _FancyWriteToConsole(params object[] lines)
+        {
+            if (lines == null)
+            {
+                Console.Write("\n");
+                return;
+            }
+            foreach (var each in lines)
+            {
+                if (each is ConsoleColor)
+                    Console.ForegroundColor = (ConsoleColor)each;
+                else if (each is string)
+                    Console.WriteLine(each);
+                else if (each is IEnumerable)
+                    foreach (var intEach in (IEnumerable)each)
+                        _FancyWriteToConsole(intEach);
+                else
+                    Console.WriteLine(each);
+            }
+        }
+    }
+}

--- a/JenkinsConsoleUtility/packages.config
+++ b/JenkinsConsoleUtility/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Octokit" version="0.32.0" targetFramework="net45" />
-  <package id="PlayFabAllSDK" version="1.38.181001" targetFramework="net45" />
+  <package id="PlayFabAllSDK" version="1.57.190903" targetFramework="net45" />
 </packages>


### PR DESCRIPTION
NOTE: Code in public repo!

Reviewers:
You're mostly looking at the new file: CheckBblStandby.cs

That verifies that the regions look good for the version numbers that are important.
It takes a lot of configurable inputs:
PF_TEST_TITLE_DATA_JSON = path
BBL_VERSIONS = semicolon-separated-strings
GAP_MAX_THRESHOLDS = 6-semicolon-separated-ints
STANDBY_MIN_THRESHOLDS = 6-semicolon-separated-ints
MAX_CAPACITY_PERCENT_THRESHOLDS = 6-semicolon-separated-ints
CYCLE_DURATION_MINS = float
CYCLE_PERIOD_SEC = float
RETRY_DELAY_SEC = float
RETRY_COUNT = int

Example Output:

Found Version: 2.0.1,  BuildId: 73...f6
    - AustraliaSoutheast, (sby:480/max:30000)(sby:480/prp:0/act:24/max:30000)
    - AustraliaEast, (sby:480/max:30000)(sby:480/prp:0/act:69/max:30000)
    - WestUs, (sby:480/max:23000)(sby:293/prp:12/act:2670/max:23000)
SEV_5 2.0.1, 73...f6 - High "StandBy + Propping" Gap (175) in region:WestUs
    - BrazilSouth, (sby:480/max:30000)(sby:432/prp:24/act:509/max:30000)
    - CentralUs, (sby:480/max:30000)(sby:424/prp:12/act:416/max:30000)
    - EastAsia, (sby:480/max:30000)(sby:484/prp:0/act:14/max:30000)
    - EastUs, (sby:480/max:30000)(sby:224/prp:36/act:3487/max:30000)
SEV_4 2.0.1, 73...f6 - High "StandBy + Propping" Gap (220) in region:EastUs
    - EastUs2, (sby:480/max:30000)(sby:401/prp:0/act:958/max:30000)
    - JapanEast, (sby:480/max:30000)(sby:476/prp:0/act:23/max:30000)
    - JapanWest, (sby:480/max:30000)(sby:480/prp:0/act:9/max:30000)
    - NorthCentralUs, (sby:480/max:30000)(sby:301/prp:60/act:2330/max:30000)
SEV_5 2.0.1, 73...f6 - High "StandBy + Propping" Gap (119) in region:NorthCentralUs
    - NorthEurope, (sby:480/max:30000)(sby:471/prp:0/act:2775/max:30000)
    - SouthCentralUs, (sby:480/max:23000)(sby:186/prp:48/act:3441/max:23000)
SEV_4 2.0.1, 73...f6 - High "StandBy + Propping" Gap (246) in region:SouthCentralUs
    - SoutheastAsia, (sby:480/max:30000)(sby:482/prp:0/act:18/max:30000)
    - WestEurope, (sby:480/max:25000)(sby:561/prp:0/act:2857/max:25000)

Found Version: 3.0.0,  BuildId: 1a...fc
    - EastUs, (sby:36/max:1000)(sby:36/prp:0/act:0/max:1000)
    - AustraliaEast, (sby:12/max:3000)(sby:12/prp:0/act:0/max:3000)
    - AustraliaSoutheast, (sby:12/max:1500)(sby:12/prp:0/act:0/max:1500)
    - CentralUs, (sby:12/max:1500)(sby:12/prp:0/act:0/max:1500)
    - EastAsia, (sby:12/max:1000)(sby:12/prp:0/act:0/max:1000)
    - EastUs2, (sby:36/max:1000)(sby:36/prp:0/act:0/max:1000)
    - JapanEast, (sby:12/max:1500)(sby:12/prp:0/act:0/max:1500)
    - JapanWest, (sby:12/max:1500)(sby:12/prp:0/act:0/max:1500)
    - NorthEurope, (sby:36/max:3600)(sby:36/prp:0/act:0/max:3600)
    - SoutheastAsia, (sby:12/max:1500)(sby:12/prp:0/act:0/max:1500)
    - WestEurope, (sby:12/max:9600)(sby:12/prp:0/act:0/max:9600)
    - WestUs, (sby:36/max:10800)(sby:47/prp:0/act:1/max:10800)
    - NorthCentralUs, (sby:12/max:4200)(sby:12/prp:0/act:0/max:4200)
    - SouthCentralUs, (sby:12/max:10200)(sby:26/prp:0/act:22/max:10200)
    - BrazilSouth, (sby:12/max:1800)(sby:12/prp:0/act:0/max:1800)

Thunderhead alert list:

2.0.1, 73...f6 - High "StandBy + Propping" Gap (220) in region:EastUs
2.0.1, 73...f6 - High "StandBy + Propping" Gap (246) in region:SouthCentralUs

Finished Query Cycle
NONE  <- Worst Bumblelion Error Level
SEV_4  <- Worst Thunderhead Error Level
NONE  <- Typical Error Level. Total Number of Alerts: 11
Done! Press any key to close
