### PR TITLE
Fix TestTitleData crash

### DIFF
--- a/targets/UnrealMarketplacePlugin/examplesource/ExampleProject/Plugins/PlayFab/Source/PlayFab/Private/Tests/PlayFabBlueprintTests.cpp.ejs
+++ b/targets/UnrealMarketplacePlugin/examplesource/ExampleProject/Plugins/PlayFab/Source/PlayFab/Private/Tests/PlayFabBlueprintTests.cpp.ejs
@@ -10,7 +10,7 @@
 #include "PlayFabServerApi.h"
 #include "TestFramework/PlayFabTestRunner.h"
 
-void UPlayFabBlueprintTests::SetTestTitleData(UTestTitleDataLoader& testTitleData)
+void UPlayFabBlueprintTests::SetTestTitleData(const UTestTitleDataLoader& testTitleData)
 {
     UserEmail = testTitleData.userEmail;
 }

--- a/targets/UnrealMarketplacePlugin/examplesource/ExampleProject/Plugins/PlayFab/Source/PlayFab/Private/Tests/PlayFabBlueprintTests.cpp.ejs
+++ b/targets/UnrealMarketplacePlugin/examplesource/ExampleProject/Plugins/PlayFab/Source/PlayFab/Private/Tests/PlayFabBlueprintTests.cpp.ejs
@@ -4,59 +4,22 @@
 #include "TestFramework/PlayFabTestContext.h"
 
 #include "IPlayFab.h"
-
 #include "PlayFabClientApi.h"
 #include "PlayFabAuthenticationApi.h"
 #include "PlayFabDataApi.h"
 #include "PlayFabServerApi.h"
