### PR TITLE
Modified file for the UnrealMarketplacePlugin to prevent build errors

### DIFF
--- a/targets/UnrealMarketplacePlugin/source/PlayFab/Source/PlayFab/Classes/PlayFabResultCommon.h.ejs
+++ b/targets/UnrealMarketplacePlugin/source/PlayFab/Source/PlayFab/Classes/PlayFabResultCommon.h.ejs
@@ -3,6 +3,7 @@
 #pragma once
 
 #include "CoreMinimal.h"
+#include "PlayFab/Classes/PlayFabJsonObject.h"
 #include "PlayFabResultCommon.generated.h"
 
 USTRUCT(BlueprintType)


### PR DESCRIPTION
Fixed Unreal build error in files that included "PlayFabResultCommon.h" where the type "UPlayFabJsonObject" wasn't found (due to missing forward declaration) and the "UPROPERTY"-macro wasn't resolved correctly, due to a missing include
 -> Added include for "PlayFab/Classes/PlayFabJsonObject.h" which fixes both errors at once

Note: This only happens when UnityBuild is disabled! So during default compiling it doesn't happen, but there are cases where this could make a build fail.