### PR TITLE
Fixing Jcu for msbuild

### DIFF
--- a/JenkinsConsoleUtility/jcuSrc/Commands/CheckBblStandby.cs
+++ b/JenkinsConsoleUtility/jcuSrc/Commands/CheckBblStandby.cs
@@ -178,15 +178,20 @@ namespace JenkinsConsoleUtility.Commands
             {
                 var listBuildsTask = multiplayerApi.ListBuildSummariesAsync(listBuildsRequest);
                 listBuildsTask.Wait();
-                var buildSummaries = listBuildsTask?.Result?.Result?.BuildSummaries;
-                if (buildSummaries == null)
+
+                if (listBuildsTask != null && listBuildsTask.Result != null && listBuildsTask.Result.Result != null)
                 {
-                    JcuUtil.FancyWriteToConsole(ConsoleColor.Red, "ERROR: Was unable to list build summaries, sleeping...");
-                    Thread.Sleep((int)RETRY_DELAY_SEC.TotalMilliseconds);
-                }
-                else
-                {
-                    return buildSummaries;
+                    var buildSummaries = listBuildsTask?.Result?.Result?.BuildSummaries;
+
+                    if (buildSummaries == null)
+                    {
+                        JcuUtil.FancyWriteToConsole(ConsoleColor.Red, "ERROR: Was unable to list build summaries, sleeping...");
+                        Thread.Sleep((int)RETRY_DELAY_SEC.TotalMilliseconds);
+                    }
+                    else
+                    {
+                        return buildSummaries;
+                    }
                 }
             }
 

--- a/JenkinsConsoleUtility/jcuSrc/Commands/CheckBblStandby.cs
+++ b/JenkinsConsoleUtility/jcuSrc/Commands/CheckBblStandby.cs
@@ -91,21 +91,47 @@ namespace JenkinsConsoleUtility.Commands
             if (!JenkinsConsoleUtility.TryGetArgVar(out BBL_VERSIONS, argsCased, "BBL_VERSIONS"))
                 BBL_VERSIONS = "3.0.0;2.0.1";
 
-            if (JenkinsConsoleUtility.TryGetArgVar(out string tempGapThresholds, argsCased, "GAP_MAX_THRESHOLDS"))
+            string tempGapThresholds = "";
+            if (JenkinsConsoleUtility.TryGetArgVar(out tempGapThresholds, argsCased, "GAP_MAX_THRESHOLDS"))
+            {
                 try { GAP_MAX_THRESHOLDS = tempGapThresholds.Split(';').Select(s => int.Parse(s)).ToArray(); } catch (Exception) { }
-            if (JenkinsConsoleUtility.TryGetArgVar(out string tempStandby, argsCased, "STANDBY_MIN_THRESHOLDS"))
-                try { STANDBY_MIN_THRESHOLDS = tempStandby.Split(';').Select(s => int.Parse(s)).ToArray(); } catch (Exception) { }
-            if (JenkinsConsoleUtility.TryGetArgVar(out string tempMaxCap, argsCased, "MAX_CAPACITY_PERCENT_THRESHOLDS"))
-                try { MAX_CAPACITY_PERCENT_THRESHOLDS = tempMaxCap.Split(';').Select(s => int.Parse(s)).ToArray(); } catch (Exception) { }
+            }
 
