### PR TITLE
Removing check for 404

### DIFF
--- a/SDKGenerator.njsproj
+++ b/SDKGenerator.njsproj
@@ -10,6 +10,7 @@
     <TypeScriptModuleKind>CommonJS</TypeScriptModuleKind>
     <ToolsVersionPromptShown>2.3</ToolsVersionPromptShown>
     <TypeScriptToolsVersion>2.3</TypeScriptToolsVersion>
+    <NXTargetName>Default</NXTargetName>
   </PropertyGroup>
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>

--- a/SDKGenerator.njsproj
+++ b/SDKGenerator.njsproj
@@ -10,7 +10,6 @@
     <TypeScriptModuleKind>CommonJS</TypeScriptModuleKind>
     <ToolsVersionPromptShown>2.3</ToolsVersionPromptShown>
     <TypeScriptToolsVersion>2.3</TypeScriptToolsVersion>
-    <NXTargetName>Default</NXTargetName>
   </PropertyGroup>
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>

--- a/targets/csharp/source/PlayFabSDK/source/PlayFabHttp/PlayFabSysHttp.cs
+++ b/targets/csharp/source/PlayFabSDK/source/PlayFabHttp/PlayFabSysHttp.cs
@@ -76,7 +76,7 @@ namespace PlayFab.Internal
             {
                 var error = new PlayFabError();
 
-                if (string.IsNullOrEmpty(httpResponseString) || httpResponse.StatusCode == System.Net.HttpStatusCode.NotFound)
+                if (string.IsNullOrEmpty(httpResponseString))
                 {
                     error.HttpCode = (int)httpResponse.StatusCode;
                     error.HttpStatus = httpResponse.StatusCode.ToString();

--- a/targets/csharp/source/PlayFabSDK/source/Uunit/UUnitIncrementalTestRunner.cs
+++ b/targets/csharp/source/PlayFabSDK/source/Uunit/UUnitIncrementalTestRunner.cs
@@ -15,6 +15,7 @@ namespace PlayFab.UUnit
         public string titleId;
 #if ENABLE_PLAYFABSERVER_API || ENABLE_PLAYFABADMIN_API
         public string developerSecretKey;
+        public string aliasId;
 #endif
         public string userEmail;
         public Dictionary<string, string> extraHeaders;

--- a/targets/csharp/source/PlayFabSDK/source/Uunit/tests/PlayFabServerApiTest.cs
+++ b/targets/csharp/source/PlayFabSDK/source/Uunit/tests/PlayFabServerApiTest.cs
@@ -263,14 +263,12 @@ namespace PlayFab.UUnit
 
             if(tokenTask.Error != null)
             {
-                testContext.EndTest(UUnitFinishState.FAILED, "Failed to retrieve the Title Entity Token, check your playFabSettings.staticPlayer, are they still logged in? (hint no server api should be called through a logged in client)");
-                return;
+                testContext.Fail("Failed to retrieve the Title Entity Token, check your playFabSettings.staticPlayer, are they still logged in? (hint no server api should be called through a logged in client)");
             }
 
             if(aliasId == "")
             {
-                testContext.EndTest(UUnitFinishState.SKIPPED, "aliasId was blank, we will not get the expected failed NotFound response this test is asking for. Make sure testTitleData.json has a valid aliasId listed (check playfab multiplayer dashboard for your own valid aliasId)");
-                return;
+                testContext.Fail("aliasId was blank, we will not get the expected failed NotFound response this test is asking for. Make sure testTitleData.json has a valid aliasId listed (check playfab multiplayer dashboard for your own valid aliasId)");
             }
 
             MultiplayerModels.UpdateBuildAliasRequest updateBuildAliasRequest = new MultiplayerModels.UpdateBuildAliasRequest()
@@ -287,13 +285,13 @@ namespace PlayFab.UUnit
 
             string response = PlayFab.PluginManager.GetPlugin<ISerializerPlugin>(PluginContract.PlayFab_Serializer).SerializeObject(res);
 
-            if (response.Contains("MultiplayerServerNotFound"))
+            if (response.Contains("MultiplayerServerNotFound") && res.Error.HttpCode == 404)
             {
                 testContext.EndTest(UUnitFinishState.PASSED, "Detected the Expected MultiplayerServerNotFound PlayFabError");
             }
             else
             {
-                testContext.EndTest(UUnitFinishState.FAILED, "We called the Mutliplayer API expecting to not find anything, but we didn't detect this to be the error.");
+                testContext.Fail("We called the Mutliplayer API expecting to not find anything, but we didn't detect this to be the error.");
             }
         }
     }

