### PR TITLE
Toddbell/java server test fix

### DIFF
--- a/targets/java/source_shared/src/test/java/com/playfab/test/PlayFabApiTest.java.ejs
+++ b/targets/java/source_shared/src/test/java/com/playfab/test/PlayFabApiTest.java.ejs
@@ -444,7 +444,6 @@ public class PlayFabApiTest
         hwRequest.FunctionName = "helloWorld";
         hwRequest.PlayFabId = loginRes.Result.PlayFabId;
         PlayFabResult<PlayFabServerModels.ExecuteCloudScriptResult> hwResult = PlayFabServerAPI.ExecuteCloudScript(hwRequest);
-        
         assertNotNull(hwResult.Result.FunctionResult);
         Map<String, String> arbitraryResults = (Map<String, String>)hwResult.Result.FunctionResult;
         assertEquals(arbitraryResults.get("messageValue"), "Hello " + loginRes.Result.PlayFabId + "!");

--- a/targets/java/source_shared/src/test/java/com/playfab/test/PlayFabApiTest.java.ejs
+++ b/targets/java/source_shared/src/test/java/com/playfab/test/PlayFabApiTest.java.ejs
@@ -457,8 +457,8 @@ public class PlayFabApiTest
         PlayFabResult<PlayFabServerModels.ExecuteCloudScriptResult> errResult = PlayFabServerAPI.ExecuteCloudScript(errRequest);
 
         String errorMessage = CompileErrorsFromResult(errResult);
-        assertNotNull(errorMessage, result.Error);
-        assertNotNull(errorMessage, result.Result);
+        assertNotNull(errorMessage, errResult.Error);
+        assertNotNull(errorMessage, errResult.Result);
 
         //VerifyResult(errResult, true);
         //assertTrue(errResult.Result.FunctionResult == null);

--- a/targets/java/source_shared/src/test/java/com/playfab/test/PlayFabApiTest.java.ejs
+++ b/targets/java/source_shared/src/test/java/com/playfab/test/PlayFabApiTest.java.ejs
@@ -436,8 +436,7 @@ public class PlayFabApiTest
     {
         PlayFabServerModels.LoginWithServerCustomIdRequest customIdReq = new PlayFabServerModels.LoginWithServerCustomIdRequest();
         customIdReq.CreateAccount = true;
-        String serverId = playFabId;
-        customIdReq.ServerCustomId = serverId;
+        customIdReq.ServerCustomId = PlayFabSettings.BuildIdentifier;
         PlayFabResult<PlayFabServerModels.ServerLoginResult> loginRes = PlayFabServerAPI.LoginWithServerCustomId(customIdReq);
         assertNotNull(loginRes.Result);
         PlayFabServerModels.ExecuteCloudScriptServerRequest hwRequest = new PlayFabServerModels.ExecuteCloudScriptServerRequest();

--- a/targets/java/source_shared/src/test/java/com/playfab/test/PlayFabApiTest.java.ejs
+++ b/targets/java/source_shared/src/test/java/com/playfab/test/PlayFabApiTest.java.ejs
@@ -458,7 +458,6 @@ public class PlayFabApiTest
 
         String errorMessage = CompileErrorsFromResult(errResult);
         assertNotNull(errorMessage, errResult.Error);
-        assertNotNull(errorMessage, errResult.Result);
 
         //VerifyResult(errResult, true);
         //assertTrue(errResult.Result.FunctionResult == null);

--- a/targets/java/source_shared/src/test/java/com/playfab/test/PlayFabApiTest.java.ejs
+++ b/targets/java/source_shared/src/test/java/com/playfab/test/PlayFabApiTest.java.ejs
@@ -439,7 +439,7 @@ public class PlayFabApiTest
         hwRequest.PlayFabId = playFabId;
         PlayFabResult<PlayFabServerModels.ExecuteCloudScriptResult> hwResult = PlayFabServerAPI.ExecuteCloudScript(hwRequest);
         //VerifyResult(hwResult, true);
-        assertNotNull(hwResult.Result.FunctionResult);
+        //assertNotNull(hwResult.Result.FunctionResult);
         Map<String, String> arbitraryResults = (Map<String, String>)hwResult.Result.FunctionResult;
         assertEquals(arbitraryResults.get("messageValue"), "Hello " + playFabId + "!");
     }
@@ -456,9 +456,9 @@ public class PlayFabApiTest
         errRequest.PlayFabId = playFabId;
         PlayFabResult<PlayFabServerModels.ExecuteCloudScriptResult> errResult = PlayFabServerAPI.ExecuteCloudScript(errRequest);
         //VerifyResult(errResult, true);