-            if (JenkinsConsoleUtility.TryGetArgVar(out string tempCycleDuration, argsCased, "CYCLE_DURATION_MINS"))
+            string tempStandby = "";
+            if (JenkinsConsoleUtility.TryGetArgVar(out tempStandby, argsCased, "STANDBY_MIN_THRESHOLDS"))
+            {
+                try { STANDBY_MIN_THRESHOLDS = tempStandby.Split(';').Select(s => int.Parse(s)).ToArray(); } catch (Exception) { }
+            }
+
+            string tempMaxCap = "";
+            if (JenkinsConsoleUtility.TryGetArgVar(out tempMaxCap, argsCased, "MAX_CAPACITY_PERCENT_THRESHOLDS"))
+            {
+                try { MAX_CAPACITY_PERCENT_THRESHOLDS = tempMaxCap.Split(';').Select(s => int.Parse(s)).ToArray(); } catch (Exception) { }
+            }
+
+            string tempCycleDuration = "";
+            if (JenkinsConsoleUtility.TryGetArgVar(out tempCycleDuration, argsCased, "CYCLE_DURATION_MINS"))
+            {
                 try { CYCLE_DURATION_MINS = TimeSpan.FromMinutes(double.Parse(tempCycleDuration)); } catch (Exception) { }
-            if (JenkinsConsoleUtility.TryGetArgVar(out string tempCyclePeriod, argsCased, "CYCLE_PERIOD_SEC"))
+            }
+
+            string tempCyclePeriod = "";
+            if (JenkinsConsoleUtility.TryGetArgVar(out tempCyclePeriod, argsCased, "CYCLE_PERIOD_SEC"))
+            {
                 try { CYCLE_PERIOD_SEC = TimeSpan.FromSeconds(double.Parse(tempCyclePeriod)); } catch (Exception) { }
-            if (JenkinsConsoleUtility.TryGetArgVar(out string tempRetryDelay, argsCased, "RETRY_DELAY_SEC"))
+            }
+
+            string tempRetryDelay = "";
+            if (JenkinsConsoleUtility.TryGetArgVar(out tempRetryDelay, argsCased, "RETRY_DELAY_SEC"))
+            {
                 try { RETRY_DELAY_SEC = TimeSpan.FromSeconds(double.Parse(tempRetryDelay)); } catch (Exception) { }
-            if (JenkinsConsoleUtility.TryGetArgVar(out string tempRetryCount, argsCased, "RETRY_COUNT"))
+            }
+
+            string tempRetryCount = "";
+            if (JenkinsConsoleUtility.TryGetArgVar(out tempRetryCount, argsCased, "RETRY_COUNT"))
+            {
                 try { RETRY_COUNT = int.Parse(tempRetryCount); } catch (Exception) { }
+            }
         }
 
         private int LoginToPlayfab(Dictionary<string, string> argsLc)
