### PR TITLE
Update API.java.ejs

### DIFF
--- a/targets/java/templates/API.java.ejs
+++ b/targets/java/templates/API.java.ejs
@@ -36,7 +36,9 @@ import com.google.gson.reflect.*;
             task.run();
             return task.get();
         } catch(Exception e) {
-            return null;
+            PlayFabResult<<%- apiCall.result %>> exceptionResult = new PlayFabResult<<%- apiCall.result %>>();
+            exceptionResult.Error = PlayFabHTTP.GeneratePfError(-1, PlayFabErrorCode.Unknown, e.getMessage(), null);
+            return exceptionResult;
         }
     }
 


### PR DESCRIPTION
We are returning null where we catch an exception. A team has reported that this hid an error from them, so we are going to pass along the hopefully helpful exception message to the user instead of leaving them with null.