### PR TITLE
Add the path for the AndroidSdk to the msbuild for Xamarin

### DIFF
--- a/targets/csharp/XamarinTestRunner/build_Android.cmd
+++ b/targets/csharp/XamarinTestRunner/build_Android.cmd
@@ -3,5 +3,5 @@ msbuild %CSProj% -t:Restore
 msbuild %CSProj% ^
     -t:SignAndroidPackage ^
     -p:Configuration=Debug ^
-    -p:EmbedAssembliesIntoApk=true
-
+    -p:EmbedAssembliesIntoApk=true ^
+    -p:AndroidSdkDirectory=%ANDROID_HOME%


### PR DESCRIPTION
Fixes inconsistent result issues with the Xamarin Android build.