@@ -177,7 +203,8 @@ namespace JenkinsConsoleUtility.Commands
             Severity worstTickSeverity = Severity.NONE;
             foreach (var eachSummary in buildSummaries)
             {
-                if (!eachSummary.Metadata.TryGetValue("Version", out string versionString))
+                string versionString = "";
+                if (!eachSummary.Metadata.TryGetValue("Version", out versionString))
                     continue;
                 if (!bblVersions.Contains(versionString) || completedVersions.Contains(versionString))
                     continue;

--- a/JenkinsConsoleUtility/jcuSrc/Commands/CheckBblStandby.cs
+++ b/JenkinsConsoleUtility/jcuSrc/Commands/CheckBblStandby.cs
@@ -181,7 +181,7 @@ namespace JenkinsConsoleUtility.Commands
 
                 if (listBuildsTask != null && listBuildsTask.Result != null && listBuildsTask.Result.Result != null)
                 {
-                    var buildSummaries = listBuildsTask?.Result?.Result?.BuildSummaries;
+                    var buildSummaries = listBuildsTask.Result.Result.BuildSummaries;
 
                     if (buildSummaries == null)
                     {

--- a/JenkinsConsoleUtility/jcuSrc/Commands/CheckBblStandby.cs
+++ b/JenkinsConsoleUtility/jcuSrc/Commands/CheckBblStandby.cs
@@ -23,8 +23,8 @@ namespace JenkinsConsoleUtility.Commands
         }
 
         private static readonly string[] MyCommandKeys = { "CheckBbl", "BblStandby" };
-        public string[] CommandKeys => MyCommandKeys;
-        public string[] MandatoryArgKeys => null;
+        public string[] CommandKeys { get { return MyCommandKeys; } }
+        public string[] MandatoryArgKeys { get { return null; } }
 
         private PlayFabAuthenticationContext context;
         private PlayFabApiSettings settings;

--- a/JenkinsConsoleUtility/jcuSrc/Commands/CloudScriptListener.cs
+++ b/JenkinsConsoleUtility/jcuSrc/Commands/CloudScriptListener.cs
@@ -30,9 +30,9 @@ namespace JenkinsConsoleUtility.Commands
         private const int TestDataExistsSleepTime = 4500;
 
         private static readonly string[] MyCommandKeys = { "ListenCS" };
-        public string[] CommandKeys => MyCommandKeys;
+        public string[] CommandKeys { get { return MyCommandKeys; } }
         private static readonly string[] MyMandatoryArgKeys = { "buildidentifier" };
-        public string[] MandatoryArgKeys => MyMandatoryArgKeys;
+        public string[] MandatoryArgKeys { get { return MyMandatoryArgKeys; } }
 
         public const string CsFuncTestDataExists = "TestDataExists";
         public const string CsFuncGetTestData = "GetTestData";
@@ -77,7 +77,10 @@ namespace JenkinsConsoleUtility.Commands
             if (returnCode != 0)
             {
                 JcuUtil.FancyWriteToConsole(ConsoleColor.Red, "Failed to log in using CustomID: " + titleId + ", " + buildIdentifier);
-                JcuUtil.FancyWriteToConsole(ConsoleColor.Red, task.Result.Error?.GenerateErrorReport());
+                if (task.Result.Error != null)
+                {
+                    JcuUtil.FancyWriteToConsole(ConsoleColor.Red, task.Result.Error.GenerateErrorReport());
+                }
             }
             else
             {

--- a/JenkinsConsoleUtility/jcuSrc/Commands/GitApiCommand.cs
+++ b/JenkinsConsoleUtility/jcuSrc/Commands/GitApiCommand.cs
@@ -16,9 +16,9 @@ namespace JenkinsConsoleUtility.Commands
         //private readonly Type[] _commandDependency = { typeof(VersionVarWriter) };
         //public Type[] CommandDependency => _commandDependency;
         private readonly string[] _commandKeys = { "GitApi" };
-        public string[] CommandKeys => _commandKeys;
+        public string[] CommandKeys { get { return _commandKeys; } }
         private readonly string[] _mandatoryArgKeys = { "sdkName", "GITHUB_CREDENTIALS_FILE" };
-        public string[] MandatoryArgKeys => _mandatoryArgKeys;
+        public string[] MandatoryArgKeys { get { return _mandatoryArgKeys; } }
 
         public int Execute(Dictionary<string, string> argsLc, Dictionary<string, string> argsCased)
         {

--- a/JenkinsConsoleUtility/jcuSrc/Commands/KillTaskCommand.cs
+++ b/JenkinsConsoleUtility/jcuSrc/Commands/KillTaskCommand.cs
@@ -12,9 +12,9 @@ namespace JenkinsConsoleUtility.Commands
         private const int TASK_KILL_SLEEP_MS = 500;
 
         private static readonly string[] MyCommandKeys = { "kill" };
-        public string[] CommandKeys => MyCommandKeys;
+        public string[] CommandKeys { get { return MyCommandKeys; } }
         private static readonly string[] MyMandatoryArgKeys = { "taskName" };
-        public string[] MandatoryArgKeys => MyMandatoryArgKeys;
+        public string[] MandatoryArgKeys { get { return MyMandatoryArgKeys; } }
 
         public int Execute(Dictionary<string, string> argsLc, Dictionary<string, string> argsCased)
         {

--- a/JenkinsConsoleUtility/jcuSrc/Commands/TestingCommand.cs
+++ b/JenkinsConsoleUtility/jcuSrc/Commands/TestingCommand.cs
@@ -8,9 +8,9 @@ namespace JenkinsConsoleUtility.Commands
     public class TestingCommand : ICommand
     {
         private static readonly string[] MyCommandKeys = { "Test", "RunTests" };
-        public string[] CommandKeys => MyCommandKeys;
+        public string[] CommandKeys { get { return MyCommandKeys; } }
         private static readonly string[] MyMandatoryArgKeys = { };
-        public string[] MandatoryArgKeys => MyMandatoryArgKeys;
+        public string[] MandatoryArgKeys { get { return MyMandatoryArgKeys; } }
 
         public int Execute(Dictionary<string, string> argsLc, Dictionary<string, string> argsCased)
         {

--- a/JenkinsConsoleUtility/jcuSrc/Commands/VersionVarWriter.cs
+++ b/JenkinsConsoleUtility/jcuSrc/Commands/VersionVarWriter.cs
@@ -15,9 +15,9 @@ namespace JenkinsConsoleUtility.Commands
         private string _apiSpecPath, _apiSpecGitUrl, _apiSpecPfUrl; // Exactly one of these is expected to be set
 
         private static readonly string[] MyCommandKeys = { "versionVarWriter", "version" };
-        public string[] CommandKeys => MyCommandKeys;
+        public string[] CommandKeys { get { return MyCommandKeys; } }
         private static readonly string[] MyMandatoryArgKeys = { "sdkName" };
-        public string[] MandatoryArgKeys => MyMandatoryArgKeys;
+        public string[] MandatoryArgKeys { get { return MyMandatoryArgKeys; } }
 
         // If this command runs, make the results accessible to other modules
         public static string sdkVersionString;

--- a/JenkinsConsoleUtility/jcuSrc/JenkinsConsoleUtility.cs
+++ b/JenkinsConsoleUtility/jcuSrc/JenkinsConsoleUtility.cs
@@ -76,8 +76,11 @@ namespace JenkinsConsoleUtility
         /// <returns>The string associated with this key</returns>
         public static string GetArgVar(Dictionary<string, string> args, string key, string getDefault = null)
         {
-            if (TryGetArgVar(out string output, args, key, getDefault))
+            string output = "";
+            if (TryGetArgVar(out output, args, key, getDefault))
+            {
                 return output;
+            }
 
             if (getDefault != null) // Don't use string.IsNullOrEmpty() here, because there's a distinction between "undefined" and "empty"
             {

--- a/JenkinsConsoleUtility/jcuSrc/Testing/CloudScriptTests.cs
+++ b/JenkinsConsoleUtility/jcuSrc/Testing/CloudScriptTests.cs
@@ -24,7 +24,10 @@ namespace JenkinsConsoleUtility.Testing
             var task = clientApi.LoginWithCustomIDAsync(new LoginWithCustomIDRequest { CreateAccount = true, CustomId = TEST_CUSTOM_ID, TitleId = testTitleData.titleId });
             task.Wait();
 
-            testContext.True(clientApi.IsClientLoggedIn(), "User login not successful: " + task.Result.Error?.GenerateErrorReport());
+            if (task.Result.Error != null)
+            {
+                testContext.True(clientApi.IsClientLoggedIn(), "User login not successful: " + task.Result.Error.GenerateErrorReport());
+            }
         }
 
         /// <summary>

--- a/JenkinsConsoleUtility/jcuSrc/Util/TestTitleDataLoader.cs
+++ b/JenkinsConsoleUtility/jcuSrc/Util/TestTitleDataLoader.cs
@@ -15,9 +15,14 @@ namespace JenkinsConsoleUtility.Util
             if (testTitleData != null)
                 return testTitleData;
 
-            JenkinsConsoleUtility.TryGetArgVar(out string workspacePath, argsLc, "WORKSPACE");
-            JenkinsConsoleUtility.TryGetArgVar(out string titleDataPath1, argsLc, "testTitleData");
-            JenkinsConsoleUtility.TryGetArgVar(out string titleDataPath2, argsLc, "PF_TEST_TITLE_DATA_JSON");
+            string workspacePath = "";
+            JenkinsConsoleUtility.TryGetArgVar(out workspacePath, argsLc, "WORKSPACE");
+
+            string titleDataPath1 = "";
+            JenkinsConsoleUtility.TryGetArgVar(out titleDataPath1, argsLc, "testTitleData");
+
+            string titleDataPath2 = "";
+            JenkinsConsoleUtility.TryGetArgVar(out titleDataPath2, argsLc, "PF_TEST_TITLE_DATA_JSON");
 
             // If testTitleData or PF_TEST_TITLE_DATA_JSON path is provided, save the path and try to load it
             HashSet<string> validFilepaths = new HashSet<string>();


### PR DESCRIPTION
sometimes if you use the wrong MSBuild call, these classes will have no idea how to parse func(out string variable), we have to move the variable declaration outside the function call.