### PR TITLE
Prevent build flags from being overwritten

### DIFF
--- a/SDKBuildScripts/Update-PlayFabSdk.ps1
+++ b/SDKBuildScripts/Update-PlayFabSdk.ps1
@@ -133,7 +133,7 @@ param(
     [AllowEmptyString()]
     [string]$ApiSpecGitUrl,
     [Parameter(ValueFromPipelineByPropertyName = $true)]
-    [string]$OutputPath = "..\..\sdks",
+    [string]$OutputPath,
     [Parameter(ValueFromPipelineByPropertyName = $true)]
     [string]$TargetSource,
     [Parameter(ValueFromPipelineByPropertyName = $true)]
@@ -172,16 +172,22 @@ begin
         "XPlatCoreTemplate" = "xplatcoretemplate";
     }
 
-    $sdksPath = $OutputPath
-    if(![System.IO.Path]::IsPathRooted($sdksPath))
+    if(!$OutputPath)
     {
-        $sdksPath = Resolve-Path (Join-Path $PSScriptRoot $OutputPath)
+        $OutputPath = "../../sdks"
     }
 
-    if(!(Test-Path $sdksPath))
+    if(![System.IO.Path]::IsPathRooted($OutputPath))
     {
-        mkdir $sdksPath | Out-Null
+        $OutputPath = Join-Path $PSScriptRoot $OutputPath
     }
+
+    if(!(Test-Path $OutputPath))
+    {
+        mkdir $OutputPath | Out-Null
+    }
+
+    $OutputPath = Resolve-Path $OutputPath
 
     if($PSCmdlet.ParameterSetName -eq "ApiSpecPath")
     {
@@ -256,7 +262,7 @@ process
             }
         }
 
-        $destPath = Join-Path $sdksPath $targetSdkName
+        $destPath = Join-Path $OutputPath $targetSdkName
 
         if(!(Test-Path $destPath))
         {

--- a/SDKBuildScripts/Update-PlayFabSdk.ps1
+++ b/SDKBuildScripts/Update-PlayFabSdk.ps1
@@ -133,7 +133,7 @@ param(
     [AllowEmptyString()]
     [string]$ApiSpecGitUrl,
     [Parameter(ValueFromPipelineByPropertyName = $true)]
-    [string]$OutputPath,
+    [string]$OutputPath = "..\..\sdks",
     [Parameter(ValueFromPipelineByPropertyName = $true)]
     [string]$TargetSource,
     [Parameter(ValueFromPipelineByPropertyName = $true)]
@@ -172,22 +172,16 @@ begin
         "XPlatCoreTemplate" = "xplatcoretemplate";
     }
 
-    if(!$OutputPath)
+    $sdksPath = $OutputPath
+    if(![System.IO.Path]::IsPathRooted($sdksPath))
     {
-        $OutputPath = "../../sdks"
+        $sdksPath = Resolve-Path (Join-Path $PSScriptRoot $OutputPath)
     }
 
-    if(![System.IO.Path]::IsPathRooted($OutputPath))
+    if(!(Test-Path $sdksPath))
     {
-        $OutputPath = Join-Path $PSScriptRoot $OutputPath
+        mkdir $sdksPath | Out-Null
     }
-
-    if(!(Test-Path $OutputPath))
-    {
-        mkdir $OutputPath | Out-Null
-    }
-
-    $OutputPath = Resolve-Path $OutputPath
 
     if($PSCmdlet.ParameterSetName -eq "ApiSpecPath")
     {
@@ -262,7 +256,7 @@ process
             }
         }
 
