### PR TITLE
Throw Error objects intsead of strings

### DIFF
--- a/targets/js-node/source/Scripts/PlayFab/playfab.js.ejs
+++ b/targets/js-node/source/Scripts/PlayFab/playfab.js.ejs
@@ -71,7 +71,7 @@ exports.MakeRequest = function (urlStr, request, authType, authValue, callback) 
 
     var options = url.parse(completeUrl);
     if (options.protocol !== "https:")
-        throw "Unsupported protocol: " + options.protocol;
+        throw new Error("Unsupported protocol: " + options.protocol);
     options.method = "POST";
     options.port = options.port || exports.settings.port;
     options.headers = {

--- a/targets/js-node/source/test/test.ts.ejs
+++ b/targets/js-node/source/test/test.ts.ejs
@@ -95,7 +95,7 @@ exports.PlayFabApiTests = {
 
         var filename = process.env.PF_TEST_TITLE_DATA_JSON; // Set the PF_TEST_TITLE_DATA_JSON env-var to the path of a testTitleData.json file (described here: https://github.com/PlayFab/SDKGenerator/blob/master/JenkinsConsoleUtility/testTitleData.md)
         if (!filename)
-            throw "testTitleData.json file location not defined.";
+            throw new Error("testTitleData.json file location not defined.");
         var prefix = "testTitleData=";
         for (var arg in process.argv)
             if (arg.toLowerCase().indexOf(prefix) === 0)


### PR DESCRIPTION
users aren't happy that we only throw our errors as strings, which will skip over any of their callbacks that expect a Node error.