--- a/targets/csharp/source/PlayFabSDK/source/Uunit/tests/PlayFabServerApiTest.cs
+++ b/targets/csharp/source/PlayFabSDK/source/Uunit/tests/PlayFabServerApiTest.cs
@@ -246,33 +246,7 @@ namespace PlayFab.UUnit
         [UUnitTest]
         public async void TestForNotFoundWithImportantInfo(UUnitTestContext testContext)
         {
-            PlayFabSettings.staticSettings.TitleId = testTitleData.titleId;
-            PlayFabSettings.staticSettings.DeveloperSecretKey = testTitleData.developerSecretKey;
-
-            var eReq = new AuthenticationModels.GetEntityTokenRequest();
-            eReq.Entity = new AuthenticationModels.EntityKey();
-            eReq.Entity.Type = "title";
-            eReq.Entity.Id = testTitleData.titleId;
-
-            var tokenTask = await PlayFabAuthenticationAPI.GetEntityTokenAsync(eReq);
-
-            if(tokenTask.Error != null)
-            {
-                testContext.EndTest(UUnitFinishState.FAILED, "Failed to retrieve the Title Entity Token");
-                return;
-            }
-
-            MultiplayerModels.UpdateBuildAliasRequest updateBuildAliasRequest = new MultiplayerModels.UpdateBuildAliasRequest()
-            {
-                AliasId = "fakeAliasId",
-                AliasName = "aliasName",
-                AuthenticationContext = new PlayFab.PlayFabAuthenticationContext()
-                {
-                    EntityToken = tokenTask.Result != null ? tokenTask.Result.EntityToken : ""
-                },
-            };
-
-            PlayFab.PlayFabResult<MultiplayerModels.BuildAliasDetailsResponse> res = await PlayFab.PlayFabMultiplayerAPI.UpdateBuildAliasAsync(updateBuildAliasRequest);
+            PlayFabResult<MultiplayerModels.BuildAliasDetailsResponse> res = await UpdateAlias();
 
             string response = PlayFab.PluginManager.GetPlugin<ISerializerPlugin>(PluginContract.PlayFab_Serializer).SerializeObject(res);
 
@@ -284,6 +258,32 @@ namespace PlayFab.UUnit
             {
                 testContext.EndTest(UUnitFinishState.FAILED, "We called the Mutliplayer API expecting to not find anything, but we didn't detect this to be the error.");
             }
+        }
+
+        public static async Task<PlayFabResult<MultiplayerModels.BuildAliasDetailsResponse>> UpdateAlias()
+        {
+            PlayFabSettings.staticSettings.TitleId = testTitleData.titleId;
+            PlayFabSettings.staticSettings.DeveloperSecretKey = testTitleData.developerSecretKey;
+
+            var eReq = new AuthenticationModels.GetEntityTokenRequest();
+            eReq.Entity = new AuthenticationModels.EntityKey();
+            eReq.Entity.Type = "title";
+            eReq.Entity.Id = testTitleData.titleId;
+
+            var tokenTask = await PlayFabAuthenticationAPI.GetEntityTokenAsync(eReq);
+            MultiplayerModels.UpdateBuildAliasRequest updateBuildAliasRequest = new MultiplayerModels.UpdateBuildAliasRequest()
+            {
+                AliasId = "fakeAliasId",
+                AliasName = "aliasName",
+                AuthenticationContext = new PlayFab.PlayFabAuthenticationContext()
+                {
+                    EntityToken = tokenTask.Result.EntityToken // entity token of the title
+                },
+            };
+
+            PlayFab.PlayFabResult<MultiplayerModels.BuildAliasDetailsResponse> res = await PlayFab.PlayFabMultiplayerAPI.UpdateBuildAliasAsync(updateBuildAliasRequest);
+
+            return res;
         }
     }
 }

--- a/targets/csharp/source/PlayFabSDK/source/Uunit/tests/PlayFabServerApiTest.cs
+++ b/targets/csharp/source/PlayFabSDK/source/Uunit/tests/PlayFabServerApiTest.cs
@@ -290,7 +290,7 @@ namespace PlayFab.UUnit
             }
             else
             {
-                testContext.Fail("We called the Mutliplayer API expecting to not find anything, but we didn't detect this to be the error. Details: " + res.Error.ErrorMessage + " and http code: "+res.Error.HttpCode);
+                testContext.Fail("We called the Mutliplayer API expecting to not find anything, but we didn't detect this to be the error. Details: " + res.Error.GenerateErrorReport() + " and http code: "+res.Error.HttpCode);
             }
         }
     }

--- a/targets/csharp/source/PlayFabSDK/source/Uunit/tests/PlayFabServerApiTest.cs
+++ b/targets/csharp/source/PlayFabSDK/source/Uunit/tests/PlayFabServerApiTest.cs
@@ -290,7 +290,7 @@ namespace PlayFab.UUnit
             }
             else
             {
-                testContext.Fail("We called the Mutliplayer API expecting to not find anything, but we didn't detect this to be the error. Details: " + res.Error.ErrorDetails + " and http code: "+res.Error.HttpCode);
+                testContext.Fail("We called the Mutliplayer API expecting to not find anything, but we didn't detect this to be the error. Details: " + res.Error.ErrorMessage + " and http code: "+res.Error.HttpCode);
             }
         }
     }


### PR DESCRIPTION
We are skipping out on deserializing 404 strings. I'm assuming this was done as an optimization (what could they possibly need out of a "we didn't find the url, you probably should fix that")?

Apparently if you try to get mutliplayer servers with a mis-named server, this also returns 404 (our server couldn't find that particular build alias or match id). But our early cut out check only adds HttpStatus and Code, no other info (in fact, the Error comes out as Success, so it's a successful 404!). This does make sense though, the || statement clearly indicates an empty string will probably not survive the try/catch deserialization. Immediately after that check though, we seem to properly detect any error and pass all info appropriately along.

Fiddler shows there is a lot more info that we are missing (explicitly calls out what the user input as the alias). 