### PR TITLE
Add DISABLE_PLAYFAB_STATIC_API to CSharp

### DIFF
--- a/targets/csharp/make.js
+++ b/targets/csharp/make.js
@@ -277,12 +277,9 @@ function getResultActions(tabbing, apiCall, api, isInstance) {
         return tabbing + "result.AuthenticationContext = new PlayFabAuthenticationContext(result.SessionTicket, result.EntityToken.EntityToken, result.PlayFabId, result.EntityToken.Entity.Id, result.EntityToken.Entity.Type);\n"
             + tabbing + "PlayFabSettings.staticPlayer.CopyFrom(result.AuthenticationContext);\n"
             + tabbing + "await MultiStepClientLogin(result.SettingsForUser.NeedsAttribution);\n";
-    else if (apiCall.result === "AttributeInstallResult" && isInstance)
+    else if (apiCall.result === "AttributeInstallResult")
         return tabbing + "// Modify AdvertisingIdType:  Prevents us from sending the id multiple times, and allows automated tests to determine id was sent successfully\n"
-            + tabbing + "if (apiSettings != null) apiSettings.AdvertisingIdType += \"_Successful\";\n";
-    else if (apiCall.result === "AttributeInstallResult" && !isInstance)
-        return tabbing + "// Modify AdvertisingIdType:  Prevents us from sending the id multiple times, and allows automated tests to determine id was sent successfully\n"
-            + tabbing + "PlayFabSettings.staticSettings.AdvertisingIdType += \"_Successful\";\n";
+            + tabbing + "requestSettings.AdvertisingIdType += \"_Successful\";\n";
     else if (apiCall.result === "GetEntityTokenResponse" && isInstance)
         return tabbing + "var updateContext = authenticationContext;\n"
             + tabbing + "updateContext.EntityToken = result.EntityToken;\n"

--- a/targets/csharp/source/PlayFabSDK/source/Uunit/tests/HttpTests.cs
+++ b/targets/csharp/source/PlayFabSDK/source/Uunit/tests/HttpTests.cs
@@ -11,6 +11,8 @@ namespace PlayFab.UUnit
         private IPlayFabPlugin realHttpPlugin = null;
         private MockTransport mockHttpPlugin = null;
 
+        private readonly PlayFabClientInstanceAPI clientApi = new PlayFabClientInstanceAPI(PlayFabSettings.staticPlayer);
+
         private class MockTransport : ITransportPlugin
         {
             public static HttpStatusCode code;
@@ -60,7 +62,7 @@ namespace PlayFab.UUnit
             mockHttpPlugin.AssignResponse(HttpStatusCode.OK, "{\"data\": {\"RSAPublicKey\": \"Test Result\"} }", null);
 
             // GetTitlePublicKey has no auth, and trivial input/output so it's pretty ideal for a fake API call
-            var task = PlayFabClientAPI.GetTitlePublicKeyAsync(null);
+            var task = clientApi.GetTitlePublicKeyAsync(null);
             task.Wait();
 
             testContext.IsNull(task.Result.Error);
@@ -83,7 +85,7 @@ namespace PlayFab.UUnit
             mockHttpPlugin.AssignResponse(HttpStatusCode.NotFound, null, expectedError);
 
             // GetTitlePublicKey has no auth, and trivial input/output so it's pretty ideal for a fake API call
-            var task = PlayFabClientAPI.GetTitlePublicKeyAsync(null);
+            var task = clientApi.GetTitlePublicKeyAsync(null);
             task.Wait();
 
             testContext.IsNull(task.Result.Result);
@@ -106,7 +108,7 @@ namespace PlayFab.UUnit
             mockHttpPlugin.AssignResponse(HttpStatusCode.InternalServerError, null, expectedError);
 
             // GetTitlePublicKey has no auth, and trivial input/output so it's pretty ideal for a fake API call
-            var task = PlayFabClientAPI.GetTitlePublicKeyAsync(null);
+            var task = clientApi.GetTitlePublicKeyAsync(null);
             task.Wait();
 
             testContext.IsNull(task.Result.Result);
@@ -117,4 +119,5 @@ namespace PlayFab.UUnit
         }
     }
 }
+
 #endif

--- a/targets/csharp/source/PlayFabSDK/source/Uunit/tests/InstanceAuthTests.cs
+++ b/targets/csharp/source/PlayFabSDK/source/Uunit/tests/InstanceAuthTests.cs
@@ -57,8 +57,8 @@ namespace PlayFab.UUnit
             testContext.False(client2.IsClientLoggedIn(), "Client2 login did not clean up properly.");
             testContext.False(auth1.IsEntityLoggedIn(), "Entity1 login did not clean up properly.");
             testContext.False(auth2.IsEntityLoggedIn(), "Entity2 login did not clean up properly.");
-            testContext.False(PlayFabClientAPI.IsClientLoggedIn(), "Static client login did not clean up properly.");
-            testContext.False(PlayFabAuthenticationAPI.IsEntityLoggedIn(), "Static entity login did not clean up properly.");
+            testContext.False(PlayFabSettings.staticPlayer.IsClientLoggedIn(), "Static client login did not clean up properly.");
+            testContext.False(PlayFabSettings.staticPlayer.IsEntityLoggedIn(), "Static entity login did not clean up properly.");
         }
 
         [UUnitTest]
@@ -77,8 +77,8 @@ namespace PlayFab.UUnit
             testContext.True(player1.IsEntityLoggedIn(), "player1 entity login failed");
             testContext.True(auth1.IsEntityLoggedIn(), "auth1 entity login failed");
 
