### PR TITLE
Create PlayFabSDK.asmdef

### DIFF
--- a/targets/unity-v2/source/PlayFabSDK.asmdef
+++ b/targets/unity-v2/source/PlayFabSDK.asmdef
@@ -1,0 +1,3 @@
+﻿{
+	"name": "PlayFabSDK"
+}


### PR DESCRIPTION
TL;DR - This is a bare minimum asmdef file for the unity SDK which will prevent it from compiling when a user navigates back to the editor.

details:
From Unity docs: https://docs.unity3d.com/Manual/ScriptCompilationAssemblyDefinitionFiles.html

Assembly Definition benefits
When you separate your code into assemblies that have well-defined dependencies, Unity reduces their compilation time by only rebuilding the dependent assemblies when you make a change to a script. Assembly Definitions also help you manage dependencies in Projects that contain platform and Unity-version-specific code.

Without Assembly Definitions, Unity compiles any C# scripts in your Project into one of the predefined, managed assemblies. Unity must then recompile every script in the entire Project when you change any script. This means that the length of time between making a code change and seeing that change in action grows longer as you add more scripts to the Project.

Note: Although it’s not required, whenever you use Assembly Definitions in a Project, you should do so for all of the code in your Project. Otherwise, when you change scripts in one of the predefined assemblies, Unity has to still recompile all the code in your Project, because the predefined assemblies automatically depend upon any assemblies you create using an Assembly Definition.