+#include "TestFramework/PlayFabTestRunner.h"
+
+void UPlayFabBlueprintTests::SetTestTitleData(UTestTitleDataLoader& testTitleData)
+{
+    UserEmail = testTitleData.userEmail;
+}
 
 void UPlayFabBlueprintTests::ClassSetUp()
 {
-    // README:
-    // modify the TEST_TITLE_DATA_LOC to a location of a testTitleData.json file
-    // The format of this file is described in the sdk readme
-    //  - OR -
-    // Comment the "return false;" below, and
-    //   Fill in all the variables under: POPULATE THIS SECTION WITH REAL INFORMATION
-
     IPlayFab* playFabSettings = &(IPlayFab::Get());
-
     playFabSettings->setAdvertisingIdType(TEXT(""));
     playFabSettings->setAdvertisingIdValue(TEXT(""));
-
-    if (!FPaths::FileExists(TEST_TITLE_DATA_LOC))
-    {
-        // Prefer to load path from environment variable, if present
-#if PLATFORM_WINDOWS
-        char* envPath = nullptr;
-        size_t envPathStrLen;
-        errno_t err = _dupenv_s(&envPath, &envPathStrLen, "PF_TEST_TITLE_DATA_JSON");
-        if (err == 0 && envPath != nullptr)
-            TEST_TITLE_DATA_LOC = FString(ANSI_TO_TCHAR(envPath));
-        free(envPath); // It's OK to call free with NULL
-#endif
-    }
-
-    FString titleDataJson;
-    if (FFileHelper::LoadFileToString(titleDataJson, *TEST_TITLE_DATA_LOC))
-    {
-        TSharedPtr<FJsonObject> JsonObject;
-        TSharedRef<TJsonReader<>> Reader = TJsonReaderFactory<>::Create(titleDataJson);
-        FJsonSerializer::Deserialize(Reader, JsonObject);
-        playFabSettings->setGameTitleId(JsonObject->GetStringField(TEXT("titleId")));
-        playFabSettings->setDeveloperSecretKey(JsonObject->GetStringField(TEXT("developerSecretKey")));
-        UserEmail = JsonObject->GetStringField(TEXT("userEmail"));
-    }
-    else
-    {
-        // Add your real test data here and remove this return if you want to skip testTitleData
-        return;
-
-        // Populate this section with real information, if you're not using the testTitleData.json file (or are using a device)
-        playFabSettings->setGameTitleId(TEXT("")); // Without a titleId, your game will do terrible things (usually crash)
-        playFabSettings->setDeveloperSecretKey(TEXT("")); // Non-client api calls will all crash without a secret key
-        UserEmail = "yourEmail"; // This is the email for the user
-    }
 }
 
 <% if (hasClientOptions) { %>

--- a/targets/UnrealMarketplacePlugin/examplesource/ExampleProject/Plugins/PlayFab/Source/PlayFab/Private/Tests/PlayFabCppTests.cpp.ejs
+++ b/targets/UnrealMarketplacePlugin/examplesource/ExampleProject/Plugins/PlayFab/Source/PlayFab/Private/Tests/PlayFabCppTests.cpp.ejs
@@ -10,7 +10,7 @@
 #include "Core/PlayFabAuthenticationAPI.h"
 #include "TestFramework/PlayFabTestRunner.h"
 
-void UPlayFabCppTests::SetTestTitleData(UTestTitleDataLoader& testTitleData)
+void UPlayFabCppTests::SetTestTitleData(const UTestTitleDataLoader& testTitleData)
 {
     UserEmail = testTitleData.userEmail;
 }

--- a/targets/UnrealMarketplacePlugin/examplesource/ExampleProject/Plugins/PlayFab/Source/PlayFab/Private/Tests/PlayFabCppTests.cpp.ejs
+++ b/targets/UnrealMarketplacePlugin/examplesource/ExampleProject/Plugins/PlayFab/Source/PlayFab/Private/Tests/PlayFabCppTests.cpp.ejs
@@ -8,62 +8,40 @@
 #include "Core/PlayFabServerAPI.h"
 #include "Core/PlayFabDataAPI.h"
 #include "Core/PlayFabAuthenticationAPI.h"
+#include "TestFramework/PlayFabTestRunner.h"
+
+void UPlayFabCppTests::SetTestTitleData(UTestTitleDataLoader& testTitleData)
+{
+    UserEmail = testTitleData.userEmail;
+}
 
 void UPlayFabCppTests::ClassSetUp()
 {
-    bool success = true;
-
-    FString jsonInput;
-    FString filename = TEST_TITLE_DATA_LOC;
-
-    if (!FPaths::FileExists(filename))
-    {
-        // Prefer to load path from environment variable, if present
-#if PLATFORM_WINDOWS
-        char* envPath = nullptr;
-        size_t envPathStrLen;
-        errno_t err = _dupenv_s(&envPath, &envPathStrLen, "PF_TEST_TITLE_DATA_JSON");
-        if (err == 0 && envPath != nullptr)
-            filename = FString(ANSI_TO_TCHAR(envPath));
-
-        if (envPath != nullptr)
-            free(envPath);
-#endif
-    }
-
-    success &= FFileHelper::LoadFileToString(jsonInput, *filename);
-
-    TSharedPtr<FJsonObject> jsonParsed = nullptr;
-    if (success)
-    {
-        TSharedRef<TJsonReader<>> jsonReader = TJsonReaderFactory<>::Create(jsonInput);
-        success &= FJsonSerializer::Deserialize(jsonReader, jsonParsed);
-    }
-
-    if (success) success &= jsonParsed->TryGetStringField("titleId", TitleId);
-    if (success) success &= jsonParsed->TryGetStringField("developerSecretKey", DevSecretKey);
-    if (success) success &= jsonParsed->TryGetStringField("userEmail", UserEmail);
-
-    if (!success)
-        return;
+    IPlayFab* playFabSettings = &(IPlayFab::Get());
+    playFabSettings->setAdvertisingIdType(TEXT(""));
+    playFabSettings->setAdvertisingIdValue(TEXT(""));
 
     ClientAPI = IPlayFabModuleInterface::Get().GetClientAPI();
     ServerAPI = IPlayFabModuleInterface::Get().GetServerAPI();
     DataAPI = IPlayFabModuleInterface::Get().GetDataAPI();
     AuthenticationAPI = IPlayFabModuleInterface::Get().GetAuthenticationAPI();
-
-    checkf(ClientAPI.IsValid(), TEXT("The ClientAPI reports itself as invalid."));
-    checkf(ServerAPI.IsValid(), TEXT("The ServerAPI reports itself as invalid."));
-    checkf(DataAPI.IsValid(), TEXT("The DataAPI reports itself as invalid."));
-    checkf(AuthenticationAPI.IsValid(), TEXT("The AuthenticationAPI reports itself as invalid."));
-
-    ServerAPI->SetTitleId(TitleId);
-    ServerAPI->SetDevSecretKey(DevSecretKey);
 }
 
 void UPlayFabCppTests::SetUp(UPlayFabTestContext* testContext)
 {
     CurrentTestContext = testContext;
+
+    if (ServerAPI == nullptr || !ServerAPI.IsValid())
+    {
+        testContext->EndTest(PlayFabApiTestFinishState::SKIPPED, "Could not load the PlayFab API");
+    }
+
+    IPlayFab* playFabSettings = &(IPlayFab::Get());
+    FString titleId = playFabSettings->getGameTitleId();
+    if (titleId.Len() == 0)
+    {
+        testContext->EndTest(PlayFabApiTestFinishState::SKIPPED, "Could not load testTitleData.json");
+    }
 }
 
 void UPlayFabCppTests::OnSharedError(const PlayFab::FPlayFabCppError& InError) const

--- a/targets/UnrealMarketplacePlugin/examplesource/ExampleProject/Plugins/PlayFab/Source/PlayFab/Public/Tests/PlayFabBlueprintTests.h.ejs
+++ b/targets/UnrealMarketplacePlugin/examplesource/ExampleProject/Plugins/PlayFab/Source/PlayFab/Public/Tests/PlayFabBlueprintTests.h.ejs
@@ -26,7 +26,7 @@ public:
 
     // #### PlayFab TestSuite Interface ####
 
-    virtual void SetTestTitleData(UTestTitleDataLoader& testTitleData) override;
+    virtual void SetTestTitleData(const UTestTitleDataLoader& testTitleData) override;
 
     virtual void ClassSetUp() override;
 

--- a/targets/UnrealMarketplacePlugin/examplesource/ExampleProject/Plugins/PlayFab/Source/PlayFab/Public/Tests/PlayFabBlueprintTests.h.ejs
+++ b/targets/UnrealMarketplacePlugin/examplesource/ExampleProject/Plugins/PlayFab/Source/PlayFab/Public/Tests/PlayFabBlueprintTests.h.ejs
@@ -21,8 +21,12 @@ class PLAYFAB_API UPlayFabBlueprintTests : public UPlayFabTestCase
 
 public:
     int testMessageInt;
+    UPROPERTY()
+    FString UserEmail;
 
     // #### PlayFab TestSuite Interface ####
+
+    virtual void SetTestTitleData(UTestTitleDataLoader& testTitleData) override;
 
     virtual void ClassSetUp() override;
 

--- a/targets/UnrealMarketplacePlugin/examplesource/ExampleProject/Plugins/PlayFab/Source/PlayFab/Public/Tests/PlayFabCppTests.h.ejs
+++ b/targets/UnrealMarketplacePlugin/examplesource/ExampleProject/Plugins/PlayFab/Source/PlayFab/Public/Tests/PlayFabCppTests.h.ejs
@@ -67,7 +67,8 @@ public:
         InOutTests.ADD_TEST(Get Entity Token (CPP), GetEntityToken);
         InOutTests.ADD_TEST(Object API (CPP), ObjectAPI);
     }
