### PR TITLE
Python empty responses should not be considered failures

### DIFF
--- a/targets/PythonSdk/source/playfab/PlayFabHTTP.py
+++ b/targets/PythonSdk/source/playfab/PlayFabHTTP.py
@@ -59,9 +59,10 @@ def DoPost(urlPath, request, authKey, authVal, callback, customData = None, extr
         except Exception as e:
             # Global notification about exception in caller's callback
             PlayFabSettings.GlobalExceptionLogger(e) 
-    elif response and callback:
+    elif (response or response == {}) and callback:
         try:
             # Notify the caller about an API Call success
+            # User should also check for {} on the response as it can still be a valid call
             callback(response, None) 
         except Exception as e:
             # Global notification about exception in caller's callback


### PR DESCRIPTION
Python callbacks may have a successful call, but may return an empty data block.
https://community.playfab.com/questions/39112/playfabhttp-recieved-an-empty-response.html

So some successes should be considered passing, despite having empty data. Otherwise, we will call a user failure, but they still have all the data they requested (so did the call really fail just because data may not be present in the callback?)