### PR TITLE
Toddbell/asmdef fix

### DIFF
--- a/targets/unity-v2/source/PlayFabSDK.asmdef
+++ b/targets/unity-v2/source/PlayFabSDK.asmdef
@@ -1,3 +1,15 @@
 ﻿{
-	"name": "PlayFabSDK"
+    "name": "PlayFabSDK",
+    "references": [
+        "PlayFabShared"
+    ],
+    "optionalUnityReferences": [],
+    "includePlatforms": [],
+    "excludePlatforms": [],
+    "allowUnsafeCode": false,
+    "overrideReferences": false,
+    "precompiledReferences": [],
+    "autoReferenced": true,
+    "defineConstraints": [],
+    "versionDefines": []
 }

--- a/targets/unity-v2/source/Shared/Editor/PlayFabSdkEditor.asmdef
+++ b/targets/unity-v2/source/Shared/Editor/PlayFabSdkEditor.asmdef
@@ -1,6 +1,8 @@
-﻿{
-    "name": "PlayFabSdkSharedEditor",
-    "references": [],
+{
+    "name": "PlayFabSDKEditor",
+    "references": [
+        "PlayFabShared"
+    ],
     "includePlatforms": [
         "Editor"
     ],

--- a/targets/unity-v2/source/Shared/Models/Editor/PlayFabSharedModelsEditor.asmdef
+++ b/targets/unity-v2/source/Shared/Models/Editor/PlayFabSharedModelsEditor.asmdef
@@ -1,0 +1,16 @@
+{
+    "name": "PlayFabSharedModelsEditor",
+    "references": [
+        "PlayFabShared"
+    ],
+    "includePlatforms": [
+        "Editor"
+    ],
+    "excludePlatforms": [],
+    "allowUnsafeCode": false,
+    "overrideReferences": false,
+    "precompiledReferences": [],
+    "autoReferenced": true,
+    "defineConstraints": [],
+    "versionDefines": []
+}


### PR DESCRIPTION
We were missing shared references to PlayFabShared within Editor dll's created by the new asmdef files. 
This fix adds the missing references.
Fix also ensures the file's noted json name value is the same as the asmdef filename.
Also adds another asmdef required for a separate Editor folder under Shared/Models.