-    
+
+    virtual void SetTestTitleData(UTestTitleDataLoader& testTitleData) override;
     virtual void ClassSetUp() override;
     virtual void SetUp(UPlayFabTestContext* testContext) override;
 
@@ -78,6 +79,8 @@ private:
     PlayFabServerPtr ServerAPI;
     PlayFabAuthenticationPtr AuthenticationAPI;
     PlayFabDataPtr DataAPI;
+    UPROPERTY()
+    FString UserEmail;
 
     /**
      * Shared Error callback.

--- a/targets/UnrealMarketplacePlugin/examplesource/ExampleProject/Plugins/PlayFab/Source/PlayFab/Public/Tests/PlayFabCppTests.h.ejs
+++ b/targets/UnrealMarketplacePlugin/examplesource/ExampleProject/Plugins/PlayFab/Source/PlayFab/Public/Tests/PlayFabCppTests.h.ejs
@@ -68,7 +68,7 @@ public:
         InOutTests.ADD_TEST(Object API (CPP), ObjectAPI);
     }
 
-    virtual void SetTestTitleData(UTestTitleDataLoader& testTitleData) override;
+    virtual void SetTestTitleData(const UTestTitleDataLoader& testTitleData) override;
     virtual void ClassSetUp() override;
     virtual void SetUp(UPlayFabTestContext* testContext) override;
 

--- a/targets/UnrealMarketplacePlugin/examplesource/ExampleProject/Plugins/PlayFab/Source/PlayFabCommon/Private/TestFramework/PlayFabTestRunner.cpp.ejs
+++ b/targets/UnrealMarketplacePlugin/examplesource/ExampleProject/Plugins/PlayFab/Source/PlayFabCommon/Private/TestFramework/PlayFabTestRunner.cpp.ejs
@@ -2,6 +2,8 @@
 
 #include "TestFramework/PlayFabTestRunner.h"
 
+#include "PlayFab/Public/IPlayFab.h"
+#include "PlayFab/Private/PlayFabPrivate.h"
 #include "TestFramework/PlayFabTestCase.h"
 #include "TestFramework/PlayFabTestContext.h"
 
@@ -16,10 +18,87 @@ UPlayFabTestRunner::UPlayFabTestRunner(const FObjectInitializer& ObjectInitializ
 {
 }
 
+UTestTitleDataLoader::UTestTitleDataLoader()
+{
+    isValid = LoadTestTitleData();
+}
+
+bool UTestTitleDataLoader::LoadFromCode()
+{
+    // README:
+    // modify the TEST_TITLE_DATA_LOC to a location of a testTitleData.json file
+    // The format of this file is described in the sdk readme
+    //  - OR -
+    // Comment the "return false;" below, and
+    //   Fill in all the variables under: POPULATE THIS SECTION WITH REAL INFORMATION
+
+    return false;
+
+    titleId = "<your title id>";
+    developerSecretKey = "<your title secret>";
+    userEmail = "<a valid email linked to LoginWithEmailAddress>";
+
+    return true;
+}
+
+bool UTestTitleDataLoader::LoadFromFile()
+{
+    bool success = true;
+
+    FString jsonInput;
+    FString filename = FPaths::ProjectContentDir() + TEXT("/TestTitleData/testTitleData.json");
+
+    if (!FPaths::FileExists(filename))
+    {
+        // Prefer to load path from environment variable, if present
+#if PLATFORM_WINDOWS
+        char* envPath = nullptr;
+        size_t envPathStrLen;
+        errno_t err = _dupenv_s(&envPath, &envPathStrLen, "PF_TEST_TITLE_DATA_JSON");
+        if (err == 0 && envPath != nullptr)
+            filename = FString(ANSI_TO_TCHAR(envPath));
+        if (envPath != nullptr)
+            free(envPath);
+#endif
+    }
+
+    FString titleDataJson;
+    success &= FPaths::FileExists(filename) && FFileHelper::LoadFileToString(titleDataJson, *filename);
+    if (!success)
+        return success;
+
+    TSharedPtr<FJsonObject> ttdJson;
+    TSharedRef<TJsonReader<>> Reader = TJsonReaderFactory<>::Create(titleDataJson);
+    FJsonSerializer::Deserialize(Reader, ttdJson);
+    success &= ttdJson->TryGetStringField("titleId", titleId);
+    success &= ttdJson->TryGetStringField("developerSecretKey", developerSecretKey);
+    success &= ttdJson->TryGetStringField("userEmail", userEmail);
+
+    userEmail.Len();
+
+    return success;
+}
+
+void UTestTitleDataLoader::ApplyToSettings()
+{
+    // Settings are globally shared
+    IPlayFab* playFabSettings = &(IPlayFab::Get());
+    playFabSettings->setGameTitleId(titleId);
+    playFabSettings->setDeveloperSecretKey(developerSecretKey);
+}
+
+bool UTestTitleDataLoader::LoadTestTitleData()
+{
+    bool result = LoadFromFile() || LoadFromCode();
+    if (result)
+        ApplyToSettings();
+    return result;
+}
+
 FString IPlayFabTestRunner::GenerateTestSummary()
 {
-    auto& SuiteTests = GetSuiteTests();
-    auto& OutputSummary = GetCachedSummary();
+    TArray<UPlayFabTestContext*>& SuiteTests = GetSuiteTests();
+    FString& OutputSummary = GetCachedSummary();
 
     OutputSummary.Empty(SUMMARY_INIT_BUFFER_SIZE); // Set the capacity to handle everything we're about to put into it
 
@@ -61,8 +140,11 @@ void IPlayFabTestRunner::AddTestCase(UPlayFabTestCase* InTestCase)
     if (SuiteState != PlayFabApiTestActiveState::PENDING)
         return;
 
-    auto& SuiteTests = GetSuiteTests();
+    TArray<UPlayFabTestContext*>& SuiteTests = GetSuiteTests();
     InTestCase->GetTests(SuiteTests);
+    UTestTitleDataLoader& testTitleData = GetCachedTitleData();
+    if (testTitleData.isValid)
+        InTestCase->SetTestTitleData(testTitleData);
 }
 
 void IPlayFabTestRunner::ManageTestCase(UPlayFabTestCase* nextTestCase)
@@ -87,7 +169,7 @@ void IPlayFabTestRunner::Run(const float InDeltaTime)
     if (SuiteState != PlayFabApiTestActiveState::PENDING)
         return;
 
-    auto& SuiteTests = GetSuiteTests();
+    TArray<UPlayFabTestContext*>& SuiteTests = GetSuiteTests();
     const auto Index = CurrentTestIndex;
     if (Index < SuiteTests.Num())
     {
@@ -96,18 +178,18 @@ void IPlayFabTestRunner::Run(const float InDeltaTime)
 
         ManageTestCase(CurrentTestCase);
 
-        if (CurrentTestData->activeState == PlayFabApiTestActiveState::PENDING
-            && CurrentTestData->activeState != PlayFabApiTestActiveState::ACTIVE)
+        if (CurrentTestData->activeState == PlayFabApiTestActiveState::PENDING)
         {
             numberOfTests++;
 
             UE_LOG(LogPlayFabCommon, Log, TEXT("Starting test: %s"), *CurrentTestData->testName);
-
             CurrentTestCase->SetUp(CurrentTestData);
-            CurrentTestData->activeState = PlayFabApiTestActiveState::ACTIVE;
-
             CurrentTestData->startTime = FDateTime::UtcNow();
-            CurrentTestData->testFunc.Execute(CurrentTestData);
+            if (CurrentTestData->activeState == PlayFabApiTestActiveState::PENDING)
+            {
+                CurrentTestData->activeState = PlayFabApiTestActiveState::ACTIVE;
+                CurrentTestData->testFunc.Execute(CurrentTestData);
+            }
         }
 
         if (CurrentTestData->GetDurationInSeconds() > TEST_TIMEOUT_SECONDS)
@@ -115,8 +197,7 @@ void IPlayFabTestRunner::Run(const float InDeltaTime)
             CurrentTestData->EndTest(PlayFabApiTestFinishState::TIMEDOUT, TEXT("Timed Out"));
         }
 
-        if (CurrentTestData->activeState == PlayFabApiTestActiveState::ACTIVE
-            && CurrentTestData->activeState != PlayFabApiTestActiveState::COMPLETE)
+        if (CurrentTestData->activeState == PlayFabApiTestActiveState::ACTIVE)
         {
             CurrentTestCase->Tick(CurrentTestData);
         }
@@ -124,10 +205,8 @@ void IPlayFabTestRunner::Run(const float InDeltaTime)
         {
             switch (CurrentTestData->finishState)
             {
-            case PlayFabApiTestFinishState::PASSED: passedTests++;
-                break;
-            case PlayFabApiTestFinishState::FAILED: failedTests++;
-                break;
+            case PlayFabApiTestFinishState::PASSED: passedTests++; break;
+            case PlayFabApiTestFinishState::FAILED: failedTests++; break;
             default: break;
             }
 

--- a/targets/UnrealMarketplacePlugin/examplesource/ExampleProject/Plugins/PlayFab/Source/PlayFabCommon/Private/TestFramework/PlayFabTestRunner.cpp.ejs
+++ b/targets/UnrealMarketplacePlugin/examplesource/ExampleProject/Plugins/PlayFab/Source/PlayFabCommon/Private/TestFramework/PlayFabTestRunner.cpp.ejs
@@ -145,7 +145,7 @@ void IPlayFabTestRunner::AddTestCase(UPlayFabTestCase* InTestCase)
 
     TArray<UPlayFabTestContext*>& SuiteTests = GetSuiteTests();
     InTestCase->GetTests(SuiteTests);
-    UTestTitleDataLoader& testTitleData = GetCachedTitleData();
+    const UTestTitleDataLoader& testTitleData = GetCachedTitleData();
     if (testTitleData.isValid)
         InTestCase->SetTestTitleData(testTitleData);
 }

--- a/targets/UnrealMarketplacePlugin/examplesource/ExampleProject/Plugins/PlayFab/Source/PlayFabCommon/Private/TestFramework/PlayFabTestRunner.cpp.ejs
+++ b/targets/UnrealMarketplacePlugin/examplesource/ExampleProject/Plugins/PlayFab/Source/PlayFabCommon/Private/TestFramework/PlayFabTestRunner.cpp.ejs
@@ -46,8 +46,6 @@ bool UTestTitleDataLoader::LoadFromCode()
 
 bool UTestTitleDataLoader::LoadFromFile()
 {
-    bool success = true;
-
     FString jsonInput;
     FString filename = FPaths::ProjectContentDir() + TEXT("/TestTitleData/testTitleData.json");
 
@@ -66,18 +64,16 @@ bool UTestTitleDataLoader::LoadFromFile()
     }
 
     FString titleDataJson;
-    success &= FPaths::FileExists(filename) && FFileHelper::LoadFileToString(titleDataJson, *filename);
+    bool success = FPaths::FileExists(filename) && FFileHelper::LoadFileToString(titleDataJson, *filename);
     if (!success)
         return success;
 
     TSharedPtr<FJsonObject> ttdJson;
     TSharedRef<TJsonReader<>> Reader = TJsonReaderFactory<>::Create(titleDataJson);
     FJsonSerializer::Deserialize(Reader, ttdJson);
-    success &= ttdJson->TryGetStringField("titleId", titleId);
-    success &= ttdJson->TryGetStringField("developerSecretKey", developerSecretKey);
-    success &= ttdJson->TryGetStringField("userEmail", userEmail);
-
-    userEmail.Len();
+    success &= ttdJson->TryGetStringField("titleId", titleId) && titleId.Len() > 0;
+    success &= ttdJson->TryGetStringField("developerSecretKey", developerSecretKey) && developerSecretKey.Len() > 0;
+    success &= ttdJson->TryGetStringField("userEmail", userEmail) && userEmail.Len() > 0;
 
     return success;
 }
@@ -92,10 +88,12 @@ void UTestTitleDataLoader::ApplyToSettings()
 
 bool UTestTitleDataLoader::LoadTestTitleData()
 {
-    bool result = LoadFromFile() || LoadFromCode();
-    if (result)
+    bool loadSuccessful = LoadFromFile() || LoadFromCode();
+    if (loadSuccessful)
+    {
         ApplyToSettings();
-    return result;
+    }
+    return loadSuccessful;
 }
 
 FString IPlayFabTestRunner::GenerateTestSummary()

--- a/targets/UnrealMarketplacePlugin/examplesource/ExampleProject/Plugins/PlayFab/Source/PlayFabCommon/Private/TestFramework/PlayFabTestRunner.cpp.ejs
+++ b/targets/UnrealMarketplacePlugin/examplesource/ExampleProject/Plugins/PlayFab/Source/PlayFabCommon/Private/TestFramework/PlayFabTestRunner.cpp.ejs
@@ -26,11 +26,14 @@ UTestTitleDataLoader::UTestTitleDataLoader()
 bool UTestTitleDataLoader::LoadFromCode()
 {
     // README:
-    // modify the TEST_TITLE_DATA_LOC to a location of a testTitleData.json file
-    // The format of this file is described in the sdk readme
-    //  - OR -
-    // Comment the "return false;" below, and
-    //   Fill in all the variables under: POPULATE THIS SECTION WITH REAL INFORMATION
+    //   In order for tests to run, you need a valid testTitleData.json file
+    //   Format specification here: https://github.com/PlayFab/SDKGenerator/blob/master/JenkinsConsoleUtility/testTitleData.md
+    // Option 1: You can drop a testTitleData.json file into this location in your Unreal Project:
+    //   FPaths::ProjectContentDir() + TEXT("/TestTitleData/testTitleData.json");
+    // Option 2: You can specify the PF_TEST_TITLE_DATA_JSON environment variable
+    //   (Windows or Linux), containing the full path of a testTitleData.json file, anywhere on your computer
+    // Option 3:
+    //   Delete this "return false;", and fill in the code variables below with your title's information
 
     return false;
 

--- a/targets/UnrealMarketplacePlugin/examplesource/ExampleProject/Plugins/PlayFab/Source/PlayFabCommon/Public/TestFramework/PlayFabTestCase.h.ejs
+++ b/targets/UnrealMarketplacePlugin/examplesource/ExampleProject/Plugins/PlayFab/Source/PlayFabCommon/Public/TestFramework/PlayFabTestCase.h.ejs
@@ -50,7 +50,7 @@ public:
     /**
      * Before testing, if these tests require TesTitleData, they'll be given by this method
      */
