### PR TITLE
Modify the SDKGenerator template to use the newer ListQosServersForTitle() API

### DIFF
--- a/targets/csharp/source/PlayFabSDK/source/Qos/PlayFabQosApi.cs
+++ b/targets/csharp/source/PlayFabSDK/source/Qos/PlayFabQosApi.cs
@@ -92,8 +92,8 @@ namespace PlayFab.QoS
                 return _dataCenterMap;
             }
 
-            var request = new ListQosServersRequest();
-            PlayFabResult<ListQosServersResponse> response = await multiplayerApi.ListQosServersAsync(request);
+            var request = new ListQosServersForTitleRequest();
+            PlayFabResult<ListQosServersForTitleResponse> response = await multiplayerApi.ListQosServersForTitleAsync(request);
 
             if (response == null || response.Error != null)
             {


### PR DESCRIPTION
Modify the SDKGenerator template to use the newer ListQosServersForTitle() API