### PR TITLE
Fix Python error code reference

### DIFF
--- a/targets/PythonSdk/source/playfab/PlayFabHTTP.py
+++ b/targets/PythonSdk/source/playfab/PlayFabHTTP.py
@@ -72,7 +72,7 @@ def DoPost(urlPath, request, authKey, authVal, callback, customData = None, extr
             emptyResponseError = PlayFabErrors.PlayFabError()
             emptyResponseError.Error = "Empty Response Recieved"
             emptyResponseError.ErrorMessage = "PlayFabHTTP Recieved an empty response"
-            emptyResponseError.ErrorCode = PlayFabErrorCode.Unknown;
+            emptyResponseError.ErrorCode = PlayFabErrors.PlayFabErrorCode.Unknown
             callback(None, emptyResponseError)
         except Exception as e:
             # Global notification about exception in caller's callback


### PR DESCRIPTION
Per [issue 9](https://github.com/PlayFab/PythonSdk/issues/9)
PlayFabErrorCode needs to be qualified by PlayFabErrors.

Also, Python statements are not terminated by semicolons.