-    virtual void SetTestTitleData(UTestTitleDataLoader& testTitleData) {}
+    virtual void SetTestTitleData(const UTestTitleDataLoader& testTitleData) {}
 
     /**
      * During testing, this is the first function that will be called for each TestCase.

--- a/targets/UnrealMarketplacePlugin/examplesource/ExampleProject/Plugins/PlayFab/Source/PlayFabCommon/Public/TestFramework/PlayFabTestCase.h.ejs
+++ b/targets/UnrealMarketplacePlugin/examplesource/ExampleProject/Plugins/PlayFab/Source/PlayFabCommon/Public/TestFramework/PlayFabTestCase.h.ejs
@@ -7,6 +7,7 @@
 #include "PlayFabTestCase.generated.h"
 
 class UPlayFabTestContext;
+class UTestTitleDataLoader;
 
 /**
  * A macro to quickly add a test to a TArray<UPlayFabTestContext*>.
@@ -24,8 +25,6 @@ protected:
     // A bunch of constants: load these from testTitleData.json
     // TODO: Should be moved out of UPlayFabTestCase.
     UPROPERTY()
-    FString TEST_TITLE_DATA_LOC = FPaths::ProjectContentDir() + TEXT("/TestTitleData/testTitleData.json");;
-    UPROPERTY()
     FString TEST_DATA_KEY = "testCounter";
     UPROPERTY()
     FString TEST_STAT_NAME = "str";
@@ -38,13 +37,6 @@ protected:
     UPROPERTY()
     FDateTime testMessageTime;
 
-    UPROPERTY()
-    FString TitleId;
-    UPROPERTY()
-    FString DevSecretKey;
-    UPROPERTY()
-    FString UserEmail;
-
 public:
     // Default Constructor.
     UPlayFabTestCase();
@@ -53,39 +45,44 @@ public:
      * Before testing, this function is called to gather the list of tests to run for each TestCase.
      * It is not considered part of any test. A failure or exception in this method will halt the test framework.
      */
