### PR TITLE
Stop client-side JS library crash for games using Phaser 3

### DIFF
--- a/targets/javascript/templates/PlayFab_Api.js.ejs
+++ b/targets/javascript/templates/PlayFab_Api.js.ejs
@@ -285,7 +285,7 @@ PlayFab.<%- api.name %>Api = {
 var PlayFab<%- api.name %>SDK = PlayFab.<%- api.name %>Api;
 <% if (hasClientOptions) { %>
 PlayFab.RegisterWithPhaser = function() {
-    if ( typeof Phaser === "undefined" )
+    if ( typeof Phaser === "undefined" || typeof Phaser.Plugin === "undefined" )
         return;
 
     Phaser.Plugin.PlayFab = function (game, parent) {


### PR DESCRIPTION
Hi!

The PlayFab client-side JS library has some special code that detects if a game is using [PhaserJS](https://phaser.io) and automatically injects itself using Phaser's module system if so.

This code presumably works great with Phaser 2. However, Phaser 3 is a ground-up rewrite that, among other things, breaks compatibility with the plugin API. As a result, `Phaser.Plugin` does not exist, and as such trying to load the JS PlayFab library with a Phaser 3 game results in an error that stops PlayFab from properly initializing. To work around this, my Phaser 3 game [Flappy Royale](https://github.com/flappy-royale/flappy-royale) just pulls in the server-side node module to use in the client — this works fine, but naturally isn't an ideal long-term solution.

This small PR just makes it so that the client JS library doesn't attempt to register with Phaser if the Phaser 2 plugin system isn't present. Future improvements could include adding proper support for the Phaser 3 plugin system, but for now this at least means devs can use the `playfab-web-sdk` library alongside games that use Phaser 3.

(I didn't touch any tests, but it doesn't obviously look like there was anything touching the Phaser integration? Happy to go back and backfill tests if you think there's value)

Thanks so much!