### PR TITLE
Fix TS type definitions for PlayerProfileViewConstraints arguments

### DIFF
--- a/targets/javascript/make.js
+++ b/targets/javascript/make.js
@@ -205,12 +205,12 @@ function getPropertyTsType(property, datatype) {
         output = "string";
     else if (property.actualtype === "Boolean")
         output = "boolean";
+    else if (property.isclass)
+        output = property.actualtype;
     else if (property.actualtype.contains("int") || property.actualtype === "float" || property.actualtype === "double")
         output = "number";
     else if (property.actualtype === "DateTime")
         output = "string";
-    else if (property.isclass)
-        output = property.actualtype;
     else if (property.isenum)
         output = "string";
     else if (property.actualtype === "object")

--- a/targets/js-node/make.js
+++ b/targets/js-node/make.js
@@ -176,12 +176,12 @@ function getPropertyTsType(property, datatype) {
         output = "string";
     else if (property.actualtype === "Boolean")
         output = "boolean";
+    else if (property.isclass)
+        output = property.actualtype;
     else if (property.actualtype.contains("int") || property.actualtype === "float" || property.actualtype === "double")
         output = "number";
     else if (property.actualtype === "DateTime")
         output = "string";
-    else if (property.isclass)
-        output = property.actualtype;
     else if (property.isenum)
         output = "string";
     else if (property.actualtype === "object")


### PR DESCRIPTION
Hold on to your hats, this is a really fun one.

In the TypeScript type definitions for both the node.js and browser JS SDKs, there is currently an issue where any API request object that accepts a `ProfileConstraints` parameter has the type for that parameter incorrectly listed as `number` instead of the `PlayerProfileViewConstraints` class. 

See https://github.com/PlayFab/NodeSDK/issues/103 for one specific example, but I found this was happening across every time a `PlayerProfileViewConstraints` parameter was included in an object shape (6 times in Server, 7 times in Client, 1 time in Admin). Oddly, the type definitions for the `PlayerProfileViewConstraints` class itself were being properly generated in all three Client/Server/Admin type definition files.

The logic to generate the type signature is a giant else if block. There is a check, presumably to capture a wide range of numeric types, that checks if the property type string has the substring "int", and if so sets the type to "number". 

Sadly, the string "PlayerProfileViewConstraints" contains "int" as a substring, and thus is falsely counted as the "number" type 🤦

I'm not comfortable changing that substring check without having a clearer sense of what sorts of integer values it is meant to match. That said, moving the "isclass" check (which is `true` for PlayerProfileViewConstraints, since it is, well, a class) before the int substring check successfully fixes this issue for me. 

Running the SDK generator on both js-node and javascript locally with these changes in place, I was able to manually verify that the type definitions are now being generated correctly.

Let me know if you have any questions! If you want to chat privately for any reason, I'm a corp employee, so feel free to reach out internally.
