### PR TITLE
Adding singular retries to flaky tests

### DIFF
--- a/targets/csharp/source/PlayFabSDK/source/Uunit/tests/PlayFabApiTest.cs
+++ b/targets/csharp/source/PlayFabSDK/source/Uunit/tests/PlayFabApiTest.cs
@@ -152,8 +152,17 @@ namespace PlayFab.UUnit
             var loginTask = clientApi.LoginWithCustomIDAsync(loginRequest, null, testTitleData.extraHeaders);
             ContinueWithContext(loginTask, testContext, LoginWithAdvertisingIdContinued, true, "Login with advertId failed", true);
         }
+
+        bool advertLoginRetry = true;
         private void LoginWithAdvertisingIdContinued(PlayFabResult<LoginResult> loginResult, UUnitTestContext testContext, string failMessage)
         {
+            if (!clientApi.IsClientLoggedIn() && advertLoginRetry)
+            {
+                advertLoginRetry = false;
+                LoginWithAdvertisingId(testContext);
+                return;
+            }
+
             testContext.True(clientApi.IsClientLoggedIn(), failMessage);
             testContext.StringEquals(PlayFabSettings.AD_TYPE_ANDROID_ID + "_Successful", PlayFabSettings.staticSettings.AdvertisingIdType);
         }

--- a/targets/csharp/source/PlayFabSDK/source/Uunit/tests/PlayFabServerApiTest.cs
+++ b/targets/csharp/source/PlayFabSDK/source/Uunit/tests/PlayFabServerApiTest.cs
@@ -183,6 +183,7 @@ namespace PlayFab.UUnit
             testContext.EndTest(UUnitFinishState.PASSED, null);
         }
 
+        bool retryParallelRequest = true;
         /// <summary>
         /// SERVER API
         /// Try to parallel request at same time
@@ -236,6 +237,13 @@ namespace PlayFab.UUnit
                 }
                 else
                 {
+                    if(retryParallelRequest)
+                    {
+                        retryParallelRequest = false;
+                        ParallelRequest(testContext);
+                        return;
+                    }
+
                     testContext.Fail("Parallel Requests failed " + whenAll.Exception.Flatten().Message);
                 }
             });


### PR DESCRIPTION
possible timeout issue though.

We could instead move this logic up to the test runner level, and explicitly call out ParallelTestRequest and LoginWithAdvert as tests to retry once more, but should probably alot the whole (currently 15 second) timeout again.