### PR TITLE
Update PlayFabApiTest.java.ejs

### DIFF
--- a/targets/java/source_shared/src/test/java/com/playfab/test/PlayFabApiTest.java.ejs
+++ b/targets/java/source_shared/src/test/java/com/playfab/test/PlayFabApiTest.java.ejs
@@ -459,10 +459,14 @@ public class PlayFabApiTest
         errRequest.FunctionName = "throwError";
         errRequest.PlayFabId = playFabId;
         PlayFabResult<PlayFabServerModels.ExecuteCloudScriptResult> errResult = PlayFabServerAPI.ExecuteCloudScript(errRequest);
-        String errorMessage = CompileErrorsFromResult(errResult);
-        assertNotNull(errorMessage, errResult.Error);
+<% } if (hasClientOptions && hasServerOptions) { %>
+    assertNotNull(errResult.Result.Error);
+<% } else if (hasServerOptions && !hasClientOptions) { %>
+    String errorMessage = CompileErrorsFromResult(errResult);
+    assertNotNull(errorMessage, errResult.Error);
+<% } if (hasServerOptions) { %>
     }
-<% } %><% if (hasClientOptions) { %>
+<% } if (hasClientOptions) { %>
     /**
      *  ENTITY API
      *  Log in or create a user, track their PlayFabId


### PR DESCRIPTION
Combo SDK is seeing the Error show up under the Result instead of the Error itself BUT server only hands the error back on a base wrapper class error.