### PR TITLE
removing all background flags from Unity SDK

### DIFF
--- a/targets/unity-v2/source/ExampleTestProject/Assets/PlayFabSDK/Shared/Internal/PlayFabHttp/PlayFabHTTP.cs
+++ b/targets/unity-v2/source/ExampleTestProject/Assets/PlayFabSDK/Shared/Internal/PlayFabHttp/PlayFabHTTP.cs
@@ -61,8 +61,6 @@ namespace PlayFab.Internal
             if (transport.IsInitialized)
                 return;
 
-            Application.runInBackground = true; // Http requests respond even if you lose focus
-
             transport.Initialize();
             CreateInstance(); // Invoke the SingletonMonoBehaviour
         }

--- a/targets/unity-v2/source/ExampleTestProject/Assets/PlayFabSDK/Shared/Public/PlayFabDataGatherer.cs
+++ b/targets/unity-v2/source/ExampleTestProject/Assets/PlayFabSDK/Shared/Public/PlayFabDataGatherer.cs
@@ -97,7 +97,6 @@ namespace PlayFab
             StreamingAssetsPath = Application.streamingAssetsPath;
             TargetFrameRate = Application.targetFrameRate;
             UnityVersion = Application.unityVersion;
-            RunInBackground = Application.runInBackground;
 
             //DEVICE & OS
             DeviceModel = SystemInfo.deviceModel;


### PR DESCRIPTION
as a library, this forces developers to have the game running in the background. Although we would highly recommend setting it to true  when the game starts (and subsequently setting to false when the application suspends so you can properly background your app without having it killed)