### PR TITLE
Removing usage of legacy CLI option

### DIFF
--- a/SDKBuildScripts/Linux/ue4_mkpl_build.sh
+++ b/SDKBuildScripts/Linux/ue4_mkpl_build.sh
@@ -1,7 +1,6 @@
 SdkName="UnrealMarketplacePlugin"
 targetSrc="UnrealMarketplacePlugin"
 delSrc=true
-SdkGenArgs="-flags nonnullable"
 
 cd ..
 

--- a/SDKBuildScripts/Windows/ue4_mkpl_build.bat
+++ b/SDKBuildScripts/Windows/ue4_mkpl_build.bat
@@ -2,7 +2,6 @@ setlocal
 set SdkName=UnrealMarketplacePlugin
 set targetSrc=UnrealMarketplacePlugin
 set delSrc=true
-set SdkGenArgs=-flags nonnullable
 
 cd ..
 

--- a/SDKBuildScripts/shared_build.bat
+++ b/SDKBuildScripts/shared_build.bat
@@ -28,7 +28,7 @@ cd %~dp0
 pushd ..
 if [%1] == [] (
     rem === BUILDING %SdkName% ===
-    node generate.js %targetSrc%=%destPath% %apiSpecSource% %SdkGenArgs% %buildIdentifier%
+    node generate.js %targetSrc%=%destPath% %apiSpecSource% %buildIdentifier%
 ) else (
     rem === BUILDING %SdkName% with params %* ===
     node generate.js %targetSrc%=%destPath% %*

--- a/SDKBuildScripts/shared_build.sh
+++ b/SDKBuildScripts/shared_build.sh
@@ -42,11 +42,11 @@ BuildSdk () {
     pushd ..
     echo === SHARED BUILDING $SdkName ===
     if [ ! -z "$SdkGenPrvTmplRepo" ]; then
-        node generate.js $SdkGenPrvTmplRepo=$destPath $apiSpecSource $SdkGenArgs $buildIdentifier $VerticalNameInternal
+        node generate.js $SdkGenPrvTmplRepo=$destPath $apiSpecSource $buildIdentifier $VerticalNameInternal
     elif [ -z "$targetSrc" ]; then
-        node generate.js -destPath $destPath $apiSpecSource $SdkGenArgs $buildIdentifier $VerticalNameInternal
+        node generate.js -destPath $destPath $apiSpecSource $buildIdentifier $VerticalNameInternal
     else
-        node generate.js $targetSrc=$destPath $apiSpecSource $SdkGenArgs $buildIdentifier $VerticalNameInternal
+        node generate.js $targetSrc=$destPath $apiSpecSource $buildIdentifier $VerticalNameInternal
     fi
     popd
 }


### PR DESCRIPTION
This input is now entirely controlled by genConfig.json for all Primary SDKs
In all these cases, attempting to provide this input won't even be honored by SdkGenerator