### PR TITLE
Toddbell/unreal steel toe

### DIFF
--- a/targets/UnrealMarketplacePlugin/makeCpp.js
+++ b/targets/UnrealMarketplacePlugin/makeCpp.js
@@ -666,6 +666,10 @@ function getRequestActions(tabbing, apiCall, isInstanceApi) {
         return tabbing + "if((request.AuthenticationContext.IsValid() && request.AuthenticationContext->GetClientSessionTicket().Len() == 0)\n"
             + tabbing + "    || (!request.AuthenticationContext.IsValid() && " + getAuthReference(isInstanceApi, true) + "GetClientSessionTicket().Len() == 0)) {\n"
             + tabbing + "    UE_LOG(LogPlayFabCpp, Error, TEXT(\"You must log in before calling this function\"));\n"
+            + tabbing + "}\n"
+            + tabbing + "if (request.AuthenticationContext.IsValid() && request.AuthenticationContext->GetDeveloperSecretKey().Len() == 0))"
+            + tabbing + "{\n"
+            + tabbing + "    UE_LOG(LogPlayFabCpp, Error, TEXT(\"You may not set the DeveloperSecretKey if you are calling a Client API.\"));\n"
             + tabbing + "}\n";
     return "";
 }

--- a/targets/UnrealMarketplacePlugin/makeCpp.js
+++ b/targets/UnrealMarketplacePlugin/makeCpp.js
@@ -627,7 +627,7 @@ function getRequestActions(tabbing, apiCall, isInstanceApi) {
                 + tabbing + "    request.TitleId = this->settings->GetTitleId();\n";
         }
         else {
-            return tabbing + "if (PlayFabSettings::GetTitleId().Len() > 0)\n" 
+            return tabbing + "if (PlayFabSettings::GetTitleId().Len() > 0)\n"
                 + tabbing + "    request.TitleId = PlayFabSettings::GetTitleId();\n";
         }
     }
@@ -663,13 +663,14 @@ function getRequestActions(tabbing, apiCall, isInstanceApi) {
             + tabbing + "    UE_LOG(LogPlayFabCpp, Error, TEXT(\"You must first set your PlayFab developerSecretKey to use this function (Unreal Settings Menu, or in C++ code)\"));\n"
             + tabbing + "}\n";
     else if (apiCall.auth === "SessionTicket")
-        return tabbing + "if((request.AuthenticationContext.IsValid() && request.AuthenticationContext->GetClientSessionTicket().Len() == 0)\n"
-            + tabbing + "    || (!request.AuthenticationContext.IsValid() && " + getAuthReference(isInstanceApi, true) + "GetClientSessionTicket().Len() == 0)) {\n"
-            + tabbing + "    UE_LOG(LogPlayFabCpp, Error, TEXT(\"You must log in before calling this function\"));\n"
-            + tabbing + "}\n"
-            + tabbing + "if (request.AuthenticationContext.IsValid() && request.AuthenticationContext->GetDeveloperSecretKey().Len() == 0))"
+        return tabbing + "if (request.AuthenticationContext.IsValid() && request.AuthenticationContext->GetDeveloperSecretKey().Len() == 0)"
             + tabbing + "{\n"
             + tabbing + "    UE_LOG(LogPlayFabCpp, Error, TEXT(\"You may not set the DeveloperSecretKey if you are calling a Client API.\"));\n"
+            + tabbing + "    return false;\n"
+            + tabbing + "}\n"
+            + tabbing + "if((request.AuthenticationContext.IsValid() && request.AuthenticationContext->GetClientSessionTicket().Len() == 0)\n"
+            + tabbing + "    || (!request.AuthenticationContext.IsValid() && " + getAuthReference(isInstanceApi, true) + "GetClientSessionTicket().Len() == 0)) {\n"
+            + tabbing + "    UE_LOG(LogPlayFabCpp, Error, TEXT(\"You must log in before calling this function\"));\n"
             + tabbing + "}\n";
     return "";
 }

--- a/targets/UnrealMarketplacePlugin/makeCpp.js
+++ b/targets/UnrealMarketplacePlugin/makeCpp.js
@@ -663,7 +663,7 @@ function getRequestActions(tabbing, apiCall, isInstanceApi) {
             + tabbing + "    UE_LOG(LogPlayFabCpp, Error, TEXT(\"You must first set your PlayFab developerSecretKey to use this function (Unreal Settings Menu, or in C++ code)\"));\n"
             + tabbing + "}\n";
     else if (apiCall.auth === "SessionTicket")
-        return tabbing + "if (request.AuthenticationContext.IsValid() && request.AuthenticationContext->GetDeveloperSecretKey().Len() == 0)"
+        return tabbing + "if (request.AuthenticationContext.IsValid() && request.AuthenticationContext->GetDeveloperSecretKey().Len() != 0)"
             + tabbing + "{\n"
             + tabbing + "    UE_LOG(LogPlayFabCpp, Error, TEXT(\"You may not set the DeveloperSecretKey if you are calling a Client API.\"));\n"
             + tabbing + "    return false;\n"

--- a/targets/UnrealMarketplacePlugin/makeCpp.js
+++ b/targets/UnrealMarketplacePlugin/makeCpp.js
@@ -671,6 +671,7 @@ function getRequestActions(tabbing, apiCall, isInstanceApi) {
             + tabbing + "if((request.AuthenticationContext.IsValid() && request.AuthenticationContext->GetClientSessionTicket().Len() == 0)\n"
             + tabbing + "    || (!request.AuthenticationContext.IsValid() && " + getAuthReference(isInstanceApi, true) + "GetClientSessionTicket().Len() == 0)) {\n"
             + tabbing + "    UE_LOG(LogPlayFabCpp, Error, TEXT(\"You must log in before calling this function\"));\n"
+            + tabbing + "    return false;\n"
             + tabbing + "}\n";
     return "";
 }

--- a/targets/UnrealMarketplacePlugin/makeCpp.js
+++ b/targets/UnrealMarketplacePlugin/makeCpp.js
@@ -665,7 +665,7 @@ function getRequestActions(tabbing, apiCall, isInstanceApi) {
     else if (apiCall.auth === "SessionTicket")
         return tabbing + "if (request.AuthenticationContext.IsValid() && request.AuthenticationContext->GetDeveloperSecretKey().Len() != 0)"
             + tabbing + "{\n"
-            + tabbing + "    UE_LOG(LogPlayFabCpp, Error, TEXT(\"You may not set the DeveloperSecretKey if you are calling a Client API.\"));\n"
+            + tabbing + "    UE_LOG(LogPlayFabCpp, Error, TEXT(\"You must not set the DeveloperSecretKey if you are calling a Client API.\"));\n"
             + tabbing + "    return false;\n"
             + tabbing + "}\n"
             + tabbing + "if((request.AuthenticationContext.IsValid() && request.AuthenticationContext->GetClientSessionTicket().Len() == 0)\n"


### PR DESCRIPTION
Adds a check for the developer secret key if we are calling a client API. 

If a developer adds their secret key to the PlayFabSetSettings blueprint, they may be able to accidentally release their game with their dev secret key embedded in their blueprint (this secret key is not necessary for calling client api's so it shouldn't be set for a shipped game).