### PR TITLE
Delete .npmignore

### DIFF
--- a/targets/js-node/source/.npmignore
+++ b/targets/js-node/source/.npmignore
@@ -1,2 +1,0 @@
-/node_modules/
-.npmignore


### PR DESCRIPTION
We already ignore node_modules in the .gitignore file. Also having the npmignore file will stomp on the gitignore file (so we have been exposing a lot of files we didn't want exposed).