-            testContext.False(PlayFabClientAPI.IsClientLoggedIn(), "p1 client context leaked to static context");
-            testContext.False(PlayFabAuthenticationAPI.IsEntityLoggedIn(), "p1 entity context leaked to static context");
+            testContext.False(PlayFabSettings.staticPlayer.IsClientLoggedIn(), "p1 client context leaked to static context");
+            testContext.False(PlayFabSettings.staticPlayer.IsEntityLoggedIn(), "p1 entity context leaked to static context");
 
             // Verify useful player information
             testContext.NotNull(player1.PlayFabId);
@@ -104,8 +104,8 @@ namespace PlayFab.UUnit
             testContext.True(player2.IsEntityLoggedIn(), "player2 entity login failed");
             testContext.True(auth2.IsEntityLoggedIn(), "auth2 entity login failed");
 
-            testContext.False(PlayFabClientAPI.IsClientLoggedIn(), "p2 client context leaked to static context");
-            testContext.False(PlayFabAuthenticationAPI.IsEntityLoggedIn(), "p2 entity context leaked to static context");
+            testContext.False(PlayFabSettings.staticPlayer.IsClientLoggedIn(), "p2 client context leaked to static context");
+            testContext.False(PlayFabSettings.staticPlayer.IsEntityLoggedIn(), "p2 entity context leaked to static context");
 
             // Verify useful player information
             testContext.NotNull(player2.PlayFabId);
@@ -115,6 +115,7 @@ namespace PlayFab.UUnit
             testContext.EndTest(UUnitFinishState.PASSED, PlayFabSettings.staticSettings.TitleId + ", " + loginTask.Result.Result.PlayFabId);
         }
 
+#if !DISABLE_PLAYFAB_STATIC_API
         [UUnitTest]
         public void StaticLogin(UUnitTestContext testContext)
         {
@@ -126,8 +127,8 @@ namespace PlayFab.UUnit
             var loginTask = PlayFabClientAPI.LoginWithCustomIDAsync(loginRequest);
             loginTask.Wait();
 
-            testContext.True(PlayFabClientAPI.IsClientLoggedIn(), "p2 client context leaked to static context");
-            testContext.True(PlayFabAuthenticationAPI.IsEntityLoggedIn(), "p2 entity context leaked to static context");
+            testContext.True(PlayFabSettings.staticPlayer.IsClientLoggedIn(), "p2 client context leaked to static context");
+            testContext.True(PlayFabSettings.staticPlayer.IsEntityLoggedIn(), "p2 entity context leaked to static context");
 
             testContext.False(client1.IsClientLoggedIn(), "Static login leaked to Client1");
             testContext.False(client2.IsClientLoggedIn(), "tatic login leaked to Client2");
@@ -139,10 +140,11 @@ namespace PlayFab.UUnit
             testContext.NotNull(PlayFabSettings.staticPlayer.EntityId);
             testContext.NotNull(PlayFabSettings.staticPlayer.EntityType);
 
-            PlayFabClientAPI.ForgetAllCredentials();
+            PlayFabSettings.staticPlayer.ForgetAllCredentials();
 
             testContext.EndTest(UUnitFinishState.PASSED, PlayFabSettings.staticSettings.TitleId + ", " + loginTask.Result.Result.PlayFabId);
         }
+#endif
     }
 }
 

--- a/targets/csharp/source/PlayFabSDK/source/Uunit/tests/PlayFabQosApiTest.cs
+++ b/targets/csharp/source/PlayFabSDK/source/Uunit/tests/PlayFabQosApiTest.cs
@@ -1,10 +1,10 @@
 ﻿#if !DISABLE_PLAYFABCLIENT_API && !DISABLE_PLAYFABENTITY_API
+
 namespace PlayFab.UUnit
 {
     using System;
     using ClientModels;
     using QoS;
-    using ServerModels;
 
     public class PlayFabQosApiTest : UUnitTestCase
     {
@@ -12,6 +12,8 @@ namespace PlayFab.UUnit
 
         // Functional
         private static bool TITLE_INFO_SET = false;
+
+        private readonly PlayFabClientInstanceAPI clientApi = new PlayFabClientInstanceAPI(PlayFabSettings.staticPlayer);
 
         /// <summary>
         /// PlayFab Title cannot be created from SDK tests, so you must provide your titleId to run unit tests.
@@ -50,7 +52,7 @@ namespace PlayFab.UUnit
 
             try
             {
-                PlayFabClientAPI.LoginWithCustomIDAsync(loginWithCustomIdRequest, null, testTitleData.extraHeaders).Wait();
+                clientApi.LoginWithCustomIDAsync(loginWithCustomIdRequest, null, testTitleData.extraHeaders).Wait();
             }
             catch (AggregateException aggregateException) when (aggregateException.InnerException != null)
             {
@@ -65,4 +67,5 @@ namespace PlayFab.UUnit
         }
     }
 }
+
 #endif

--- a/targets/csharp/templates/PlayFab_API.cs.ejs
+++ b/targets/csharp/templates/PlayFab_API.cs.ejs
@@ -1,4 +1,4 @@
-#if <%- getApiDefineFlag(api) %>
+#if <%- getApiDefineFlag(api) %> && !DISABLE_PLAYFAB_STATIC_API
 
 using PlayFab.<%- api.name %>Models;
 using PlayFab.Internal;


### PR DESCRIPTION
Fix a bunch of tests and older features to to use instance APIs instead of statics (But still using the staticPlayer which is functionally identical)
Fixed a bug in ClientInstanceApi MultiStepClientLogin impl.