-        $destPath = Join-Path $OutputPath $targetSdkName
+        $destPath = Join-Path $sdksPath $targetSdkName
 
         if(!(Test-Path $destPath))
         {

--- a/generate.js
+++ b/generate.js
@@ -119,6 +119,8 @@ function parseCommandInputs(args, argsByName, errorMessages, buildTarget) {
     argsByName.buildidentifier = argsByName.buildidentifier.toLowerCase(); // lowercase the buildIdentifier
     if (argsByName.hasOwnProperty("flags"))
         buildTarget.buildFlags = lowercaseFlagsList(argsByName.flags.split(" "));
+    if (argsByName.hasOwnProperty("version"))
+        buildTarget.versionString = argsByName.version
 }
 function extractArgs(args, argsByName, buildTarget, errorMessages) {
     var cmdArgs = args.slice(2, args.length); // remove "node.exe generate.js"
@@ -290,7 +292,11 @@ function loadApisFromGitHub(argsByName, apiCache, apiSpecGitUrl, onComplete) {
         finishCountdown -= 1;
         if (finishCountdown === 0) {
             console.log("Finished loading files from GitHub");
-            sdkGeneratorGlobals.apiTemplateDescription = "-apiSpecGitUrl " + argsByName.apiSpecGitUrl;
+            sdkGeneratorGlobals.apiTemplateDescription = "-apiSpecGitUrl"
+            if(argsByName.apiSpecGitUrl)
+            {
+                sdkGeneratorGlobals.apiTemplateDescription += " " + argsByName.apiSpecGitUrl;
+            }
             catchAndReport(onComplete);
         }
     }
@@ -392,7 +398,7 @@ function generateApis(buildIdentifier, target) {
     }
     if (genConfig) {
         if (genConfig.buildFlags)
-            target.buildFlags = genConfig.buildFlags.split(" ");
+            target.buildFlags = target.buildFlags.concat(genConfig.buildFlags.split(" "));
         if (genConfig.templateFolder)
             target.templateFolder = genConfig.templateFolder;
         if (genConfig.versionKey)
@@ -401,14 +407,15 @@ function generateApis(buildIdentifier, target) {
             target.versionString = genConfig.versionString;
     }
     getMakeScriptForTemplate(target);
-    console.log("Making SDK from: " + target.templateFolder + "\n - to: " + target.destPath);
+    console.log("Creating SDK from template: " + target.templateFolder);
+    console.log("Outputing SDK to: " + target.destPath);
     // It would probably be better to pass these into the functions, but I don't want to change all the make___Api parameters for all projects today.
     //   For now, just change the global variables in each with the data loaded from SdkManualNotes.json
     if (target.versionKey && !target.versionString) {
         var apiNotes = getApiJson("SdkManualNotes");
         target.versionString = apiNotes.sdkVersion[target.versionKey];
     }
-    console.log("BuildTarget: " + JSON.stringify(target));
+    console.log("BuildTarget: " + JSON.stringify(target, null, 2));
     sdkGlobals.sdkVersion = target.versionString;
     sdkGlobals.buildIdentifier = buildIdentifier;
     if (sdkGlobals.sdkVersion === null) {
@@ -710,5 +717,8 @@ function catchAndReport(method) {
 }
 // Kick everything off
 catchAndReport(parseAndLoadApis);
-setTimeout(function () { }, 5000);
+if(process.argv.indexOf("-nowait") == -1)
+{
+    setTimeout(function () { }, 5000);
+}
 //# sourceMappingURL=generate.js.map

--- a/targets/WindowsSdk/make.js
+++ b/targets/WindowsSdk/make.js
@@ -14,7 +14,7 @@ exports.makeCombinedAPI = function (apis, sourceDir, apiOutputDir) {
         extraDefines: "ENABLE_PLAYFABADMIN_API;ENABLE_PLAYFABSERVER_API;",
         sdkVersion: sdkGlobals.sdkVersion,
         sdkDate: sdkGlobals.sdkVersion.split(".")[2],
-        sdkYear: sdkGlobals.sdkVersion.split(".")[2].substr(0, 2),
+        sdkYear: "20" + sdkGlobals.sdkVersion.split(".")[2].substr(0, 2),
         vsVer: "v140", // If we add 141, we'll have to tweak this again
         vsYear: "2015" // If we add 2017, we'll have to tweak this again
     };

--- a/targets/WindowsSdk/source/build/com.playfab.windowssdk.v140.autopkg.ejs
+++ b/targets/WindowsSdk/source/build/com.playfab.windowssdk.v140.autopkg.ejs
@@ -19,7 +19,7 @@ nuget {
         requireLicenseAcceptance: false;
         description: "Authentication, in-game commerce, player data, title data, inventory, characters, statistics, leaderboards, analytics and reporting, friends, multiplayer, matchmaking, tournaments, cloud script, trading, real-time event handling, player management, live ops, and server hosting for all major platforms/devices and games of any scale. This sdk gives your game the ability log into PlayFab and access cloud data and services.";
         releaseNotes: "https://api.playfab.com/releaseNotes/#<%- sdkDate %>";
-        copyright: "Copyright 20<%- sdkYear %>";
+        copyright: "Copyright <%- sdkYear %>";
         language: "C++";
         tags: { PlayFab, Baas, Paas, JSON, REST, HTTP, SSL, API, cloud, liveops, game, gamedev, native };
     };

--- a/targets/csharp/make.js
+++ b/targets/csharp/make.js
@@ -25,7 +25,7 @@ exports.makeCombinedAPI = function (apis, sourceDir, apiOutputDir) {
         libname: "All",
         sdkDate: sdkGlobals.sdkVersion.split(".")[2],
         sdkVersion: sdkGlobals.sdkVersion,
-        sdkYear: sdkGlobals.sdkVersion.split(".")[2].substr(0, 2)
+        sdkYear: "20" + sdkGlobals.sdkVersion.split(".")[2].substr(0, 2)
     };
 
     templatizeTree(locals, path.resolve(sourceDir, "source"), rootOutputDir);

--- a/targets/csharp/source/PlayFabSDK/source/PlayFabSDK.csproj.ejs
+++ b/targets/csharp/source/PlayFabSDK/source/PlayFabSDK.csproj.ejs
@@ -19,7 +19,7 @@
     <Description>Authentication, in-game commerce, player data, title data, inventory, characters, statistics, leaderboards, analytics and reporting, friends, multiplayer, matchmaking, tournaments, cloud script, trading, real-time event handling, player management, live ops, and server hosting for all major platforms/devices and games of any scale. This sdk gives your game the ability log into PlayFab and access cloud data and services.</Description>
     <Company>PlayFab</Company>
     <Product>PlayFabSDK</Product>
-    <Copyright>Copyright 20<%- sdkYear %></Copyright>
+    <Copyright>Copyright <%- sdkYear %></Copyright>
     <PackageTags>PlayFab, Baas, Paas, JSON, REST, HTTP, SSL, API, cloud, liveops, game, gamedev, native</PackageTags>
     <PackageReleaseNotes>https://docs.microsoft.com/gaming/playfab/release-notes#<%- sdkDate %></PackageReleaseNotes>
     <NeutralLanguage>en</NeutralLanguage>

--- a/targets/csharp/source/Plugins/CloudScript/source/PlayFabCloudScriptPlugin.csproj.ejs
+++ b/targets/csharp/source/Plugins/CloudScript/source/PlayFabCloudScriptPlugin.csproj.ejs
@@ -19,7 +19,7 @@
     <Description>Authentication, in-game commerce, player data, title data, inventory, characters, statistics, leaderboards, analytics and reporting, friends, multiplayer, matchmaking, tournaments, cloud script, trading, real-time event handling, player management, live ops, and server hosting for all major platforms/devices and games of any scale. This sdk gives your game the ability log into PlayFab and access cloud data and services.</Description>
     <Company>PlayFab</Company>
     <Product>PlayFabCloudScriptPlugin</Product>
-    <Copyright>Copyright 20<%- sdkYear %></Copyright>
+    <Copyright>Copyright <%- sdkYear %></Copyright>
     <PackageTags>PlayFab, Baas, Paas, JSON, REST, HTTP, SSL, API, cloud, liveops, game, gamedev, native</PackageTags>
     <PackageReleaseNotes>https://docs.microsoft.com/gaming/playfab/release-notes#<%- sdkDate %></PackageReleaseNotes>
     <NeutralLanguage>en</NeutralLanguage>
@@ -43,7 +43,7 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
-    
+
   <ItemGroup>
      <PackageReference Include="PlayFabAllSDK" Version="<%- sdkVersion %>" />
   </ItemGroup>


### PR DESCRIPTION
Merge build flags from on args with ones loaded from genConfig.json.
- Currently if you specify the beta build flag it will be ignored for C#
  builds because the genConfig.json includes the CSharpOnly flag.
Update generate.js to support version override argument.
Fix some generate.js debug output.
Add -nowait parameter to enable skipping the delay at end of generate.
Updated date use in C# targets to be more Y3K compliant.
Updated Powershell script to support additional build flags and version.