### PR TITLE
Create PlayFabSdkSharedEditor.asmdef

### DIFF
--- a/targets/unity-v2/source/Shared/Editor/PlayFabSdkSharedEditor.asmdef
+++ b/targets/unity-v2/source/Shared/Editor/PlayFabSdkSharedEditor.asmdef
@@ -1,0 +1,14 @@
+﻿{
+    "name": "PlayFabSdkSharedEditor",
+    "references": [],
+    "includePlatforms": [
+        "Editor"
+    ],
+    "excludePlatforms": [],
+    "allowUnsafeCode": false,
+    "overrideReferences": false,
+    "precompiledReferences": [],
+    "autoReferenced": true,
+    "defineConstraints": [],
+    "versionDefines": []
+}


### PR DESCRIPTION
Any editor folder would need to explicitly utilize the Editor platform only. If we have a base asmdef with an editor folder underneath it may not act correctly.