### PR TITLE
Update PlayFabSettings.cs.ejs

### DIFF
--- a/targets/unity-v2/source/Shared/Public/PlayFabSettings.cs.ejs
+++ b/targets/unity-v2/source/Shared/Public/PlayFabSettings.cs.ejs
@@ -51,7 +51,8 @@ namespace PlayFab
             var settingsList = Resources.LoadAll<PlayFabSharedSettings>("PlayFabSharedSettings");
             if (settingsList.Length != 1)
             {
-                throw new Exception("The number of PlayFabSharedSettings objects should be 1: " + settingsList.Length);
+                Debug.LogWarning("The number of PlayFabSharedSettings objects should be 1: " + settingsList.Length);
+                Debug.LogWarning("If you are upgrading your SDK, you can ignore this warning as PlayFabSharedSettings will be imported soon. If you are not upgrading your SDK and you see this message, you should re-download the latest PlayFab source code.");
             }
             return settingsList[0];
         }


### PR DESCRIPTION
Before we would throw an exception. This was not necessary as we shouldn't expect the PlayFabSharedSettings object to be there when we are deleting the previous Sdk, and we will be getting one soon after we import the updated sdk (after this error triggers).