### PR TITLE
Lua result calls wrong Entity variable

### DIFF
--- a/targets/LuaSdk/make.js
+++ b/targets/LuaSdk/make.js
@@ -182,7 +182,7 @@ function getResultAction(tabbing, apiCall) {
         preCallback = internalTabbing + "PlayFabSettings._internalSettings.entityToken = result.EntityToken\n";
     else if (apiCall.result === "LoginResult") {
         preCallback = internalTabbing + "PlayFabSettings._internalSettings.sessionTicket = result.SessionTicket\n"
-            + internalTabbing + "if (result.Entity) then PlayFabSettings._internalSettings.entityToken = result.EntityToken.EntityToken end\n";
+            + internalTabbing + "if (result.EntityToken) then PlayFabSettings._internalSettings.entityToken = result.EntityToken.EntityToken end\n";
         postCallback = internalTabbing + "PlayFabClientApi._MultiStepClientLogin(result.SettingsForUser.NeedsAttribution)\n";
     }
     else if (apiCall.request === "RegisterPlayFabUserRequest") {


### PR DESCRIPTION
we missed an EntityToken change in lua in a previous fix of the same kind (notice the end of the line that was changed in this PR calls out the result's changed member).

 This somehow slipped passed our previous changes (the lua job only runs the generator, it doesn't precisely test lua).