### PR TITLE
Toddbell/as fix

### DIFF
--- a/targets/actionscript/make.js
+++ b/targets/actionscript/make.js
@@ -163,7 +163,7 @@ function getModelPropertyDef(property, datatype) {
     } else {
         if (property.optional && (basicType === "Boolean" || basicType === "int" || basicType === "uint" || basicType === "Number"))
             basicType = "*";
-        if (property.isclass) {
+        if (property.isclass && basicType === "TreatmentAssignment") {
             return property.name + ":" + getValidPlayFabActionScriptNamespacePrefix(datatype) + basicType;
         }
         else
@@ -217,7 +217,13 @@ function getModelPropertyInit(tabbing, property, datatype) {
             else
                 throw "Unknown collection type: " + property.collection + " for " + property.name + " in " + datatype.name;
         } else {
-            return tabbing + property.name + " = new " + getValidPlayFabActionScriptNamespacePrefix(datatype) + property.actualtype + "(data." + property.name + ");";
+            if (property.actualtype === "TreatmentAssignment") {
+                return tabbing + property.name + " = new " + getValidPlayFabActionScriptNamespacePrefix(datatype) + property.actualtype + "(data." + property.name + ");";
+            }
+            else {
+
+                return tabbing + property.name + " = new " + property.actualtype + "(data." + property.name + ");";
+            }
         }
     } else if (property.collection) {
         if (property.collection === "array") {

--- a/targets/actionscript/make.js
+++ b/targets/actionscript/make.js
@@ -123,7 +123,7 @@ function getVerticalNameDefault() {
     return "null";
 }
 
-function getValidActionscriptModelPath(datatype, basicType) {
+function getValidPlayFabActionScriptNamespacePrefix(datatype) {
 
     var asIndividualNamespaces = datatype.classNameSpace.split('.');
 
@@ -146,7 +146,6 @@ function getValidActionscriptModelPath(datatype, basicType) {
 
     // Current use expects this before the datatype name
     asNamespace += ".";
-    asNamespace += basicType;
 
     return asNamespace;
 }
@@ -164,7 +163,7 @@ function getModelPropertyDef(property, datatype) {
     } else {
         if (property.optional && (basicType === "Boolean" || basicType === "int" || basicType === "uint" || basicType === "Number"))
             basicType = "*";
-        return property.name + ":" + getValidActionscriptModelPath(datatype, basicType);
+        return property.name + ":" + getValidPlayFabActionScriptNamespacePrefix(datatype) + basicType;
     }
 }
 
@@ -212,7 +211,7 @@ function getModelPropertyInit(tabbing, property, datatype) {
             else
                 throw "Unknown collection type: " + property.collection + " for " + property.name + " in " + datatype.name;
         } else {
-            return tabbing + property.name + " = new " + getValidActionscriptModelPath(datatype, property.actualtype) + "(data." + property.name + ");";
+            return tabbing + property.name + " = new " + getValidPlayFabActionScriptNamespacePrefix(datatype) + property.actualtype + "(data." + property.name + ");";
         }
     } else if (property.collection) {
         if (property.collection === "array") {

--- a/targets/actionscript/make.js
+++ b/targets/actionscript/make.js
@@ -135,7 +135,12 @@ function getValidPlayFabActionScriptNamespacePrefix(datatype) {
     }
 
     for (var i = 0; i < asIndividualNamespaces.length; i++) {
-        asNamespace += asIndividualNamespaces[i].toLowerCase();
+        if (i < 1) {
+            asNamespace += asIndividualNamespaces[i].toLowerCase();
+        }
+        else {
+            asNamespace += asIndividualNamespaces[i];
+        }
 
         // we expect the input to be playfab.[SDK].[Name]
         // but the actual datatype-callable prefix namespace in ActionScript is com.playfab.[SDK][Name].

--- a/targets/actionscript/make.js
+++ b/targets/actionscript/make.js
@@ -175,9 +175,7 @@ function getModelPropertyDef(property, datatype) {
     } else {
         if (property.optional && (basicType === "Boolean" || basicType === "int" || basicType === "uint" || basicType === "Number"))
             basicType = "*";
-        if (property.isclass) {
-            return property.name + ":" + getValidPlayFabActionScriptNamespacePrefix(datatype, basicType) + basicType;
-        }
+        return property.name + ":" + getValidPlayFabActionScriptNamespacePrefix(datatype, basicType);
     }
 }
 

--- a/targets/actionscript/make.js
+++ b/targets/actionscript/make.js
@@ -155,6 +155,23 @@ function getValidPlayFabActionScriptNamespacePrefix(datatype) {
     return asNamespace;
 }
 
+function fullNamespaceRequired(propName)
+{
+    // NOTE: As of PlayFab version 191029, some objects are not properly getting recognized by ActionScript
+    // Due to the language getting deprecated within a year, we are going to add any breaking objects to this list
+    // and add the full namespace to any new object that breaks actionscript comiplation here.
+    var typesThatNeedFullNamespace = [ "TreatmentAssignment" ];
+
+    for(var i = 0; i < typesThatNeedFullNamespace.length; i++)
+    {
+        if (propName === typesThatNeedFullNamespace[i])
+        {
+            return true;
+        }
+    }
+    return false;
+}
+
 function getModelPropertyDef(property, datatype) {
     var basicType = getPropertyAsType(property, datatype);
 
@@ -168,7 +185,7 @@ function getModelPropertyDef(property, datatype) {
     } else {
         if (property.optional && (basicType === "Boolean" || basicType === "int" || basicType === "uint" || basicType === "Number"))
             basicType = "*";
-        if (property.isclass && basicType === "TreatmentAssignment") {
+        if (property.isclass && fullNamespaceRequired(basicType)) {
             return property.name + ":" + getValidPlayFabActionScriptNamespacePrefix(datatype) + basicType;
         }
         else
@@ -222,7 +239,7 @@ function getModelPropertyInit(tabbing, property, datatype) {
             else
                 throw "Unknown collection type: " + property.collection + " for " + property.name + " in " + datatype.name;
         } else {
-            if (property.actualtype === "TreatmentAssignment") {
+            if (fullNamespaceRequired(property.actualtype)) {
                 return tabbing + property.name + " = new " + getValidPlayFabActionScriptNamespacePrefix(datatype) + property.actualtype + "(data." + property.name + ");";
             }
             else {

--- a/targets/actionscript/make.js
+++ b/targets/actionscript/make.js
@@ -123,6 +123,34 @@ function getVerticalNameDefault() {
     return "null";
 }
 
+function getValidActionscriptModelPath(datatype, basicType) {
+
+    var asIndividualNamespaces = datatype.classNameSpace.split('.');
+
+    var asNamespace = "com.";
+
+    if (asIndividualNamespaces.length < 2)
+    {
+        throw new Error("Error in Generating API Model: Namespaces are expected to be in the form playfab.[SDK].[Name]");
+    }
+
+    for (var i = 0; i < asIndividualNamespaces.length; i++) {
+        asNamespace += asIndividualNamespaces[i].toLowerCase();
+
+        // we expect the input to be playfab.[SDK].[Name]
+        // but the actual datatype-callable prefix namespace in ActionScript is com.playfab.[SDK][Name].
+        if (i < asIndividualNamespaces.length - 2) {
+            asNamespace += ".";
+        }
+    }
+
+    // Current use expects this before the datatype name
+    asNamespace += ".";
+    asNamespace += basicType;
+
+    return asNamespace;
+}
+
 function getModelPropertyDef(property, datatype) {
     var basicType = getPropertyAsType(property, datatype);
 
@@ -136,7 +164,7 @@ function getModelPropertyDef(property, datatype) {
     } else {
         if (property.optional && (basicType === "Boolean" || basicType === "int" || basicType === "uint" || basicType === "Number"))
             basicType = "*";
-        return property.name + ":" + basicType;
+        return property.name + ":" + getValidActionscriptModelPath(datatype, basicType);
     }
 }
 
@@ -184,7 +212,7 @@ function getModelPropertyInit(tabbing, property, datatype) {
             else
                 throw "Unknown collection type: " + property.collection + " for " + property.name + " in " + datatype.name;
         } else {
-            return tabbing + property.name + " = new " + property.actualtype + "(data." + property.name + ");";
+            return tabbing + property.name + " = new " + getValidActionscriptModelPath(datatype, property.actualtype) + "(data." + property.name + ");";
         }
     } else if (property.collection) {
         if (property.collection === "array") {

--- a/targets/actionscript/make.js
+++ b/targets/actionscript/make.js
@@ -163,7 +163,13 @@ function getModelPropertyDef(property, datatype) {
     } else {
         if (property.optional && (basicType === "Boolean" || basicType === "int" || basicType === "uint" || basicType === "Number"))
             basicType = "*";
-        return property.name + ":" + getValidPlayFabActionScriptNamespacePrefix(datatype) + basicType;
+        if (property.isclass) {
+            return property.name + ":" + getValidPlayFabActionScriptNamespacePrefix(datatype) + basicType;
+        }
+        else
+        {
+            return property.name + ":" + basicType;
+        }
     }
 }
 


### PR DESCRIPTION
TreatmentAssignment appears in our ClientModels and our ServerModels. The error we see is "TreatmentAssignment is not a recognized class" BUT this class definitely exists in both Models packages. 

This PR is a quick fix that applies the specific package path when TreatmentAssignement is used. 

I'm unable to see why we can't just rely on what was working before (simple declaration without namespace). There are MANY classes that are "shared" between Client and Server, but ONLY TreatmentAssignment is having this compile problem? 

TreatmentAssignment is at least compiling standalone. So the main issue is not in the class itself, just the objects that use it as a member variable.

Potentially the cleanest approach would be to change the package namespace for every model to just be within the brackets of "package { }" and then import the Models namespace below? This would be a fundamental packaging change just for one particular class (but would be ideal for continued future maintenance as we wouldn't need to add any new objects to the make.js file). 