### PR TITLE
Don't run every `if` during enum conversion.

### DIFF
--- a/targets/WindowsSdk/templates/PlayFab_DataModels.h.ejs
+++ b/targets/WindowsSdk/templates/PlayFab_DataModels.h.ejs
@@ -19,14 +19,14 @@ for (var enumIdx = 0; enumIdx < enumtypes.length; enumIdx++) { var enumtype = en
         inline void ToJsonEnum(const <%- enumtype.name %> input, web::json::value& output)
         {
 <% for(var i=0; i<enumtype.enumvalues.length; i++) { var enumval = enumtype.enumvalues[i]
-%>            if (input == <%- enumtype.name %><%- enumval.name %>) output = web::json::value(L"<%- enumval.name %>");
+%>            if (input == <%- enumtype.name %><%- enumval.name %>) { output = web::json::value(L"<%- enumval.name %>"); return; }
 <% } %>        }
         inline void FromJsonEnum(const web::json::value& input, <%- enumtype.name %>& output)
         {
             if (!input.is_string()) return;
             const utility::string_t& inputStr = input.as_string();
 <% for(var i=0; i<enumtype.enumvalues.length; i++) { var enumval = enumtype.enumvalues[i]
-%>            if (inputStr == L"<%- enumval.name %>") output = <%- enumtype.name %><%- enumval.name %>;
+%>            if (inputStr == L"<%- enumval.name %>") { output = <%- enumtype.name %><%- enumval.name %>; return; }
 <% } %>        }
 <% } %>
         // <%- api.name %> Classes<%


### PR DESCRIPTION
This would prevent enum conversion functions from running the if-check
for every possible value during conversion.  There's no code in the
conversion functions after the if-checks, so there's no reason not to
leave when a matching value is found.  This is a tiny change that
_should_ be safe, but I haven't tested it.  See
PlayFabServerDataModels.h for country codes, currencies, generic error
codes, etc. for examples of giant functions running every if-check.

Better yet, make a bigger change to use a switch statement when
converting to json enums.  Result should be a condition-free conversion
that uses a jump table underneath for small enough enums, and falling
back on the behavior as currently written on larger enums.  Depending on
the compiler's "decision".