### PR TITLE
Update PluginManager.cs

### DIFF
--- a/targets/unity-v2/source/Shared/Public/PluginManager.cs
+++ b/targets/unity-v2/source/Shared/Public/PluginManager.cs
@@ -80,7 +80,7 @@ namespace PlayFab
 
         private IPlayFabPlugin CreatePlugin<T>() where T : IPlayFabPlugin, new()
         {
-            return (IPlayFabPlugin)Activator.CreateInstance(typeof(T));
+            return (IPlayFabPlugin)System.Activator.CreateInstance(typeof(T));
         }
 
         private ITransportPlugin CreatePlayFabTransportPlugin()


### PR DESCRIPTION
prefixing System to Activator. Apparently someone may have made their own type of Activator and it screws up our package.