### PR TITLE
Update PlayFabResultHandler.cpp.ejs

### DIFF
--- a/targets/UnrealMarketplacePlugin/source/PlayFab/Source/PlayFabCpp/Private/Core/PlayFabResultHandler.cpp.ejs
+++ b/targets/UnrealMarketplacePlugin/source/PlayFab/Source/PlayFabCpp/Private/Core/PlayFabResultHandler.cpp.ejs
@@ -108,7 +108,10 @@ bool PlayFabRequestHandler::DecodeError(TSharedPtr<FJsonObject> JsonObject, Play
             {
                 if (val.Value->AsArray().Num() > 0)
                 {
-                    OutError.ErrorDetails.Add(val.Key, val.Value->AsArray()[0]->AsString());
+                    for(const auto& obj : val.Value->AsArray())
+                    {
+                        OutError.ErrorDetails.Add(val.Key, obj->AsString());
+                    }
                 }
                 else
                 {


### PR DESCRIPTION
We only apply error details for the first player, but in multiplayer scenarios, we should expect multiple players to appear in the array.