### PR TITLE
Get all the Unity tests updated and working

### DIFF
--- a/SDKBuildScripts/mac_unity_RunAutoTests.sh
+++ b/SDKBuildScripts/mac_unity_RunAutoTests.sh
@@ -19,16 +19,16 @@ BuildIdentifier=JBuild_${SdkName}_${VerticalName}_${NODE_NAME}_${EXECUTOR_NUMBER
 
 JenkernaughtSaveCloudScriptResults() {
     echo === Save test results to Jenkernaught ===
-    pushd "$WORKSPACE/SDKGenerator/JenkinsConsoleUtility/bin/Debug"
-    cmd <<< "JenkinsConsoleUtility --listencs -buildIdentifier $BuildIdentifier -workspacePath $WORKSPACE -timeout 30 -verbose true"
-    # . ./JenkinsConsoleUtility --listencs -buildIdentifier $BuildIdentifier -workspacePath $WORKSPACE -timeout 30 -verbose true
+    pushd "${WORKSPACE}/SDKGenerator/JenkinsConsoleUtility/bin/Debug"
+    cmd <<< "JenkinsConsoleUtility --listencs -buildIdentifier $BuildIdentifier -workspacePath ${WORKSPACE} -timeout 30 -verbose true"
+    # . ./JenkinsConsoleUtility --listencs -buildIdentifier $BuildIdentifier -workspacePath ${WORKSPACE} -timeout 30 -verbose true
     popd
 }
 
 RunMacJenkernaught() {
     echo === Build OSX Client Target ===
     pushd "${ProjRootPath}/${SdkName}_TC/"
-    $UNITY_VERSION -buildOSXUniversalPlayer "${ProjRootPath}/${SdkName}_TC" -accept-apiupdate -disable-assembly-updater -noUpm -nographics -quit -batchmode -executeMethod PlayFab.Internal.PlayFabPackager.MakeOsxBuild -logFile "${ProjRootPath}/buildOSXClient.txt" || (cat "${ProjRootPath}/buildOSXClient.txt" && return 1)
+    $UNITY_VERSION -buildOSXUniversalPlayer "${ProjRootPath}/${SdkName}_TC" -accept-apiupdate -disable-assembly-updater -noUpm -nographics -quit -batchmode -executeMethod PlayFab.Internal.PlayFabPackager.MakeOsxBuild -logFile "${WORKSPACE}/logs/buildOSXClient.txt" || (cat "${WORKSPACE}/logs/buildOSXClient.txt" && return 1)
     popd
 
     JenkernaughtSaveCloudScriptResults

--- a/SDKBuildScripts/unity_RunAutoTests.sh
+++ b/SDKBuildScripts/unity_RunAutoTests.sh
@@ -52,20 +52,25 @@ CheckVars() {
     if [ -z "$TestXbox" ]; then
         TestXbox="false"
     fi
+    if [ -z "$TestCompileFlags" ]; then
+        TestCompileFlags="true"
+    fi
     if [ -z "$BuildMainUnityPackage" ]; then
         BuildMainUnityPackage="false"
     fi
 }
 
 SetProjDefines() {
-    echo === Test compilation in all example projects ===
+    if [ "$TestCompileFlags" = "true" ]; then
+        echo === Test compilation in all example projects ===
 
-    # TC is used by essentially all of the test projects
-    . ./unity_copyTestTitleData.sh "${RepoProject}/Assets/Resources" copy || exit 1
+        # TC is used by essentially all of the test projects
+        . ./unity_copyTestTitleData.sh "${RepoProject}/Assets/Resources" copy || exit 1
 
-    SetEachProjDefine ${SdkName}_TA
-    SetEachProjDefine ${SdkName}_TS
-    SetEachProjDefine ${SdkName}_TZ
+        SetEachProjDefine ${SdkName}_TA
+        SetEachProjDefine ${SdkName}_TS
+        SetEachProjDefine ${SdkName}_TZ
+    fi
 }
 
 SetEachProjDefine() {

--- a/SDKBuildScripts/unity_RunAutoTests.sh
+++ b/SDKBuildScripts/unity_RunAutoTests.sh
@@ -73,15 +73,15 @@ SetProjDefines() {
 SetEachProjDefine() {
     echo === Set Each Proj Define ===
     pushd "${ProjRootPath}/$1"
-    $UNITY_VERSION -projectPath "${ProjRootPath}/$1" -quit -batchmode -executeMethod SetupPlayFabExample.Setup -logFile "${ProjRootPath}/compile$1.txt" || (cat "${ProjRootPath}/compile$1.txt" && return 1)
+    $UNITY_VERSION -projectPath "${ProjRootPath}/$1" -quit -batchmode -executeMethod SetupPlayFabExample.Setup -logFile "${WORKSPACE}/logs/compile$1.txt" || (cat "${WORKSPACE}/logs/compile$1.txt" && return 1)
     popd
 }
 
 JenkernaughtSaveCloudScriptResults() {
     echo === Save test results to Jenkernaught ===
-    pushd "$WORKSPACE/SDKGenerator/JenkinsConsoleUtility/bin/Debug"
-    cmd <<< "JenkinsConsoleUtility --listencs -buildIdentifier $BuildIdentifier -workspacePath $WORKSPACE -timeout 30 -verbose true"
-    # . ./JenkinsConsoleUtility --listencs -buildIdentifier $BuildIdentifier -workspacePath $WORKSPACE -timeout 30 -verbose true
+    pushd "${WORKSPACE}/SDKGenerator/JenkinsConsoleUtility/bin/Debug"
+    cmd <<< "JenkinsConsoleUtility --listencs -buildIdentifier $BuildIdentifier -workspacePath ${WORKSPACE} -timeout 30 -verbose true"
+    # . ./JenkinsConsoleUtility --listencs -buildIdentifier $BuildIdentifier -workspacePath ${WORKSPACE} -timeout 30 -verbose true
     popd
 }
 
@@ -89,7 +89,7 @@ RunClientJenkernaught() {
     if [ "$TestWin32Build" = "true" ]; then
         echo === Build Win32 Client Target ===
         pushd "${RepoProject}"
-        $UNITY_VERSION -projectPath "${RepoProject}" -quit -batchmode -executeMethod PlayFab.Internal.PlayFabPackager.MakeWin32TestingBuild -logFile "${ProjRootPath}/buildWin32Client.txt" || (cat "${ProjRootPath}/buildWin32Client.txt" && return 1)
+        $UNITY_VERSION -projectPath "${RepoProject}" -quit -batchmode -executeMethod PlayFab.Internal.PlayFabPackager.MakeWin32TestingBuild -logFile "${WORKSPACE}/logs/buildWin32Client.txt" || (cat "${WORKSPACE}/logs/buildWin32Client.txt" && return 1)
         popd
 
         echo === Run the $UNITY_VERSION Client UnitTests ===
@@ -107,7 +107,7 @@ BuildClientByFunc() {
     if [ "$1" = "true" ]; then
         echo === Build $2 Target ===
         pushd "${RepoProject}"
-        $UNITY_VERSION -projectPath "${RepoProject}" -quit -batchmode -executeMethod PlayFab.Internal.PlayFabPackager.$2 -logFile "${ProjRootPath}/${2}.txt" || (cat "${ProjRootPath}/${2}.txt" && return 1)
+        $UNITY_VERSION -projectPath "${RepoProject}" -quit -batchmode -executeMethod PlayFab.Internal.PlayFabPackager.$2 -logFile "${WORKSPACE}/logs/${2}.txt" || (cat "${WORKSPACE}/logs/${2}.txt" && return 1)
         popd
         #Run the console test command if present
         if [ ! -z "$3" ]; then
@@ -117,15 +117,15 @@ BuildClientByFunc() {
 }
 
 ExecPs4OnConsole() {
-    . "$WORKSPACE/JenkinsSdkSetupScripts/JenkinsScripts/Consoles/ps4/unity_ps4.sh"
+    . "${WORKSPACE}/JenkinsSdkSetupScripts/JenkinsScripts/Consoles/ps4/unity_ps4.sh"
 }
 
 ExecSwitchOnConsole() {
-    . "$WORKSPACE/JenkinsSdkSetupScripts/JenkinsScripts/Consoles/switch/unity_switch.sh"
+    . "${WORKSPACE}/JenkinsSdkSetupScripts/JenkinsScripts/Consoles/switch/unity_switch.sh"
 }
 
 ExecXboxOnConsole() {
-    . "$WORKSPACE/JenkinsSdkSetupScripts/JenkinsScripts/Consoles/xbox/unity_xbox.sh"
+    . "${WORKSPACE}/JenkinsSdkSetupScripts/JenkinsScripts/Consoles/xbox/unity_xbox.sh"
 }
 
 TryBuildAndTestAndroid() {
@@ -135,23 +135,23 @@ TryBuildAndTestAndroid() {
         pushd "${RepoProject}"
 
             #copy test title data in
-            pushd "$WORKSPACE/SDKGenerator/SDKBuildScripts"
-                . ./unity_copyTestTitleData.sh "$WORKSPACE/sdks/${SdkName}/ExampleTestProject/Assets/Testing/Resources" copy || exit 1
+            pushd "${WORKSPACE}/SDKGenerator/SDKBuildScripts"
+                . ./unity_copyTestTitleData.sh "${WORKSPACE}/sdks/${SdkName}/ExampleTestProject/Assets/Testing/Resources" copy || exit 1
             popd
             if [[ $? -ne 0 ]]; then return 1; fi
 
             #build the APK
-            $UNITY_VERSION -projectPath "${RepoProject}" -quit -batchmode -executeMethod PlayFab.Internal.PlayFabPackager.MakeAndroidBuild -logFile "$WORKSPACE/logs/buildAndroidOutput.txt" || (cat "$WORKSPACE/logs/buildAndroidOutput.txt" && return 1)
+            $UNITY_VERSION -projectPath "${RepoProject}" -quit -batchmode -executeMethod PlayFab.Internal.PlayFabPackager.MakeAndroidBuild -logFile "${WORKSPACE}/logs/buildAndroidOutput.txt" || (cat "${WORKSPACE}/logs/buildAndroidOutput.txt" && return 1)
             if [[ $? -ne 0 ]]; then return 1; fi
 
-            pushd "$WORKSPACE/SDKGenerator/SDKBuildScripts"
+            pushd "${WORKSPACE}/SDKGenerator/SDKBuildScripts"
 
                 #pull the test title data back out
-                . ./unity_copyTestTitleData.sh "$WORKSPACE/sdks/${SdkName}/ExampleTestProject/Assets/Testing/Resources" delete || exit 1
+                . ./unity_copyTestTitleData.sh "${WORKSPACE}/sdks/${SdkName}/ExampleTestProject/Assets/Testing/Resources" delete || exit 1
                 if [[ $? -ne 0 ]]; then return 1; fi
 
                 #upload the APK and run the tests on AppCenter Test
-                . ./runAppCenterTest.sh "${WORKSPACE}/testBuilds/PlayFabAndroid.apk" "$WORKSPACE/SDKGenerator/SDKBuildScripts/AppCenterUITestLauncher/AppCenterUITestLauncher/debugassemblies" unity-android || exit 1
+                . ./runAppCenterTest.sh "${WORKSPACE}/testBuilds/PlayFabAndroid.apk" "${WORKSPACE}/SDKGenerator/SDKBuildScripts/AppCenterUITestLauncher/AppCenterUITestLauncher/debugassemblies" unity-android || exit 1
                 if [[ $? -ne 0 ]]; then return 1; fi
 
             popd
@@ -171,27 +171,27 @@ TryBuildAndTestiOS() {
         pushd "${RepoProject}"
 
             #copy the test title data in
-            pushd "$WORKSPACE/SDKGenerator/SDKBuildScripts"
-                . ./unity_copyTestTitleData.sh "$WORKSPACE/sdks/${SdkName}/ExampleTestProject/Assets/Testing/Resources" copy || exit 1
+            pushd "${WORKSPACE}/SDKGenerator/SDKBuildScripts"
+                . ./unity_copyTestTitleData.sh "${WORKSPACE}/sdks/${SdkName}/ExampleTestProject/Assets/Testing/Resources" copy || exit 1
             popd
             if [[ $? -ne 0 ]]; then return 1; fi
 
             #build the xcode project to prepare for IPA generation
-            $UNITY_VERSION -projectPath "${RepoProject}" -quit -batchmode -appcenter -executeMethod PlayFab.Internal.PlayFabPackager.MakeIPhoneBuild -logFile "$WORKSPACE/logs/buildPackageOutput.txt" || (cat "$WORKSPACE/logs/buildiPhoneOutput.txt" && return 1)
+            $UNITY_VERSION -projectPath "${RepoProject}" -quit -batchmode -appcenter -executeMethod PlayFab.Internal.PlayFabPackager.MakeIPhoneBuild -logFile "${WORKSPACE}/logs/buildPackageOutput.txt" || (cat "${WORKSPACE}/logs/buildiPhoneOutput.txt" && return 1)
             if [[ $? -ne 0 ]]; then return 1; fi
 
-            pushd "$WORKSPACE/SDKGenerator/SDKBuildScripts"
+            pushd "${WORKSPACE}/SDKGenerator/SDKBuildScripts"
 
                 #pull the test title data back out.
-                . ./unity_copyTestTitleData.sh "$WORKSPACE/sdks/${SdkName}/ExampleTestProject/Assets/Testing/Resources" delete || exit 1
+                . ./unity_copyTestTitleData.sh "${WORKSPACE}/sdks/${SdkName}/ExampleTestProject/Assets/Testing/Resources" delete || exit 1
                 if [[ $? -ne 0 ]]; then return 1; fi
 
                 #build the IPA on AppCenter Build
-                . ./unity_buildAppCenterTestIOS.sh "${WORKSPACE}/testBuilds/PlayFabIOS" "$WORKSPACE/vso" 'git@ssh.dev.azure.com:v3/playfab/Playfab%20SDK%20Automation/UnitySDK_XCode_AppCenterBuild' ${SdkName}_${NODE_NAME}_${EXECUTOR_NUMBER} init || exit 1
+                . ./unity_buildAppCenterTestIOS.sh "${WORKSPACE}/testBuilds/PlayFabIOS" "${WORKSPACE}/vso" 'git@ssh.dev.azure.com:v3/playfab/Playfab%20SDK%20Automation/UnitySDK_XCode_AppCenterBuild' ${SdkName}_${NODE_NAME}_${EXECUTOR_NUMBER} init || exit 1
                 if [[ $? -ne 0 ]]; then return 1; fi
 
                 #run the downloaded IPA on AppCenter Test
-                . ./runAppCenterTest.sh "$WORKSPACE/SDKGenerator/SDKBuildScripts/PlayFabIOS.ipa" "$WORKSPACE/SDKGenerator/SDKBuildScripts/AppCenterUITestLauncher/AppCenterUITestLauncher/debugassemblies" unity-ios || exit 1
+                . ./runAppCenterTest.sh "${WORKSPACE}/SDKGenerator/SDKBuildScripts/PlayFabIOS.ipa" "${WORKSPACE}/SDKGenerator/SDKBuildScripts/AppCenterUITestLauncher/AppCenterUITestLauncher/debugassemblies" unity-ios || exit 1
                 if [[ $? -ne 0 ]]; then return 1; fi
 
             popd
@@ -207,10 +207,10 @@ BuildPackages() {
     if [ "$UNITY_PUBLISH_VERSION" = "$UNITY_VERSION" ] && [ "$BuildMainUnityPackage" = "true" ]; then
         echo === Build the SDK asset bundle ===
         cd "$RepoProject"
-        $UNITY_VERSION -projectPath "$RepoProject" -quit -batchmode -executeMethod PlayFab.Internal.PlayFabPackager.PackagePlayFabSdk -logFile "$WORKSPACE/logs/buildPackageOutput.txt" || (cat "$WORKSPACE/logs/buildPackageOutput.txt" && return 1)
+        $UNITY_VERSION -projectPath "$RepoProject" -quit -batchmode -executeMethod PlayFab.Internal.PlayFabPackager.PackagePlayFabSdk -logFile "${WORKSPACE}/logs/buildPackageOutput.txt" || (cat "${WORKSPACE}/logs/buildPackageOutput.txt" && return 1)
         echo === Build the EdEx asset bundle ===
         cd "$RepoProject"
-        $UNITY_VERSION -projectPath "$RepoProject" -quit -batchmode -executeMethod PlayFab.Internal.PlayFabEdExPackager.BuildUnityPackage -logFile "$WORKSPACE/logs/buildEdExOutput.txt" || (cat "$WORKSPACE/logs/buildEdExOutput.txt" && return 1)
+        $UNITY_VERSION -projectPath "$RepoProject" -quit -batchmode -executeMethod PlayFab.Internal.PlayFabEdExPackager.BuildUnityPackage -logFile "${WORKSPACE}/logs/buildEdExOutput.txt" || (cat "${WORKSPACE}/logs/buildEdExOutput.txt" && return 1)
     fi
 }
 
@@ -228,7 +228,7 @@ EC() {
 }
 
 KillUnityProcesses() {
-    pushd "$WORKSPACE/SDKGenerator/JenkinsConsoleUtility/bin/Debug"
+    pushd "${WORKSPACE}/SDKGenerator/JenkinsConsoleUtility/bin/Debug"
     cmd <<< "JenkinsConsoleUtility --kill -taskName $UNITY_VERSION"
 }
 

--- a/SDKBuildScripts/unity_RunAutoTests.sh
+++ b/SDKBuildScripts/unity_RunAutoTests.sh
@@ -64,9 +64,6 @@ SetProjDefines() {
     if [ "$TestCompileFlags" = "true" ]; then
         echo === Test compilation in all example projects ===
 
-        # TC is used by essentially all of the test projects
-        . ./unity_copyTestTitleData.sh "${RepoProject}/Assets/Resources" copy || exit 1
-
         SetEachProjDefine ${SdkName}_TA
         SetEachProjDefine ${SdkName}_TS
         SetEachProjDefine ${SdkName}_TZ
@@ -236,6 +233,8 @@ KillUnityProcesses() {
 }
 
 DoWork() {
+    . ./unity_copyTestTitleData.sh "${RepoProject}/Assets/Resources" copy || exit 1
+
     CheckVars
     SetProjDefines
     RunClientJenkernaught

--- a/SDKBuildScripts/unity_SetupTestProjects.sh
+++ b/SDKBuildScripts/unity_SetupTestProjects.sh
@@ -4,7 +4,6 @@
 
 . "$WORKSPACE/JenkinsSdkSetupScripts/JenkinsScripts/Pipeline/util.sh" 2> /dev/null
 
-
 # USAGE Nuke <folderLinkName>
 Nuke () {
     rm "$1" 2> /dev/null || rm -f "$1" 2> /dev/null || rm -r "$1" 2> /dev/null || rm -rf "$1" 2> /dev/null || true
@@ -96,4 +95,9 @@ CheckDefault SdkName "UnitySDK"
 CheckDefault UNITY_VERSION "Unity193"
 
 # MainScript <all command line args for script>
-MainScript "$@"
+if [ -z "$TestCompileFlags" ]; then
+    TestCompileFlags="true"
+fi
+if [ "$TestCompileFlags" = "true" ]; then
+    MainScript "$@"
+fi

--- a/SDKBuildScripts/unity_SetupTestProjects.sh
+++ b/SDKBuildScripts/unity_SetupTestProjects.sh
@@ -2,7 +2,7 @@
 # USAGE: unity_SetupTestProjects.sh
 # Make folder links from the UnitySdk to this test project
 
-. "$WORKSPACE/JenkinsSdkSetupScripts/JenkinsScripts/Pipeline/util.sh" 2> /dev/null
+. "${WORKSPACE}/JenkinsSdkSetupScripts/JenkinsScripts/Pipeline/util.sh" 2> /dev/null
 
 # USAGE Nuke <folderLinkName>
 Nuke () {

--- a/targets/unity-v2/source/ExampleTestProject/Assets/Testing/Editor/PlayFabPackager.cs
+++ b/targets/unity-v2/source/ExampleTestProject/Assets/Testing/Editor/PlayFabPackager.cs
@@ -274,7 +274,7 @@ namespace PlayFab.Internal
             var ps4Path = Path.Combine(GetBuildPath(), "PlayFabPS4");
             MkDir(GetBuildPath());
             MkDir(ps4Path);
-            BuildPipeline.BuildPlayer(TestScenes, ps4Path, BuildTarget.PS4, BuildOptions.None);
+            BuildPipeline.BuildPlayer(TestScenes, ps4Path, BuildTarget.PS4, BuildOptions.Development); // Development build is required for final test-result submission (bug)
             if (Directory.GetFiles(ps4Path).Length == 0)
                 throw new PlayFabException(PlayFabExceptionCode.BuildError, "Target directory is empty: " + ps4Path + ", " + string.Join(",", Directory.GetFiles(ps4Path)));
         }

--- a/targets/unity-v2/source/ExampleTestProject/Assets/Testing/Editor/PlayFabPackager.cs
+++ b/targets/unity-v2/source/ExampleTestProject/Assets/Testing/Editor/PlayFabPackager.cs
@@ -89,7 +89,7 @@ namespace PlayFab.Internal
         private static string GetBuildPath()
         {
             var workspacePath = Environment.GetEnvironmentVariable("WORKSPACE"); // This is a Jenkins-Build environment variable
-            var rootPath = workspacePath ?? Application.dataPath;
+            var rootPath = workspacePath ?? PathCombine(Application.dataPath, ".."); // Fall back onto a safe local option
             return Path.GetFullPath(Path.Combine(rootPath, "testBuilds"));
         }
 

--- a/targets/unity-v2/source/ExampleTestProject/Assets/Testing/Tests/Shared/Uunit/UUnitIncrementalTestRunner.cs
+++ b/targets/unity-v2/source/ExampleTestProject/Assets/Testing/Tests/Shared/Uunit/UUnitIncrementalTestRunner.cs
@@ -104,27 +104,37 @@ namespace PlayFab.UUnit
         {
             if (postResultsToCloudscript && result != null)
             {
-                Debug.Log("Results posted to Cloud Script successfully: " + PlayFabSettings.BuildIdentifier + ", " + clientInstance.authenticationContext.PlayFabId);
+                var msg = "Results posted to Cloud Script successfully: " + PlayFabSettings.BuildIdentifier + ", " + clientInstance.authenticationContext.PlayFabId;
+                textDisplay.text += "\n" + msg;
+                Debug.Log(msg);
                 if (result.Logs != null)
                     foreach (var eachLog in result.Logs)
                         Debug.Log("Cloud Log: " + eachLog.Message);
             }
-
-            if (autoQuit && !Application.isEditor)
-                Application.Quit();
-            else if (!suite.AllTestsPassed())
-                throw new Exception("Results were not posted to Cloud Script: " + PlayFabSettings.BuildIdentifier);
+            QuitTesting();
         }
 
         private void OnPostTestResultsError(PlayFabError error)
         {
             Debug.LogWarning("Error posting results to Cloud Script:" + error.GenerateErrorReport());
-
-            if (autoQuit && !Application.isEditor)
-                Application.Quit();
-            else if (!suite.AllTestsPassed())
-                throw new Exception("Results were not posted to Cloud Script: " + PlayFabSettings.BuildIdentifier);
+            QuitTesting();
         }
 #endif
+        public void QuitTesting()
+        {
+            string msg = null;
+            if (autoQuit && !Application.isEditor)
+            {
+                msg = "Quitting...";
+                Application.Quit();
+            }
+            else if (!suite.AllTestsPassed())
+            {
+                msg = "Results were not posted to Cloud Script: " + PlayFabSettings.BuildIdentifier;
+            }
+
+            textDisplay.text += "\n" + msg;
+            Debug.Log(msg);
+        }
     }
 }

--- a/targets/unity-v2/source/ExampleTestProject/Assets/Testing/Tests/Shared/Uunit/UUnitIncrementalTestRunner.cs
+++ b/targets/unity-v2/source/ExampleTestProject/Assets/Testing/Tests/Shared/Uunit/UUnitIncrementalTestRunner.cs
@@ -134,7 +134,7 @@ namespace PlayFab.UUnit
             }
             else
             {
-                msg = "Failed to quit test program: " + autoQuit + Application.isEditor + suite.AllTestsPassed();
+                msg = "Failed to quit test program: " + autoQuit + !Application.isEditor + suite.AllTestsPassed();
             }
 
             textDisplay.text += "\n" + msg;

--- a/targets/unity-v2/source/ExampleTestProject/Assets/Testing/Tests/Shared/Uunit/UUnitIncrementalTestRunner.cs
+++ b/targets/unity-v2/source/ExampleTestProject/Assets/Testing/Tests/Shared/Uunit/UUnitIncrementalTestRunner.cs
@@ -132,6 +132,10 @@ namespace PlayFab.UUnit
             {
                 msg = "Results were not posted to Cloud Script: " + PlayFabSettings.BuildIdentifier;
             }
+            else
+            {
+                msg = "Failed to quit test program: " + autoQuit + Application.isEditor + suite.AllTestsPassed();
+            }
 
             textDisplay.text += "\n" + msg;
             Debug.Log(msg);


### PR DESCRIPTION
Update all logs to write to WORKSPACE/logs (instead of all over the place)
Fix some log file names to reflect the actual work step, instead of copy-pasta over-write other logs.
Add "TestCompileFlags" which skips some steps for faster iterative testing.
Move unity_copyTestTitleData out of SetProjDefines, which are unrelated, and ensures unity_copyTestTitleData always happens.
The recent default build location was inside the Assets/ proj folder which fails for some platforms.
Change PS4 test builds to Development mode because of a bug
Log a little more thoroughly around the final test sequence (investigating bug - seemed like an ok thing to keep)