### PR TITLE
 Fix PythonSDK setup

### DIFF
--- a/targets/PythonSdk/source/setup.py.ejs
+++ b/targets/PythonSdk/source/setup.py.ejs
@@ -11,10 +11,13 @@ setuptools.setup(
     long_description=long_description,
     url="https://github.com/PlayFab/PythonSdk",
     packages=setuptools.find_packages(),
-    classifiers=(
+    install_requires=[
+        'requests',
+    ],
+    classifiers=[
         "Programming Language :: Python :: 3",
         "License :: OSI Approved :: Apache Software License",
         "Operating System :: OS Independent",
         "Topic :: Games/Entertainment",
-    ),
+    ],
 )


### PR DESCRIPTION
 Per [issue 8](https://github.com/PlayFab/PythonSdk/issues/8) the
 PythonSDK needs to declare a dependency on the requests module.

 This PR amends setup.py to declare such a dependency.

 Tested using `python setup.py develop` on a machine that did not have
 the requests module installed and verifying that the requests module
 (and its dependencies) were correctly installed.

Also amend the value of classifiers to be an array rather than a tuple
 per [setupscript.html](https://docs.python.org/2/distutils/setupscript.html)