-    virtual void GetTests(TArray<UPlayFabTestContext*>& InTestList) { }
+    virtual void GetTests(TArray<UPlayFabTestContext*>& InTestList) {}
+
+    /**
+     * Before testing, if these tests require TesTitleData, they'll be given by this method
+     */
+    virtual void SetTestTitleData(UTestTitleDataLoader& testTitleData) {}
 
     /**
      * During testing, this is the first function that will be called for each TestCase.
      * This is run exactly once for this type.
      */
-    virtual void ClassSetUp() { }
+    virtual void ClassSetUp() {}
 
     /**
      * During testing, this will be called once before every test function.
      * This is run once for each test.
      * This is considered part of the active test. A failure or exception in this method will be considered a failure for the active test.
      */
-    virtual void SetUp(UPlayFabTestContext* /* testContext */) { }
+    virtual void SetUp(UPlayFabTestContext* /* testContext */) {}
 
     /**
      * During testing, this will be called every tick that a test is asynchronous.
      * This is run every tick until testContext.EndTest() is called, or until the test times out.
      * This is considered part of the active test. A failure or exception in this method will be considered a failure for the active test.
      */
-    virtual void Tick(UPlayFabTestContext* /* testContext */) { }
+    virtual void Tick(UPlayFabTestContext* /* testContext */) {}
 
     /**
      * During testing, this will be called once after every test function.
      * This is run once for each test.
      * This is considered part of the active test. A failure or exception in this method will be considered a failure for the active test.
      */
