### PR TITLE
Fix a Uobject memory chain issue in Test Framework

### DIFF
--- a/targets/UnrealMarketplacePlugin/examplesource/ExampleProject/Plugins/PlayFab/Source/PlayFab/Private/Tests/PlayFabBlueprintTests.cpp.ejs
+++ b/targets/UnrealMarketplacePlugin/examplesource/ExampleProject/Plugins/PlayFab/Source/PlayFab/Private/Tests/PlayFabBlueprintTests.cpp.ejs
@@ -10,11 +10,6 @@
 #include "PlayFabDataApi.h"
 #include "PlayFabServerApi.h"
 
-// Sets default values
-UPlayFabBlueprintTests::UPlayFabBlueprintTests()
-{
-}
-
 void UPlayFabBlueprintTests::ClassSetUp()
 {
     // README:
@@ -88,13 +83,13 @@ void UPlayFabBlueprintTests::InvalidLogin(UPlayFabTestContext* testContext)
 
 void UPlayFabBlueprintTests::InvalidLoginSuccess(FClientLoginResult result, UObject* customData)
 {
-    UPlayFabTestContext* testContext = dynamic_cast<UPlayFabTestContext*>(customData);
+    UPlayFabTestContext* testContext = static_cast<UPlayFabTestContext*>(customData);
     testContext->EndTest(PlayFabApiTestFinishState::FAILED, "Expected login to fail");
 }
 
 void UPlayFabBlueprintTests::InvalidLoginFail(FPlayFabError error, UObject* customData)
 {
-    UPlayFabTestContext* testContext = dynamic_cast<UPlayFabTestContext*>(customData);
+    UPlayFabTestContext* testContext = static_cast<UPlayFabTestContext*>(customData);
     if (error.ErrorMessage.Find("password") != -1)
         testContext->EndTest(PlayFabApiTestFinishState::PASSED, "");
     else
@@ -122,7 +117,7 @@ void UPlayFabBlueprintTests::InvalidRegistration(UPlayFabTestContext* testContex
 
 void UPlayFabBlueprintTests::InvalidRegistrationSuccess(FClientRegisterPlayFabUserResult result, UObject* customData)
 {
-    UPlayFabTestContext* testContext = dynamic_cast<UPlayFabTestContext*>(customData);
+    UPlayFabTestContext* testContext = static_cast<UPlayFabTestContext*>(customData);
     testContext->EndTest(PlayFabApiTestFinishState::FAILED, "Expected registration to fail");
 }
 
@@ -135,7 +130,7 @@ void UPlayFabBlueprintTests::InvalidRegistrationFail(FPlayFabError error, UObjec
     foundEmailMsg = (error.ErrorDetails.Find(expectedEmailMsg) != -1);
     foundPasswordMsg = (error.ErrorDetails.Find(expectedPasswordMsg) != -1);
 
-    UPlayFabTestContext* testContext = dynamic_cast<UPlayFabTestContext*>(customData);
+    UPlayFabTestContext* testContext = static_cast<UPlayFabTestContext*>(customData);
     if (foundEmailMsg && foundPasswordMsg)
         testContext->EndTest(PlayFabApiTestFinishState::PASSED, "");
     else
@@ -168,7 +163,7 @@ void UPlayFabBlueprintTests::LoginOrRegister(UPlayFabTestContext* testContext)
 void UPlayFabBlueprintTests::OnLoginOrRegister(FClientLoginResult result, UObject* customData)
 {
     PlayFabId = result.PlayFabId;
-    UPlayFabTestContext* testContext = dynamic_cast<UPlayFabTestContext*>(customData);
+    UPlayFabTestContext* testContext = static_cast<UPlayFabTestContext*>(customData);
     testContext->EndTest(PlayFabApiTestFinishState::PASSED, "");
 }
 
@@ -198,7 +193,7 @@ void UPlayFabBlueprintTests::OnLoginWithAdvertisingId(FClientLoginResult result,
 {
     IPlayFab* playFabSettings = &(IPlayFab::Get());
     // TODO: Need to wait for the NEXT api call to complete, and then test playFabSettings->AdvertisingIdType (Oh right... need to actually change AdvertisingIdType too...
-    UPlayFabTestContext* testContext = dynamic_cast<UPlayFabTestContext*>(customData);
+    UPlayFabTestContext* testContext = static_cast<UPlayFabTestContext*>(customData);
     testContext->EndTest(PlayFabApiTestFinishState::PASSED, "");
 }
 
@@ -259,7 +254,7 @@ void UPlayFabBlueprintTests::OnUserDataApiUpdate(FClientUpdateUserDataResult res
 
 void UPlayFabBlueprintTests::OnUserDataApiGet2(FClientGetUserDataResult result, UObject* customData)
 {
-    UPlayFabTestContext* testContext = dynamic_cast<UPlayFabTestContext*>(customData);
+    UPlayFabTestContext* testContext = static_cast<UPlayFabTestContext*>(customData);
 
     FDateTime now = FDateTime::UtcNow();
     FDateTime minTime = now - FTimespan(0, 5, 0);
@@ -374,7 +369,7 @@ void UPlayFabBlueprintTests::OnPlayerStatisticsApiGet2(FClientGetPlayerStatistic
             && result.Statistics[i]->GetStringField(TEXT("StatisticName")) == TEST_STAT_NAME)
             actualStatValue = result.Statistics[i]->GetNumberField(TEXT("Value"));
 
-    UPlayFabTestContext* testContext = dynamic_cast<UPlayFabTestContext*>(customData);
+    UPlayFabTestContext* testContext = static_cast<UPlayFabTestContext*>(customData);
     if (testMessageInt != actualStatValue)
         testContext->EndTest(PlayFabApiTestFinishState::FAILED, "User statistic not updated as expected, E:" + FString::FromInt(testMessageInt) + " != A:" + FString::FromInt(actualStatValue));
     else
@@ -410,7 +405,7 @@ void UPlayFabBlueprintTests::LeaderBoard(UPlayFabTestContext* testContext)
 
 void UPlayFabBlueprintTests::OnLeaderBoard(FClientGetLeaderboardResult result, UObject* customData)
 {
-    UPlayFabTestContext* testContext = dynamic_cast<UPlayFabTestContext*>(customData);
+    UPlayFabTestContext* testContext = static_cast<UPlayFabTestContext*>(customData);
     if (result.Leaderboard.Num() > 0)
         testContext->EndTest(PlayFabApiTestFinishState::PASSED, "");
     else
@@ -442,7 +437,7 @@ void UPlayFabBlueprintTests::AccountInfo(UPlayFabTestContext* testContext)
 
 void UPlayFabBlueprintTests::OnAccountInfo(FClientGetAccountInfoResult result, UObject* customData)
 {
-    UPlayFabTestContext* testContext = dynamic_cast<UPlayFabTestContext*>(customData);
+    UPlayFabTestContext* testContext = static_cast<UPlayFabTestContext*>(customData);
 
     if (!result.AccountInfo->HasField("TitleInfo"))
     {
@@ -497,7 +492,7 @@ void UPlayFabBlueprintTests::CloudScript(UPlayFabTestContext* testContext)
 
 void UPlayFabBlueprintTests::OnHelloWorldCloudScript(FClientExecuteCloudScriptResult result, UObject* customData)
 {
-    UPlayFabTestContext* testContext = dynamic_cast<UPlayFabTestContext*>(customData);
+    UPlayFabTestContext* testContext = static_cast<UPlayFabTestContext*>(customData);
 
     if (!result.FunctionResult->HasField("messageValue"))
     {
@@ -541,7 +536,7 @@ void UPlayFabBlueprintTests::CloudScriptError(UPlayFabTestContext* testContext)
 
 void UPlayFabBlueprintTests::OnCloudScriptError(FClientExecuteCloudScriptResult result, UObject* customData)
 {
-    UPlayFabTestContext* testContext = dynamic_cast<UPlayFabTestContext*>(customData);
+    UPlayFabTestContext* testContext = static_cast<UPlayFabTestContext*>(customData);
 
     if (result.FunctionResult != nullptr)
     {
@@ -588,7 +583,7 @@ void UPlayFabBlueprintTests::WriteEvent(UPlayFabTestContext* testContext)
 
 void UPlayFabBlueprintTests::OnWritePlayerEvent(FClientWriteEventResponse result, UObject* customData)
 {
-    UPlayFabTestContext* testContext = dynamic_cast<UPlayFabTestContext*>(customData);
+    UPlayFabTestContext* testContext = static_cast<UPlayFabTestContext*>(customData);
     testContext->EndTest(PlayFabApiTestFinishState::PASSED, "");
 }
 
@@ -620,7 +615,7 @@ void UPlayFabBlueprintTests::OnGetEntityToken(FAuthenticationGetEntityTokenRespo
     entityId = result.Entity->GetStringField("Id");
     entityType = result.Entity->GetStringField("Type");
 
-    UPlayFabTestContext* testContext = dynamic_cast<UPlayFabTestContext*>(customData);
+    UPlayFabTestContext* testContext = static_cast<UPlayFabTestContext*>(customData);
     testContext->EndTest(PlayFabApiTestFinishState::PASSED, "");
 }
 
@@ -697,7 +692,7 @@ void UPlayFabBlueprintTests::OnSetObjectApi(FDataSetObjectsResponse result, UObj
 
 void UPlayFabBlueprintTests::OnGetObjectApi2(FDataGetObjectsResponse result, UObject* customData)
 {
-    UPlayFabTestContext* testContext = dynamic_cast<UPlayFabTestContext*>(customData);
+    UPlayFabTestContext* testContext = static_cast<UPlayFabTestContext*>(customData);
 
     int actualValue = -1000; // Fail if the data isn't present
     if (result.Objects->HasField(TEST_DATA_KEY))
@@ -733,7 +728,7 @@ void UPlayFabBlueprintTests::ServerTitleData(UPlayFabTestContext* testContext)
 
 void UPlayFabBlueprintTests::OnServerTitleData(FServerGetTitleDataResult result, UObject* customData)
 {
-    UPlayFabTestContext* testContext = dynamic_cast<UPlayFabTestContext*>(customData);
+    UPlayFabTestContext* testContext = static_cast<UPlayFabTestContext*>(customData);
     // There is no guarantee about content in titleData, so as long as this request succeeds, test passes
     testContext->EndTest(PlayFabApiTestFinishState::PASSED, "");
 }

--- a/targets/UnrealMarketplacePlugin/examplesource/ExampleProject/Plugins/PlayFab/Source/PlayFab/Private/Tests/PlayFabCppTests.cpp.ejs
+++ b/targets/UnrealMarketplacePlugin/examplesource/ExampleProject/Plugins/PlayFab/Source/PlayFab/Private/Tests/PlayFabCppTests.cpp.ejs
@@ -15,7 +15,7 @@ void UPlayFabCppTests::ClassSetUp()
 
     FString jsonInput;
     FString filename = TEST_TITLE_DATA_LOC;
-    
+
     if (!FPaths::FileExists(filename))
     {
         // Prefer to load path from environment variable, if present
@@ -191,7 +191,7 @@ void UPlayFabCppTests::GetUserDataAPI_Success(const PlayFab::ClientModels::FGetU
             // If I know what value I'm expecting, and I did not get it, log an error
             UE_LOG(LogPlayFabTests, Error, TEXT("GetUserData: Update value did not match new value %d!=%d"), UserDataAPI_ExpectedValue, actualValue);
 
-            CurrentTestContext->EndTest(PlayFabApiTestFinishState::FAILED, FString::Format(TEXT("Update value did not match new value {0}!={1}"), {UserDataAPI_ExpectedValue, actualValue})); // Error
+            CurrentTestContext->EndTest(PlayFabApiTestFinishState::FAILED, FString::Format(TEXT("Update value did not match new value {0}!={1}"), { UserDataAPI_ExpectedValue, actualValue })); // Error
         }
         else
         {

--- a/targets/UnrealMarketplacePlugin/examplesource/ExampleProject/Plugins/PlayFab/Source/PlayFab/Public/Tests/PlayFabBlueprintTests.h.ejs
+++ b/targets/UnrealMarketplacePlugin/examplesource/ExampleProject/Plugins/PlayFab/Source/PlayFab/Public/Tests/PlayFabBlueprintTests.h.ejs
@@ -20,9 +20,6 @@ class PLAYFAB_API UPlayFabBlueprintTests : public UPlayFabTestCase
     GENERATED_BODY()
 
 public:
-    ///////////////////// Actor stuff /////////////////////
-    UPlayFabBlueprintTests(); // Sets default values for this actor's properties
-
     int testMessageInt;
 
     // #### PlayFab TestSuite Interface ####
@@ -56,7 +53,7 @@ if (hasServerOptions) { %>
     UFUNCTION()
     void OnSharedError(FPlayFabError error, UObject* customData)
     {
-        UPlayFabTestContext* testContext = dynamic_cast<UPlayFabTestContext*>(customData);
+        auto testContext = static_cast<UPlayFabTestContext*>(customData);
         testContext->EndTest(PlayFabApiTestFinishState::FAILED, "Unexpected error: " + error.ErrorMessage + "\n" + error.ErrorDetails);
     }
     

--- a/targets/UnrealMarketplacePlugin/examplesource/ExampleProject/Plugins/PlayFab/Source/PlayFab/Public/Tests/PlayFabCppTests.h.ejs
+++ b/targets/UnrealMarketplacePlugin/examplesource/ExampleProject/Plugins/PlayFab/Source/PlayFab/Public/Tests/PlayFabCppTests.h.ejs
@@ -47,11 +47,7 @@ class PLAYFAB_API UPlayFabCppTests : public UPlayFabTestCase
 {
     GENERATED_BODY()
 
-    // Used to end tests.
-    class UPlayFabTestContext* CurrentTestContext = nullptr;
-
 public:
-
     virtual void GetTests(TArray<UPlayFabTestContext*>& InOutTests) override
     {
 <% if (hasClientOptions) { %>
@@ -72,13 +68,16 @@ public:
         InOutTests.ADD_TEST(Object API (CPP), ObjectAPI);
     }
     
+    virtual void ClassSetUp() override;
+    virtual void SetUp(UPlayFabTestContext* testContext) override;
+
+private:
+    // Used to end tests.
+    class UPlayFabTestContext* CurrentTestContext = nullptr;
     PlayFabClientPtr ClientAPI;
     PlayFabServerPtr ServerAPI;
     PlayFabAuthenticationPtr AuthenticationAPI;
     PlayFabDataPtr DataAPI;
-
-    virtual void ClassSetUp() override;
-    virtual void SetUp(UPlayFabTestContext* testContext) override;
 
     /**
      * Shared Error callback.
@@ -129,12 +128,14 @@ public:
     void AccountInfo();
     void AccountInfo_Success(const PlayFab::ClientModels::FGetAccountInfoResult& result);
 
+    UPROPERTY()
     FString CLOUD_FUNCTION_HELLO_WORLD = TEXT("helloWorld");
 
     UFUNCTION()
     void CloudScript();
     void CloudScript_Success(const PlayFab::ClientModels::FExecuteCloudScriptResult& result);
 
+    UPROPERTY()
     FString CLOUD_FUNCTION_THROW_ERROR = TEXT("throwError");
 
     UFUNCTION()

--- a/targets/UnrealMarketplacePlugin/examplesource/ExampleProject/Plugins/PlayFab/Source/PlayFabCommon/Private/TestFramework/PlayFabTestContext.cpp.ejs
+++ b/targets/UnrealMarketplacePlugin/examplesource/ExampleProject/Plugins/PlayFab/Source/PlayFabCommon/Private/TestFramework/PlayFabTestContext.cpp.ejs
@@ -1,8 +1,35 @@
+<%- copyright %>
 
 #include "TestFramework/PlayFabTestContext.h"
 
-UFUNCTION()
-void UPlayFabTestContext::EndTest(PlayFabApiTestFinishState InFinishState, FString InMessage)
+void UPlayFabTestContext::Setup(const FString& InName, UPlayFabTestCase* InTestCase, const FString& InTestFuncName)
+{
+    testName = InName;
+    activeState = PlayFabApiTestActiveState::PENDING;
+    finishState = PlayFabApiTestFinishState::TIMEDOUT;
+    testResultMsg = "";
+    startTime = 0;
+    endTime = 0;
+
+    TestCase = InTestCase;
+
+    UPlayFabTestContext::FApiTestCase TestDelegate;
+    TestDelegate.BindUFunction(TestCase, *InTestFuncName);
+
+    UE_LOG(LogTemp, Log, TEXT("Binding %s: %s"), *InName, *InTestFuncName);
+
+    testFunc = TestDelegate;
+};
+
+UPlayFabTestContext* UPlayFabTestContext::CreateTestContext(const FString& InName, UPlayFabTestCase* InTestCase, const FString& InTestFuncName)
+{
+    auto OutTestContext = NewObject<UPlayFabTestContext>();
+    OutTestContext->Setup(InName, InTestCase, InTestFuncName);
+
+    return OutTestContext;
+}
+
+void UPlayFabTestContext::EndTest(PlayFabApiTestFinishState InFinishState, const FString& InMessage)
 {
     UE_LOG(LogPlayFabCommon, Log, TEXT("Ending Test: %s."), *testName);
 
@@ -12,4 +39,31 @@ void UPlayFabTestContext::EndTest(PlayFabApiTestFinishState InFinishState, FStri
     endTime = FDateTime::UtcNow();
 
     activeState = PlayFabApiTestActiveState::COMPLETE;
+}
+
+FString UPlayFabTestContext::GenerateTestSummary(FDateTime InNow)
+{
+    FString temp;
+    temp = FString::FromInt(GetDurationInMilliseconds());
+    while (temp.Len() < 12)
+        temp = " " + temp;
+    temp += " ms, ";
+    switch (finishState)
+    {
+    case PlayFabApiTestFinishState::PASSED: temp += "pass: ";
+        break;
+    case PlayFabApiTestFinishState::FAILED: temp += "FAILED: ";
+        break;
+    case PlayFabApiTestFinishState::SKIPPED: temp += "SKIPPED: ";
+        break;
+    case PlayFabApiTestFinishState::TIMEDOUT: temp += "TIMED OUT: ";
+        break;
+    }
+    temp += testName;
+    if (testResultMsg.Len() > 0)
+    {
+        temp += " - ";
+        temp += testResultMsg;
+    }
+    return temp;
 }

--- a/targets/UnrealMarketplacePlugin/examplesource/ExampleProject/Plugins/PlayFab/Source/PlayFabCommon/Private/TestFramework/PlayFabTestRunner.cpp.ejs
+++ b/targets/UnrealMarketplacePlugin/examplesource/ExampleProject/Plugins/PlayFab/Source/PlayFabCommon/Private/TestFramework/PlayFabTestRunner.cpp.ejs
@@ -18,6 +18,9 @@ UPlayFabTestRunner::UPlayFabTestRunner(const FObjectInitializer& ObjectInitializ
 
 FString IPlayFabTestRunner::GenerateTestSummary()
 {
+    auto& SuiteTests = GetSuiteTests();
+    auto& OutputSummary = GetCachedSummary();
+
     OutputSummary.Empty(SUMMARY_INIT_BUFFER_SIZE); // Set the capacity to handle everything we're about to put into it
 
     FDateTime now = FDateTime::UtcNow();
@@ -58,20 +61,23 @@ void IPlayFabTestRunner::AddTestCase(UPlayFabTestCase* InTestCase)
     if (SuiteState != PlayFabApiTestActiveState::PENDING)
         return;
 
+    auto& SuiteTests = GetSuiteTests();
     InTestCase->GetTests(SuiteTests);
 }
 
-void IPlayFabTestRunner::ManageTestCase(UPlayFabTestCase* InNewTestCase, UPlayFabTestCase* InCurrentTestCase)
+void IPlayFabTestRunner::ManageTestCase(UPlayFabTestCase* nextTestCase)
 {
-    if (InNewTestCase != InCurrentTestCase)
-    {
-        if (IsValid(InNewTestCase))
-            InNewTestCase->ClassTearDown();
+    UPlayFabTestCase* prevTestCase = GetActiveTest();
 
-        if (IsValid(InCurrentTestCase))
+    if (prevTestCase != nextTestCase)
+    {
+        if (IsValid(prevTestCase))
+            prevTestCase->ClassTearDown();
+
+        if (IsValid(nextTestCase))
         {
-            SuiteTestCase = InCurrentTestCase;
-            SuiteTestCase->ClassSetUp();
+            SetActiveTest(nextTestCase);
+            nextTestCase->ClassSetUp();
         }
     }
 }
@@ -81,13 +87,14 @@ void IPlayFabTestRunner::Run(const float InDeltaTime)
     if (SuiteState != PlayFabApiTestActiveState::PENDING)
         return;
 
+    auto& SuiteTests = GetSuiteTests();
     const auto Index = CurrentTestIndex;
     if (Index < SuiteTests.Num())
     {
         auto CurrentTestData = SuiteTests[Index];
         UPlayFabTestCase* CurrentTestCase = CurrentTestData->GetTestCase();
 
-        ManageTestCase(SuiteTestCase, CurrentTestCase);
+        ManageTestCase(CurrentTestCase);
 
         if (CurrentTestData->activeState == PlayFabApiTestActiveState::PENDING
             && CurrentTestData->activeState != PlayFabApiTestActiveState::ACTIVE)
@@ -132,8 +139,9 @@ void IPlayFabTestRunner::Run(const float InDeltaTime)
     }
     else
     {
-        ManageTestCase(nullptr, SuiteTestCase); // Cleanup
+        ManageTestCase(nullptr); // Cleanup
 
         SuiteState = PlayFabApiTestActiveState::COMPLETE;
+        GEngine->ForceGarbageCollection(true);
     }
 }

--- a/targets/UnrealMarketplacePlugin/examplesource/ExampleProject/Plugins/PlayFab/Source/PlayFabCommon/Public/TestFramework/PlayFabTestCase.h.ejs
+++ b/targets/UnrealMarketplacePlugin/examplesource/ExampleProject/Plugins/PlayFab/Source/PlayFabCommon/Public/TestFramework/PlayFabTestCase.h.ejs
@@ -23,17 +23,27 @@ class PLAYFABCOMMON_API UPlayFabTestCase : public UObject
 protected:
     // A bunch of constants: load these from testTitleData.json
     // TODO: Should be moved out of UPlayFabTestCase.
-    UPROPERTY() FString TEST_TITLE_DATA_LOC = FPaths::ProjectContentDir() + TEXT("/TestTitleData/testTitleData.json");;
-    UPROPERTY() FString TEST_DATA_KEY = "testCounter";
-    UPROPERTY() FString TEST_STAT_NAME = "str";
-    UPROPERTY() FString PlayFabId;
-    UPROPERTY() FString entityId;
-    UPROPERTY() FString entityType;
-    UPROPERTY() FDateTime testMessageTime;
+    UPROPERTY()
+    FString TEST_TITLE_DATA_LOC = FPaths::ProjectContentDir() + TEXT("/TestTitleData/testTitleData.json");;
+    UPROPERTY()
+    FString TEST_DATA_KEY = "testCounter";
+    UPROPERTY()
+    FString TEST_STAT_NAME = "str";
+    UPROPERTY()
+    FString PlayFabId;
+    UPROPERTY()
+    FString entityId;
+    UPROPERTY()
+    FString entityType;
+    UPROPERTY()
+    FDateTime testMessageTime;
 
-    UPROPERTY() FString TitleId;
-    UPROPERTY() FString DevSecretKey;
-    UPROPERTY() FString UserEmail;
+    UPROPERTY()
+    FString TitleId;
+    UPROPERTY()
+    FString DevSecretKey;
+    UPROPERTY()
+    FString UserEmail;
 
 public:
     // Default Constructor.

--- a/targets/UnrealMarketplacePlugin/examplesource/ExampleProject/Plugins/PlayFab/Source/PlayFabCommon/Public/TestFramework/PlayFabTestContext.h.ejs
+++ b/targets/UnrealMarketplacePlugin/examplesource/ExampleProject/Plugins/PlayFab/Source/PlayFabCommon/Public/TestFramework/PlayFabTestContext.h.ejs
@@ -8,6 +8,8 @@
 
 #include "PlayFabTestContext.generated.h"
 
+class UPlayFabTestCase;
+
 // Represent a running Test, with every information about it's execution.
 UCLASS(Blueprintable, BlueprintType)
 class PLAYFABCOMMON_API UPlayFabTestContext : public UObject
@@ -45,50 +47,24 @@ public:
     UPROPERTY()
     FDateTime endTime;
 
-    UPROPERTY() UPlayFabTestCase* TestCase;
+    UPROPERTY()
+    UPlayFabTestCase* TestCase;
 
-    UFUNCTION() UPlayFabTestCase* GetTestCase() const { return TestCase; }
-
+    FORCEINLINE UPlayFabTestCase* GetTestCase() const { return TestCase; }
 
     /**
      * Initializes this Test.
      * @param InName This Test's name.
      * @param InTestFunc This Test's function.
      */
-    UFUNCTION()
-    void Setup(FString InName, UPlayFabTestCase* InTestCase, FString InTestFuncName)
-    {
-        testName = InName;
-        activeState = PlayFabApiTestActiveState::PENDING;
-        finishState = PlayFabApiTestFinishState::TIMEDOUT;
-        testResultMsg = "";
-        startTime = 0;
-        endTime = 0;
+    void Setup(const FString& InName, UPlayFabTestCase* InTestCase, const FString& InTestFuncName);
 
-        TestCase = InTestCase;
-
-        UPlayFabTestContext::FApiTestCase TestDelegate;
-        TestDelegate.BindUFunction(TestCase, *InTestFuncName);
-
-        UE_LOG(LogTemp, Log, TEXT("Binding %s: %s"), *InName, *InTestFuncName);
-
-        testFunc = TestDelegate;
-    };
-
-    UFUNCTION()
-    static UPlayFabTestContext* CreateTestContext(FString InName, UPlayFabTestCase* InTestCase, FString InTestFuncName)
-    {
-        auto OutTestContext = NewObject<UPlayFabTestContext>();
-        OutTestContext->Setup(InName, InTestCase, InTestFuncName);
-
-        return OutTestContext;
-    }
+    static UPlayFabTestContext* CreateTestContext(const FString& InName, UPlayFabTestCase* InTestCase, const FString& InTestFuncName);
 
     /**
      * Returns the time this Test took to complete, as a Timespan.
      * @returns The time this Test tool to complete, as a Timespan.
      */
-    UFUNCTION(BlueprintPure)
     FORCEINLINE FTimespan GetDuration() const
     {
         FDateTime now = FDateTime::UtcNow();
@@ -102,49 +78,20 @@ public:
      * Returns the time this Test took to complete, in seconds.
      * @returns The time this Test tool to complete, in seconds.
      */
-    UFUNCTION(BlueprintPure)
     FORCEINLINE float GetDurationInSeconds() const { return GetDuration().GetTotalSeconds(); }
 
     /**
      * Returns the time this Test took to complete, in milliseconds.
      * @returns The time this Test took to complete, in milliseconds.
      */
-    UFUNCTION(BlueprintPure)
     FORCEINLINE float GetDurationInMilliseconds() const { return GetDuration().GetTotalMilliseconds(); }
 
-    UFUNCTION()
-    void EndTest(PlayFabApiTestFinishState InFinishState = PlayFabApiTestFinishState::PASSED, FString InMessage = "");
+    void EndTest(PlayFabApiTestFinishState InFinishState = PlayFabApiTestFinishState::PASSED, const FString& InMessage = "");
 
     /**
      * Generates this Test's summary, and returns it as a FString.
      * @param InNow The current time
      * @returns This Test's Summary
      */
-    UFUNCTION()
-    FString GenerateTestSummary(FDateTime InNow)
-    {
-        FString temp;
-        temp = FString::FromInt(GetDurationInMilliseconds());
-        while (temp.Len() < 12)
-            temp = " " + temp;
-        temp += " ms, ";
-        switch (finishState)
-        {
-        case PlayFabApiTestFinishState::PASSED: temp += "pass: ";
-            break;
-        case PlayFabApiTestFinishState::FAILED: temp += "FAILED: ";
-            break;
-        case PlayFabApiTestFinishState::SKIPPED: temp += "SKIPPED: ";
-            break;
-        case PlayFabApiTestFinishState::TIMEDOUT: temp += "TIMED OUT: ";
-            break;
-        }
-        temp += testName;
-        if (testResultMsg.Len() > 0)
-        {
-            temp += " - ";
-            temp += testResultMsg;
-        }
-        return temp;
-    }
+    FString GenerateTestSummary(FDateTime InNow);
 };

--- a/targets/UnrealMarketplacePlugin/examplesource/ExampleProject/Plugins/PlayFab/Source/PlayFabCommon/Public/TestFramework/PlayFabTestRunner.h.ejs
+++ b/targets/UnrealMarketplacePlugin/examplesource/ExampleProject/Plugins/PlayFab/Source/PlayFabCommon/Public/TestFramework/PlayFabTestRunner.h.ejs
@@ -17,6 +17,8 @@ class PLAYFABCOMMON_API UPlayFabTestRunner : public UInterface
     GENERATED_UINTERFACE_BODY()
 };
 
+class UPlayFabTestCase;
+
 class PLAYFABCOMMON_API IPlayFabTestRunner
 {
     GENERATED_IINTERFACE_BODY()
@@ -24,15 +26,14 @@ class PLAYFABCOMMON_API IPlayFabTestRunner
 protected:
     // Current State of the test runner.
     PlayFabApiTestActiveState SuiteState;
-    // All the tests to be run.
-    TArray<class UPlayFabTestContext*> SuiteTests;
+
+    virtual TArray<UPlayFabTestContext*>& GetSuiteTests() = 0;
+    virtual UPlayFabTestCase* GetActiveTest() = 0;
+    virtual void SetActiveTest(UPlayFabTestCase* newTestCase) = 0;
+    virtual FString& GetCachedSummary() = 0;
+
     // Index of the test currently run.
     int CurrentTestIndex;
-    // Current test case run.
-    class UPlayFabTestCase* SuiteTestCase;
-    // Last generated OutputSummary.
-    FString OutputSummary;
-
     // Total number of tests
     int numberOfTests;
     // Number of failed tests
@@ -48,14 +49,11 @@ public:
     virtual FString GenerateTestSummary();
 
     // Adds a Test case to be run.
-    UFUNCTION(BlueprintCallable)
-    virtual void AddTestCase(class UPlayFabTestCase* InTestCase);
+    void AddTestCase(UPlayFabTestCase* InTestCase);
 
     // Manage the switch between different test cases.
-    UFUNCTION()
-    virtual void ManageTestCase(class UPlayFabTestCase* InNewTestCase, class UPlayFabTestCase* InCurrentTestCase);
+    void ManageTestCase(UPlayFabTestCase* nextTestCase);
 
     // Run the Tests.
-    UFUNCTION(BlueprintCallable)
-    virtual void Run(const float InDeltaTime);
+    void Run(const float InDeltaTime);
 };

--- a/targets/UnrealMarketplacePlugin/examplesource/ExampleProject/Source/ExampleProject/PfTestActor.cpp.ejs
+++ b/targets/UnrealMarketplacePlugin/examplesource/ExampleProject/Source/ExampleProject/PfTestActor.cpp.ejs
@@ -7,11 +7,30 @@
 
 #include "Runtime/Engine/Classes/Engine/World.h"
 
-// Sets default values
 APfTestActor::APfTestActor()
 {
     // Set this actor to call Tick() every frame.  You can turn this off to improve performance if you don't need it.
     PrimaryActorTick.bCanEverTick = true;
+}
+
+TArray<UPlayFabTestContext*>& APfTestActor::GetSuiteTests()
+{
+    return suiteTests;
+}
+
+UPlayFabTestCase* APfTestActor::GetActiveTest()
+{
+    return activeTestCase;
+}
+
+void APfTestActor::SetActiveTest(UPlayFabTestCase* newTestCase)
+{
+    activeTestCase = newTestCase;
+}
+
+FString& APfTestActor::GetCachedSummary()
+{
+    return outputSummary;
 }
 
 // Called when the game starts or when spawned
@@ -19,8 +38,12 @@ void APfTestActor::BeginPlay()
 {
     Super::BeginPlay();
 
-    AddTestCase(NewObject<UPlayFabCppTests>());
-    AddTestCase(NewObject<UPlayFabBlueprintTests>());
+    pCppTests = NewObject<UPlayFabCppTests>();
+    pBpTests = NewObject<UPlayFabBlueprintTests>();
+
+    AddTestCase(pCppTests);
+    AddTestCase(pBpTests);
+
     _submitCloudScript = false;
 }
 
@@ -41,7 +64,7 @@ void APfTestActor::Tick(float DeltaTime)
     {
         auto pUploader = SpawnUploader(GetWorld());
         _submitCloudScript = true;
-        pUploader->UploadToCloudscript(SuiteTests);
+        pUploader->UploadToCloudscript(GetSuiteTests());
     }
 }
 

--- a/targets/UnrealMarketplacePlugin/examplesource/ExampleProject/Source/ExampleProject/PfTestActor.h.ejs
+++ b/targets/UnrealMarketplacePlugin/examplesource/ExampleProject/Source/ExampleProject/PfTestActor.h.ejs
@@ -9,22 +9,40 @@
 
 #include "PfTestActor.generated.h"
 
+class UPlayFabCppTests;
+class UPlayFabBlueprintTests;
+
 UCLASS()
 class APfTestActor : public AActor, public IPlayFabTestRunner
 {
     GENERATED_BODY()
 
 public:
-    ///////////////////// Actor stuff /////////////////////
     APfTestActor(); // Sets default values for this actor's properties
+
     virtual void BeginPlay() override; // Called when the game starts or when spawned
     virtual void Tick(float DeltaTime) override; // Called every frame
     virtual void EndPlay(const EEndPlayReason::Type reason) override;
 
+protected:
+    virtual TArray<UPlayFabTestContext*>& GetSuiteTests();
+    virtual UPlayFabTestCase* GetActiveTest();
+    virtual void SetActiveTest(UPlayFabTestCase* newTestCase);
+    virtual FString& GetCachedSummary();
+
 private:
-    UPROPERTY()
     bool _submitCloudScript;
 
-    UFUNCTION()
+    UPROPERTY()
+    TArray<UPlayFabTestContext*> suiteTests;
+    UPROPERTY()
+    UPlayFabTestCase* activeTestCase;
+    UPROPERTY()
+    FString outputSummary;
+    UPROPERTY()
+    UPlayFabCppTests* pCppTests;
+    UPROPERTY()
+    UPlayFabBlueprintTests* pBpTests;
+
     bool TestsAreComplete() const;
 };

--- a/targets/UnrealMarketplacePlugin/examplesource/ExampleProject/Source/ExampleProject/RunTestsCommandlet.cpp.ejs
+++ b/targets/UnrealMarketplacePlugin/examplesource/ExampleProject/Source/ExampleProject/RunTestsCommandlet.cpp.ejs
@@ -20,6 +20,26 @@ URunTestsCommandlet::URunTestsCommandlet()
     ShowErrorCount = true;
 }
 
+TArray<UPlayFabTestContext*>& URunTestsCommandlet::GetSuiteTests()
+{
+    return suiteTests;
+}
+
+UPlayFabTestCase* URunTestsCommandlet::GetActiveTest()
+{
+    return activeTestCase;
+}
+
+void URunTestsCommandlet::SetActiveTest(UPlayFabTestCase* newTestCase)
+{
+    activeTestCase = newTestCase;
+}
+
+FString& URunTestsCommandlet::GetCachedSummary()
+{
+    return outputSummary;
+}
+
 int32 URunTestsCommandlet::Main(const FString& Params)
 {
 #if ENGINE_MINOR_VERSION < 24
@@ -43,8 +63,11 @@ int32 URunTestsCommandlet::Main(const FString& Params)
         GIsRunning = false;
     }
 
-    AddTestCase(NewObject<UPlayFabCppTests>());
-    AddTestCase(NewObject<UPlayFabBlueprintTests>());
+    pCppTests = NewObject<UPlayFabCppTests>();
+    pBpTests = NewObject<UPlayFabBlueprintTests>();
+
+    AddTestCase(pCppTests);
+    AddTestCase(pBpTests);
 
     bool bPrintedTestSummary = false;
 
@@ -73,7 +96,7 @@ int32 URunTestsCommandlet::Main(const FString& Params)
                 UE_LOG(LogPlayFabExampleProject, Log, TEXT("Test Summary:\n%s"), *GenerateTestSummary());
                 bPrintedTestSummary = true;
                 pUploader = NewObject<ACloudScriptTestResultUploader>();
-                pUploader->UploadToCloudscript(SuiteTests);
+                pUploader->UploadToCloudscript(GetSuiteTests());
             }
         }
 

--- a/targets/UnrealMarketplacePlugin/examplesource/ExampleProject/Source/ExampleProject/RunTestsCommandlet.h.ejs
+++ b/targets/UnrealMarketplacePlugin/examplesource/ExampleProject/Source/ExampleProject/RunTestsCommandlet.h.ejs
@@ -22,6 +22,9 @@ namespace PlayFab
     }
 }
 
+class UPlayFabCppTests;
+class UPlayFabBlueprintTests;
+
 UCLASS()
 class URunTestsCommandlet : public UCommandlet, public IPlayFabTestRunner
 {
@@ -29,7 +32,23 @@ class URunTestsCommandlet : public UCommandlet, public IPlayFabTestRunner
 
 private:
     UPROPERTY()
+    TArray<UPlayFabTestContext*> suiteTests;
+    UPROPERTY()
+    UPlayFabTestCase* activeTestCase;
+    UPROPERTY()
+    FString outputSummary;
+    UPROPERTY()
     ACloudScriptTestResultUploader* pUploader;
+    UPROPERTY()
+    UPlayFabCppTests* pCppTests;
+    UPROPERTY()
+    UPlayFabBlueprintTests* pBpTests;
+
+protected:
+    virtual TArray<UPlayFabTestContext*>& GetSuiteTests();
+    virtual UPlayFabTestCase* GetActiveTest();
+    virtual void SetActiveTest(UPlayFabTestCase* newTestCase);
+    virtual FString& GetCachedSummary();
 
 public:
     // Default CTor


### PR DESCRIPTION
As an Interface, rather than a UObject, IPlayFabTestRunner can't maintain the memory uchain
So, convert static fields on that to virtual accessors, and move the actual underlying object responsibility to the child objects, which will implement the interface.
Some objects were created without maintaining a reference to them, so add member properties, and tag them with UPROPERTY

Minor Refactors:
convert some dynamic_cast's to static_cast
Remove a bunch of unnecessary UFUNCTION's
Remove a handful of unnecessary virtual tags
Move some function implementations from .h file to .cpp file for EE.
Slight consistency improvement regarding placement of UPROPERTY tag.
Simplify TestRunner methods for clarity

You can see the template output the changes here:
https://github.com/PlayFab/UnrealMarketplacePlugin/pull/16/files