-        assertTrue(errResult.Result.FunctionResult == null);
-        assertNotNull(errResult.Result.Error);
-        assertEquals(errResult.Result.Error.Error, "JavascriptException");
+        //assertTrue(errResult.Result.FunctionResult == null);
+        //assertNotNull(errResult.Result.Error);
+        //assertEquals(errResult.Result.Error.Error, "JavascriptException");
     }
 <% } %><% if (hasClientOptions) { %>
     /**

--- a/targets/java/source_shared/src/test/java/com/playfab/test/PlayFabApiTest.java.ejs
+++ b/targets/java/source_shared/src/test/java/com/playfab/test/PlayFabApiTest.java.ejs
@@ -437,11 +437,8 @@ public class PlayFabApiTest
         PlayFabServerModels.ExecuteCloudScriptServerRequest hwRequest = new PlayFabServerModels.ExecuteCloudScriptServerRequest();
         hwRequest.FunctionName = "helloWorld";
         hwRequest.PlayFabId = playFabId;
-        PlayFabResult<PlayFabServerModels.ExecuteCloudScriptResult> hwResult = PlayFabServerAPI.ExecuteCloudScript(hwRequest);
-        //VerifyResult(hwResult, true);
-        //assertNotNull(hwResult.Result.FunctionResult);
-        //Map<String, String> arbitraryResults = (Map<String, String>)hwResult.Result.FunctionResult;
-        //assertEquals(arbitraryResults.get("messageValue"), "Hello " + playFabId + "!");
+        PlayFabResult<PlayFabServerModels.ExecuteCloudScriptResult> hweResult = PlayFabServerAPI.ExecuteCloudScript(hwRequest);
+        assertNotNull(hwResult.Result);
     }
 
     /*
@@ -458,11 +455,6 @@ public class PlayFabApiTest
 
         String errorMessage = CompileErrorsFromResult(errResult);
         assertNotNull(errorMessage, errResult.Error);
-
-        //VerifyResult(errResult, true);
-        //assertTrue(errResult.Result.FunctionResult == null);
-        //assertNotNull(errResult.Result.Error);
-        //assertEquals(errResult.Result.Error.Error, "JavascriptException");
     }
 <% } %><% if (hasClientOptions) { %>
     /**

--- a/targets/java/source_shared/src/test/java/com/playfab/test/PlayFabApiTest.java.ejs
+++ b/targets/java/source_shared/src/test/java/com/playfab/test/PlayFabApiTest.java.ejs
@@ -434,11 +434,20 @@ public class PlayFabApiTest
     @Test
     public void CloudScriptServer()
     {
+        PlayFabServerModels.LoginWithServerCustomIdRequest customIdReq = new PlayFabServerModels.LoginWithServerCustomIdRequest();
+        customIdReq.CreateAccount = true;
+        String serverId = playFabId;
+        customIdReq.ServerCustomId = serverId;
+        PlayFabResult<PlayFabServerModels.ServerLoginResult> loginRes = PlayFabServerAPI.LoginWithServerCustomId(customIdReq);
+        assertNotNull(loginRes.Result);
         PlayFabServerModels.ExecuteCloudScriptServerRequest hwRequest = new PlayFabServerModels.ExecuteCloudScriptServerRequest();
         hwRequest.FunctionName = "helloWorld";
-        hwRequest.PlayFabId = playFabId;
-        PlayFabResult<PlayFabServerModels.ExecuteCloudScriptResult> hweResult = PlayFabServerAPI.ExecuteCloudScript(hwRequest);
-        assertNotNull(hwResult.Result);
+        hwRequest.PlayFabId = loginRes.Result.PlayFabId;
+        PlayFabResult<PlayFabServerModels.ExecuteCloudScriptResult> hwResult = PlayFabServerAPI.ExecuteCloudScript(hwRequest);
+        
+        assertNotNull(hwResult.Result.FunctionResult);
+        Map<String, String> arbitraryResults = (Map<String, String>)hwResult.Result.FunctionResult;
+        assertEquals(arbitraryResults.get("messageValue"), "Hello " + loginRes.Result.PlayFabId + "!");
     }
 
     /*

--- a/targets/java/source_shared/src/test/java/com/playfab/test/PlayFabApiTest.java.ejs
+++ b/targets/java/source_shared/src/test/java/com/playfab/test/PlayFabApiTest.java.ejs
@@ -438,7 +438,7 @@ public class PlayFabApiTest
         hwRequest.FunctionName = "helloWorld";
         hwRequest.PlayFabId = playFabId;
         PlayFabResult<PlayFabServerModels.ExecuteCloudScriptResult> hwResult = PlayFabServerAPI.ExecuteCloudScript(hwRequest);
-        VerifyResult(hwResult, true);
+        //VerifyResult(hwResult, true);
         assertNotNull(hwResult.Result.FunctionResult);
         Map<String, String> arbitraryResults = (Map<String, String>)hwResult.Result.FunctionResult;
         assertEquals(arbitraryResults.get("messageValue"), "Hello " + playFabId + "!");
@@ -455,7 +455,7 @@ public class PlayFabApiTest
         errRequest.FunctionName = "throwError";
         errRequest.PlayFabId = playFabId;
         PlayFabResult<PlayFabServerModels.ExecuteCloudScriptResult> errResult = PlayFabServerAPI.ExecuteCloudScript(errRequest);
-        VerifyResult(errResult, false);
+        //VerifyResult(errResult, true);
         assertTrue(errResult.Result.FunctionResult == null);
         assertNotNull(errResult.Result.Error);
         assertEquals(errResult.Result.Error.Error, "JavascriptException");

--- a/targets/java/source_shared/src/test/java/com/playfab/test/PlayFabApiTest.java.ejs
+++ b/targets/java/source_shared/src/test/java/com/playfab/test/PlayFabApiTest.java.ejs
@@ -455,6 +455,11 @@ public class PlayFabApiTest
         errRequest.FunctionName = "throwError";
         errRequest.PlayFabId = playFabId;
         PlayFabResult<PlayFabServerModels.ExecuteCloudScriptResult> errResult = PlayFabServerAPI.ExecuteCloudScript(errRequest);
+
+        String errorMessage = CompileErrorsFromResult(errResult);
+        assertNotNull(errorMessage, result.Error);
+        assertNotNull(errorMessage, result.Result);
+
         //VerifyResult(errResult, true);
         //assertTrue(errResult.Result.FunctionResult == null);
         //assertNotNull(errResult.Result.Error);

--- a/targets/java/source_shared/src/test/java/com/playfab/test/PlayFabApiTest.java.ejs
+++ b/targets/java/source_shared/src/test/java/com/playfab/test/PlayFabApiTest.java.ejs
@@ -460,7 +460,6 @@ public class PlayFabApiTest
         errRequest.FunctionName = "throwError";
         errRequest.PlayFabId = playFabId;
         PlayFabResult<PlayFabServerModels.ExecuteCloudScriptResult> errResult = PlayFabServerAPI.ExecuteCloudScript(errRequest);
-
         String errorMessage = CompileErrorsFromResult(errResult);
         assertNotNull(errorMessage, errResult.Error);
     }

--- a/targets/java/source_shared/src/test/java/com/playfab/test/PlayFabApiTest.java.ejs
+++ b/targets/java/source_shared/src/test/java/com/playfab/test/PlayFabApiTest.java.ejs
@@ -455,7 +455,7 @@ public class PlayFabApiTest
         errRequest.FunctionName = "throwError";
         errRequest.PlayFabId = playFabId;
         PlayFabResult<PlayFabServerModels.ExecuteCloudScriptResult> errResult = PlayFabServerAPI.ExecuteCloudScript(errRequest);
-        VerifyResult(errResult, true);
+        VerifyResult(errResult, false);
         assertTrue(errResult.Result.FunctionResult == null);
         assertNotNull(errResult.Result.Error);
         assertEquals(errResult.Result.Error.Error, "JavascriptException");

--- a/targets/java/source_shared/src/test/java/com/playfab/test/PlayFabApiTest.java.ejs
+++ b/targets/java/source_shared/src/test/java/com/playfab/test/PlayFabApiTest.java.ejs
@@ -440,8 +440,8 @@ public class PlayFabApiTest
         PlayFabResult<PlayFabServerModels.ExecuteCloudScriptResult> hwResult = PlayFabServerAPI.ExecuteCloudScript(hwRequest);
         //VerifyResult(hwResult, true);
         //assertNotNull(hwResult.Result.FunctionResult);
-        Map<String, String> arbitraryResults = (Map<String, String>)hwResult.Result.FunctionResult;
-        assertEquals(arbitraryResults.get("messageValue"), "Hello " + playFabId + "!");
+        //Map<String, String> arbitraryResults = (Map<String, String>)hwResult.Result.FunctionResult;
+        //assertEquals(arbitraryResults.get("messageValue"), "Hello " + playFabId + "!");
     }
 
     /*


### PR DESCRIPTION
While updating the Java SDK for minecraft earth. Our tests were originally expecting a null return where we now return a detailed PlayFab error. 