-    virtual void TearDown(UPlayFabTestContext* /* testContext */) { }
+    virtual void TearDown(UPlayFabTestContext* /* testContext */) {}
 
     /**
      * During testing, this is the last function that will be called for each TestCase.
      * This is run exactly once for this type.
      * It is not considered part of any test. A failure or exception in this method will halt the test framework.
      */
-    virtual void ClassTearDown() { }
+    virtual void ClassTearDown() {}
 };

--- a/targets/UnrealMarketplacePlugin/examplesource/ExampleProject/Plugins/PlayFab/Source/PlayFabCommon/Public/TestFramework/PlayFabTestRunner.h.ejs
+++ b/targets/UnrealMarketplacePlugin/examplesource/ExampleProject/Plugins/PlayFab/Source/PlayFabCommon/Public/TestFramework/PlayFabTestRunner.h.ejs
@@ -17,6 +17,29 @@ class PLAYFABCOMMON_API UPlayFabTestRunner : public UInterface
     GENERATED_UINTERFACE_BODY()
 };
 
+UCLASS()
+class PLAYFABCOMMON_API UTestTitleDataLoader : public UObject
+{
+    GENERATED_BODY()
+
+private:
+    bool LoadFromCode();
+    bool LoadFromFile();
+    void ApplyToSettings();
+    bool LoadTestTitleData();
+
+public:
+    UTestTitleDataLoader();
+
+    bool isValid;
+    UPROPERTY()
+    FString titleId;
+    UPROPERTY()
+    FString developerSecretKey;
+    UPROPERTY()
+    FString userEmail;
+};
+
 class UPlayFabTestCase;
 
 class PLAYFABCOMMON_API IPlayFabTestRunner
