### PR TITLE
Fulfilling customer request for ToString return information about errorDetails

### DIFF
--- a/targets/unity-v2/source/Shared/Editor/PlayFablogo.png.meta
+++ b/targets/unity-v2/source/Shared/Editor/PlayFablogo.png.meta
@@ -1,33 +1,42 @@
 fileFormatVersion: 2
 guid: ec8f5065b10fb4f04bebf82a992c442e
 TextureImporter:
-  fileIDToRecycleName: {}
-  serializedVersion: 2
+  internalIDToNameTable: []
+  externalObjects: {}
+  serializedVersion: 10
   mipmaps:
     mipMapMode: 0
     enableMipMap: 1
+    sRGBTexture: 1
     linearTexture: 0
-    correctGamma: 0
     fadeOut: 0
     borderMipMap: 0
+    mipMapsPreserveCoverage: 0
+    alphaTestReferenceValue: 0.5
     mipMapFadeDistanceStart: 1
     mipMapFadeDistanceEnd: 3
   bumpmap:
     convertToNormalMap: 0
     externalNormalMap: 0
-    heightScale: .25
+    heightScale: 0.25
     normalMapFilter: 0
   isReadable: 0
+  streamingMipmaps: 0
+  streamingMipmapsPriority: 0
   grayScaleToAlpha: 0
-  generateCubemap: 0
+  generateCubemap: 6
+  cubemapConvolution: 0
   seamlessCubemap: 0
   textureFormat: -1
   maxTextureSize: 1024
   textureSettings:
+    serializedVersion: 2
     filterMode: -1
     aniso: 16
-    mipBias: -1
-    wrapMode: -1
+    mipBias: -100
+    wrapU: -1
+    wrapV: -1
+    wrapW: -1
   nPOTScale: 0
   lightmap: 0
   compressionQuality: 50
@@ -35,13 +44,48 @@ TextureImporter:
   spriteExtrude: 1
   spriteMeshType: 1
   alignment: 0
-  spritePivot: {x: .5, y: .5}
-  spriteBorder: {x: 0, y: 0, z: 0, w: 0}
+  spritePivot: {x: 0.5, y: 0.5}
   spritePixelsToUnits: 100
+  spriteBorder: {x: 0, y: 0, z: 0, w: 0}
+  spriteGenerateFallbackPhysicsShape: 1
+  alphaUsage: 1
   alphaIsTransparency: 1
+  spriteTessellationDetail: -1
   textureType: 8
-  buildTargetSettings: []
+  textureShape: 1
+  singleChannelComponent: 0
+  maxTextureSizeSet: 0
+  compressionQualitySet: 0
+  textureFormatSet: 0
+  platformSettings:
+  - serializedVersion: 3
+    buildTarget: DefaultTexturePlatform
+    maxTextureSize: 1024
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 1
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+    androidETC2FallbackOverride: 0
+    forceMaximumCompressionQuality_BC6H_BC7: 0
   spriteSheet:
+    serializedVersion: 2
     sprites: []
+    outline: []
+    physicsShape: []
+    bones: []
+    spriteID: 5e97eb03825dee720800000000000000
+    internalID: 0
+    vertices: []
+    indices: 
+    edges: []
+    weights: []
+    secondaryTextures: []
   spritePackingTag: 
+  pSDRemoveMatte: 0
+  pSDShowRemoveMatteOption: 0
   userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/targets/unity-v2/source/Shared/Internal/PlayFabErrors.cs.ejs
+++ b/targets/unity-v2/source/Shared/Internal/PlayFabErrors.cs.ejs
@@ -23,25 +23,17 @@ namespace PlayFab
         public string HttpStatus;
         public PlayFabErrorCode Error;
         public string ErrorMessage;
-        public Dictionary<string, List<string> > ErrorDetails;
+        public Dictionary<string, List<string>> ErrorDetails;
         public object CustomData;
 
-        public override string ToString() {
-            var sb = new System.Text.StringBuilder();
-            if (ErrorDetails != null) {
-                foreach (var kv in ErrorDetails) {
-                    sb.Append(kv.Key);
-                    sb.Append(": ");
-                    sb.Append(string.Join(", ", kv.Value.ToArray()));
-                    sb.Append(" | ");
-                }
-            }
-            return string.Format("{0} PlayFabError({1}, {2}, {3} {4}", ApiEndpoint, Error, ErrorMessage, HttpCode, HttpStatus) + (sb.Length > 0 ? " - Details: " + sb.ToString() + ")" : ")");
+        public override string ToString()
+        {
+            return GenerateErrorReport();
         }
 
         [ThreadStatic]
         private static StringBuilder _tempSb;
-         /// <summary>
+        /// <summary>
         /// This converts the PlayFabError into a human readable string describing the error.
         /// If error is not found, it will return the http code, status, and error
         /// </summary>


### PR DESCRIPTION
GenerateErrorReport returns all information about the error.
ToString was providing a streamlined set of information, but that was confusing to customers, so now ToString just calls GetErrorReport.
Ancillary changes:
Separating GetServerTime from UserDataApi, so that each test is distinct and less complicated
Fixing a few typos and misspellings.