### PR TITLE
Update RunTestsCommandlet.cpp.ejs

### DIFF
--- a/targets/UnrealMarketplacePlugin/examplesource/ExampleProject/Source/ExampleProject/RunTestsCommandlet.cpp.ejs
+++ b/targets/UnrealMarketplacePlugin/examplesource/ExampleProject/Source/ExampleProject/RunTestsCommandlet.cpp.ejs
@@ -22,6 +22,10 @@ URunTestsCommandlet::URunTestsCommandlet()
 
 int32 URunTestsCommandlet::Main(const FString& Params)
 {
+#if ENGINE_MINOR_VERSION < 24
+    GIsRequestingExit = false; // Global used by Unreal to indicate that the commandlet should exit.
+#endif
+
     if (IsValid(GEngine))
     {
         GIsRunning = true;
@@ -30,7 +34,12 @@ int32 URunTestsCommandlet::Main(const FString& Params)
     {
         UE_LOG(LogPlayFabExampleProject, Error, TEXT("Invalid Engine instance."));
 
+#if ENGINE_MINOR_VERSION < 24
+        GIsRequestingExit = true;
+#else
         RequestEngineExit("Invalid PlayFab Test UnrealEngine Instance");
+#endif
+
         GIsRunning = false;
     }
 
@@ -39,7 +48,12 @@ int32 URunTestsCommandlet::Main(const FString& Params)
 
     bool bPrintedTestSummary = false;
 
-    while (GIsRunning && !IsEngineExitRequested())
+    while (GIsRunning && 
+#if ENGINE_MINOR_VERSION < 24
+    !GIsRequestingExit)
+#else
+    !IsEngineExitRequested())
+#endif  
     {
         GEngine->UpdateTimeAndHandleMaxTickRate();
         GEngine->Tick(FApp::GetDeltaTime(), false);


### PR DESCRIPTION
Apparently the previous version of unreal DO NOT support the suggested fixes from epic's compiler warnings.