@@ -29,6 +52,7 @@ protected:
 
     virtual TArray<UPlayFabTestContext*>& GetSuiteTests() = 0;
     virtual UPlayFabTestCase* GetActiveTest() = 0;
+    virtual UTestTitleDataLoader& GetCachedTitleData() = 0;
     virtual void SetActiveTest(UPlayFabTestCase* newTestCase) = 0;
     virtual FString& GetCachedSummary() = 0;
 

--- a/targets/UnrealMarketplacePlugin/examplesource/ExampleProject/Source/ExampleProject/PfTestActor.cpp.ejs
+++ b/targets/UnrealMarketplacePlugin/examplesource/ExampleProject/Source/ExampleProject/PfTestActor.cpp.ejs
@@ -23,6 +23,13 @@ UPlayFabTestCase* APfTestActor::GetActiveTest()
     return activeTestCase;
 }
 
+UTestTitleDataLoader& APfTestActor::GetCachedTitleData()
+{
+    if (ttdLoader == nullptr)
+        ttdLoader = NewObject<UTestTitleDataLoader>();
+    return *ttdLoader;
+}
+
 void APfTestActor::SetActiveTest(UPlayFabTestCase* newTestCase)
 {
     activeTestCase = newTestCase;

--- a/targets/UnrealMarketplacePlugin/examplesource/ExampleProject/Source/ExampleProject/PfTestActor.h.ejs
+++ b/targets/UnrealMarketplacePlugin/examplesource/ExampleProject/Source/ExampleProject/PfTestActor.h.ejs
@@ -27,6 +27,7 @@ public:
 protected:
     virtual TArray<UPlayFabTestContext*>& GetSuiteTests();
     virtual UPlayFabTestCase* GetActiveTest();
+    virtual UTestTitleDataLoader& GetCachedTitleData();
     virtual void SetActiveTest(UPlayFabTestCase* newTestCase);
     virtual FString& GetCachedSummary();
 
@@ -37,6 +38,8 @@ private:
     TArray<UPlayFabTestContext*> suiteTests;
     UPROPERTY()
     UPlayFabTestCase* activeTestCase;
+    UPROPERTY()
+    UTestTitleDataLoader* ttdLoader;
     UPROPERTY()
     FString outputSummary;
     UPROPERTY()

--- a/targets/UnrealMarketplacePlugin/examplesource/ExampleProject/Source/ExampleProject/RunTestsCommandlet.cpp.ejs
+++ b/targets/UnrealMarketplacePlugin/examplesource/ExampleProject/Source/ExampleProject/RunTestsCommandlet.cpp.ejs
@@ -30,6 +30,13 @@ UPlayFabTestCase* URunTestsCommandlet::GetActiveTest()
     return activeTestCase;
 }
 
+UTestTitleDataLoader& URunTestsCommandlet::GetCachedTitleData()
+{
+    if (ttdLoader == nullptr)
+        ttdLoader = NewObject<UTestTitleDataLoader>();
+    return *ttdLoader;
+}
+
 void URunTestsCommandlet::SetActiveTest(UPlayFabTestCase* newTestCase)
 {
     activeTestCase = newTestCase;

--- a/targets/UnrealMarketplacePlugin/examplesource/ExampleProject/Source/ExampleProject/RunTestsCommandlet.h.ejs
+++ b/targets/UnrealMarketplacePlugin/examplesource/ExampleProject/Source/ExampleProject/RunTestsCommandlet.h.ejs
@@ -24,6 +24,7 @@ namespace PlayFab
 
 class UPlayFabCppTests;
 class UPlayFabBlueprintTests;
+class UTestTitleDataLoader;
 
 UCLASS()
 class URunTestsCommandlet : public UCommandlet, public IPlayFabTestRunner
@@ -36,6 +37,8 @@ private:
     UPROPERTY()
     UPlayFabTestCase* activeTestCase;
     UPROPERTY()
+    UTestTitleDataLoader* ttdLoader;
+    UPROPERTY()
     FString outputSummary;
     UPROPERTY()
     ACloudScriptTestResultUploader* pUploader;
@@ -47,6 +50,7 @@ private:
 protected:
     virtual TArray<UPlayFabTestContext*>& GetSuiteTests();
     virtual UPlayFabTestCase* GetActiveTest();
+    virtual UTestTitleDataLoader& GetCachedTitleData();
     virtual void SetActiveTest(UPlayFabTestCase* newTestCase);
     virtual FString& GetCachedSummary();
 

--- a/targets/UnrealMarketplacePlugin/source/PlayFab/Source/PlayFab/Private/PlayFabPrivate.h
+++ b/targets/UnrealMarketplacePlugin/source/PlayFab/Source/PlayFab/Private/PlayFabPrivate.h
@@ -21,4 +21,4 @@
 DECLARE_LOG_CATEGORY_EXTERN(LogPlayFab, Log, All);
 DECLARE_LOG_CATEGORY_EXTERN(LogPlayFabTests, Log, All);
 
-#include "IPlayFab.h"
+#include "PlayFab/Public/IPlayFab.h"

--- a/targets/cpp-cocos2dx/ExampleTemplate/Classes/PlayFabApiTest.h
+++ b/targets/cpp-cocos2dx/ExampleTemplate/Classes/PlayFabApiTest.h
@@ -320,7 +320,6 @@ namespace PlayFabApiTest
         static PlayFabSettings* playFabSettings;
 
         // A bunch of constants loaded from testTitleData.json
-        static std::string TEST_TITLE_DATA_LOC;
         static std::string userEmail;
         const static std::string TEST_DATA_KEY;
         const static std::string TEST_STAT_NAME;
@@ -333,55 +332,6 @@ namespace PlayFabApiTest
 
         static bool ClassSetup()
         {
-            // README:
-            // Create an environment variable PF_TEST_TITLE_DATA_JSON, and set it to the location of a valid testTitleData.json file
-            // The format of this file is described in the sdk readme
-            //  - OR -
-            // Comment the "return false;" below, and
-            //   Fill in all the variables under: POPULATE THIS SECTION WITH REAL INFORMATION
-
-#if (CC_TARGET_PLATFORM == CC_PLATFORM_WIN32) // Env vars are only available on Win32
-            // Prefer to load path from environment variable, if present
-            char* envPath = nullptr;
-            size_t envPathStrLen;
-            errno_t err = _dupenv_s(&envPath, &envPathStrLen, "PF_TEST_TITLE_DATA_JSON");
-            if (err == 0 && envPath != nullptr)
-                TEST_TITLE_DATA_LOC = envPath; // If exists, reset path to env var
-            if (envPath != nullptr)
-                free(envPath);
-#endif
-
-            std::ifstream titleInput;
-            if (TEST_TITLE_DATA_LOC.length() > 0)
-                titleInput.open(TEST_TITLE_DATA_LOC, std::ios::binary | std::ios::in);
-            if (titleInput)
-            {
-                auto begin = titleInput.tellg();
-                titleInput.seekg(0, std::ios::end);
-                auto end = titleInput.tellg();
-                int size = static_cast<int>(end - begin);
-                char* titleJson = new char[size + 1];
-                titleInput.seekg(0, std::ios::beg);
-                titleInput.read(titleJson, size);
-                titleJson[size] = '\0';
-
-                Document testInputs;
-                testInputs.Parse<0>(titleJson);
-                SetTitleInfo(testInputs);
-
-                titleInput.close();
-            }
-            else
-            {
-                return false;
-                // TODO: POPULATE THIS SECTION WITH REAL INFORMATION (or set up a testTitleData file, and set your PF_TEST_TITLE_DATA_JSON to the path for that file)
-                playFabSettings->titleId = ""; // The titleId for your title, found in the "Settings" section of PlayFab Game Manager
-                userEmail = ""; // This is the email for a valid user (test tries to log into it with an invalid password, and verifies error result)
-            }
-
-            // Verify all the inputs won't cause crashes in the tests
-            return !playFabSettings->titleId.empty()
-                && !userEmail.empty();
         }
 
         static void PostTestResultsToCloudScript()


### PR DESCRIPTION
Consolidate TestTitleData loading & associated code into 1 code location (no copy paste & no independent errors in each isolated copy).
Verify tests fail but don't crash when ttd is missing.
PF tests have a more extensible pattern for utilizing shared TestTitleData