### PR TITLE
targets/panda3DSdK: Add Panda3d Python support

### DIFF
--- a/targets/Panda3DSdk/Archive/Enum.py.ejs
+++ b/targets/Panda3DSdk/Archive/Enum.py.ejs
@@ -1,0 +1,4 @@
+<%- generateApiSummary("    ", datatype, "description")
+%>class <%- datatype.name %> (enum.Enum):<% for(var i = 0; i < datatype.enumvalues.length; i++)%>
+    <%-  datatype.enumvalues[i].name %> = <%-i%>
+

--- a/targets/Panda3DSdk/Archive/Model.py.ejs
+++ b/targets/Panda3DSdk/Archive/Model.py.ejs
@@ -1,0 +1,23 @@
+<%- generateApiSummary("", datatype, "description")
+%><%- getDeprecationAttribute("", datatype)
+%>class <%- datatype.name %><%- getBaseTypeSyntax(datatype) %>:
+<%- addInitializeFunction("    ", datatype.properties.length) %>
+<% for(var i in datatype.properties) { var property = datatype.properties[i];%>
+<%- generateApiSummary("        ", property, "description")
+%><%- getDeprecationAttribute("        ", property)
+%><%- getPropertyAttribs("        ", property, datatype, api)
+%>        self.<%- getModelPropertyDef(property, datatype) %> = <%- getDefaultValueForType(property, datatype) %>
+<% } %>
+<% if(datatype.properties.length > 0) { %>
+    def fromJson(json):
+        obj = <%- datatype.name%>()
+        try:<% for(var i in datatype.properties) { var property = datatype.properties[i];%>
+            obj.<%- getModelPropertyDef(property, datatype) %> = json["<%- getModelPropertyDef(property, datatype) %>"]<% } %>
+        except error:
+            return <%- datatype.name%>()
+        return obj
+<% } %>
+<% if (datatype.sortKey) { %>
+<%- getComparator("    ", datatype.name, datatype.sortKey) %>
+<% } %>
+

--- a/targets/Panda3DSdk/Archive/Models.py.ejs
+++ b/targets/Panda3DSdk/Archive/Models.py.ejs
@@ -1,0 +1,7 @@
+from json import JSONEncoder
+import datetime
+import enum
+import PlayFabBaseClasses
+import PlayFabHTTP
+
+<% for(var d in api.datatypes) { var datatype = api.datatypes[d] %><%- makeDatatype(datatype, api) %><% } %>

--- a/targets/Panda3DSdk/Archive/PlayFabBaseClasses.py
+++ b/targets/Panda3DSdk/Archive/PlayFabBaseClasses.py
@@ -1,0 +1,18 @@
+class PlayFabBaseObject():
+    pass
+
+class PlayFabRequestCommon(PlayFabBaseObject):
+    """
+    This is a base-class for all Api-request objects.
+    It is currently unfinished, but we will add result-specific properties,
+    and add template where-conditions to make some code easier to follow
+    """
+    pass
+
+class PlayFabResultCommon(PlayFabBaseObject):
+    """
+    This is a base-class for all Api-result objects.
+    It is currently unfinished, but we will add result-specific properties,
+    and add template where-conditions to make some code easier to follow
+    """
+    pass

--- a/targets/Panda3DSdk/Archive/PlayFabJson.py
+++ b/targets/Panda3DSdk/Archive/PlayFabJson.py
@@ -1,0 +1,19 @@
+def serialize_instance(obj):
+    d = { '__classname__' : type(obj).__name__ }
+    d.update(vars(obj))
+    return d
+
+classes = {
+# may need to make this file generic?
+}
+
+def unserialize_object(d):
+    # TODO: investigate classname element more carefully
+    clsname = d.pop('__classname__', None)
+    if clsname:
+        cls = classes[clsname]
+        obj = cls.__new__(cls)  # make instance without calling __init__
+        obj.update(d)
+        return obj
+    else:
+        return d

--- a/targets/Panda3DSdk/Archive/PlayFabJson.py.ejs
+++ b/targets/Panda3DSdk/Archive/PlayFabJson.py.ejs
@@ -1,0 +1,20 @@
+def serialize_instance(obj):
+    d = { '__classname__' : type(obj).__name__ }
+    d.update(dir(obj)) 
+    return d
+
+classes = {
+<% for(var i in datatype.properties) { var property = datatype.properties[i];
+%>
+<% } %>
+}
+
+def unserialize_object(d):
+    clsname = d.pop('__classname__', None)
+    if clsname:
+        cls = classes[clsname]
+        obj = cls.__new__(cls)  # make instance without calling __init__
+        obj.update(d)
+        return obj
+    else:
+        return d

--- a/targets/Panda3DSdk/Archive/PlayFabUtil.py.ejs
+++ b/targets/Panda3DSdk/Archive/PlayFabUtil.py.ejs
@@ -1,0 +1,57 @@
+import json
+<% if (hasClientOptions) {
+%>import PlayFabClientModels
+<% } else if (hasServerOptions) {
+%>import PlayFabServerModels
+<% } %>
+
+class PlayFab:
+    class Unordered(attribute):
+        def __init__():
+            pass
+
+        def __init__(self, sortProperty):
+            self.SortProperty = sortProperty;
+
+    class PlayFabUtil:
+        """
+        All parseable ISO 8601 formats for DateTime.[Try]ParseExact - Lets us deserialize any legacy timestamps in one of these formats
+        (index 0-4) These are the standard format with ISO 8601 UTC markers (T/Z)
+        (index 5-9) These are the standard format without ISO 8601 UTC markers (T/Z)
+        """
+        DefaultDateTimeFormats = ["yyyy-MM-ddTHH:mm:ss.FFFFFFZ", "yyyy-MM-ddTHH:mm:ss.FFFFZ", "yyyy-MM-ddTHH:mm:ss.FFFZ", "yyyy-MM-ddTHH:mm:ss.FFZ", "yyyy-MM-ddTHH:mm:ssZ", "yyyy-MM-dd HH:mm:ss.FFFFFF", "yyyy-MM-dd HH:mm:ss.FFFF", "yyyy-MM-dd HH:mm:ss.FFF", "yyyy-MM-dd HH:mm:ss.FF", "yyyy-MM-dd HH:mm:ss"]
+
+        DEFAULT_UTC_OUTPUT_INDEX = 2 # The default format everybody should use
+        DEFAULT_LOCAL_OUTPUT_INDEX = 7 # The default format if you want to use local time (This doesn't have universal support in all PlayFab code)
+
+        def GenerateErrorReport(error):
+            if error == None:
+                return None
+            return error.GenerateErrorReport()
+
+        def GetCloudScriptErrorReport(result):
+            if result.Error != None:
+                return result.Error.GenerateErrorReport()
+            if result.Result.Error == None:
+                return None
+
+            str = []
+            hasError = not noneOrEmpty(result.Result.Error.Error)
+            hasMsg = not noneOrEmpty(result.Result.Error.Message)
+            if hasError:
+                str.append(result.Result.Error.Error)
+            if hasError and hasMsg:
+                str.append(" - ")
+            if hasMsg:
+                str.append(result.Result.Error.Message)
+
+            for eachLog in result.Result.Logs:
+                if str.Length > 0:
+                    str.append("\n")
+                str.append(eachLog.Level)
+                if not noneOrEmpty(eachLog.Message):
+                    str.append(" - ").append(eachLog.Message)
+                if eachLog.Data != None:
+                    str.append("\n").append(JsonWrapper.SerializeObject(eachLog.Data))
+
+            return "".join(str)

--- a/targets/Panda3DSdk/make.js
+++ b/targets/Panda3DSdk/make.js
@@ -1,0 +1,345 @@
+var path = require("path");
+
+// Making resharper less noisy - These are defined in Generate.js
+if (typeof (templatizeTree) === "undefined") templatizeTree = function () { };
+if (typeof (getCompiledTemplate) === "undefined") getCompiledTemplate = function () { };
+var cPythonLineComment = "\"\"\"";
+var cPythonNewLineComment = "\"\"\"\n";
+
+// moves over setup.py and uploadPython.sh
+function copyOverScripts(apis, sourceDir, apiOutputDir)
+{
+    var srcDir = path.resolve(sourceDir, "source");
+    var locals = {
+        apis: apis,
+        errorList: apis[0].errorList,
+        errors: apis[0].errors,
+        sdkVersion: sdkGlobals.sdkVersion,
+        getVerticalNameDefault: getVerticalNameDefault
+    };
+    templatizeTree(locals, srcDir, apiOutputDir);
+}
+
+exports.makeCombinedAPI = function (apis, sourceDir, apiOutputDir) {
+    var locals = {
+        apis: apis,
+        buildIdentifier: sdkGlobals.buildIdentifier,
+        friendlyName: "PlayFab Python Combined Sdk",
+        errorList: apis[0].errorList,
+        errors: apis[0].errors,
+        sdkVersion: sdkGlobals.sdkVersion,
+        getVerticalNameDefault: getVerticalNameDefault
+    };
+
+    console.log("Generating Combined Client/Server api from: " + sourceDir + " to: " + apiOutputDir);
+
+    templatizeTree(locals, path.resolve(sourceDir, "source"), apiOutputDir);
+    for (var i = 0; i < apis.length; i++) {
+        if (apis[i] != null) {
+            makeApi(apis[i], sourceDir, apiOutputDir);
+        }
+    }
+
+    copyOverScripts(apis, sourceDir, apiOutputDir);
+}
+
+// TODO: comment back in when Models are ready
+//function makeDataTypes(apis, sourceDir, apiOutputDir) {
+//    var modelTemplate = getCompiledTemplate(path.resolve(sourceDir, "templates/Model.py.ejs"));
+//    var modelsTemplate = getCompiledTemplate(path.resolve(sourceDir, "templates/Models.py.ejs"));
+//    var enumTemplate = getCompiledTemplate(path.resolve(sourceDir, "templates/Enum.py.ejs"));
+//    var jsonTemplate = getCompiledTemplate(path.resolve(sourceDir, "templates/PlayFabJson.py.ejs"));
+
+//    var makeDatatype = function (datatype, api) {
+//        var modelLocals = {
+//            api: api,
+//            datatype: datatype,
+//            multiTab: multiTab,
+//            generateApiSummary: generateApiSummary,
+//            getModelPropertyDef: getModelPropertyDef,
+//            getPropertyAttribs: getPropertyAttribs,
+//            getBaseTypeSyntax: getBaseTypeSyntax,
+//            getDeprecationAttribute: getDeprecationAttribute,
+//            getDefaultValueForType: getDefaultValueForType,
+//            addInitializeFunction: addInitializeFunction,
+//            getJsonSerialization: getJsonSerialization,
+//            getComparator: getComparator,
+//        };
+
+//        writeFile(path.resolve(apiOutputDir, "source/PlayFabJson.py"), jsonTemplate(modelLocals));
+
+//        return (datatype.isenum) ? enumTemplate(modelLocals) : modelTemplate(modelLocals);
+//    };
+
+//    for (var a = 0; a < apis.length; a++) {
+//        var modelsLocal = {
+//            api: apis[a],
+//            makeDatatype: makeDatatype
+//        };
+
+//        writeFile(path.resolve(apiOutputDir, "source/playfab" + apis[a].name + "Models.py"), modelsTemplate(modelsLocal));
+//    }
+//}
+
+function makeApi(api, sourceDir, apiOutputDir) {
+    console.log("Generating Python " + api.name + " library to " + apiOutputDir);
+
+    var apiLocals = {
+        api: api,
+        getAuthParams: getAuthParams,
+        getRequestActions: getRequestActions,
+        getResultActions: getResultActions,
+        getDeprecationAttribute: getDeprecationAttribute,
+        generateApiSummary: generateApiSummary,
+        hasClientOptions: getAuthMechanisms([api]).includes("SessionTicket"),
+    };
+
+    var apiTemplate = getCompiledTemplate(path.resolve(sourceDir, "templates/API.py.ejs"));
+    writeFile(path.resolve(apiOutputDir, "panda3d_playfab/PlayFab" + api.name + "API.py"), apiTemplate(apiLocals));
+}
+
+function getVerticalNameDefault() {
+    if (sdkGlobals.verticalName) {
+        return "\"" + sdkGlobals.verticalName + "\"";
+    }
+
+    return "None";
+}
+
+function getDeprecationAttribute(tabbing, apiObj) {
+    var isDeprecated = apiObj.hasOwnProperty("deprecation");
+    var deprecationTime = null;
+    if (isDeprecated)
+        deprecationTime = new Date(apiObj.deprecation.DeprecatedAfter);
+    var isError = isDeprecated && (new Date() > deprecationTime) ? "true" : "false";
+
+    if (isDeprecated && apiObj.deprecation.ReplacedBy != null)
+        return tabbing + cPythonLineComment + tabbing + "# [Obsolete(\"Use '" + apiObj.deprecation.ReplacedBy + "' instead\", " + isError + ")]\n" + tabbing + cPythonLineComment;
+    else if (isDeprecated)
+        return tabbing + cPythonLineComment + tabbing + "# [Obsolete(\"No longer available\", " + isError + ")]\n" + tabbing + cPythonLineComment;
+    return "";
+}
+
+// TODO: This will be needed for Model Generation
+//function getBaseTypeSyntax(datatype) {
+//    var parents = [];
+    
+//    if (datatype.className.toLowerCase().endsWith("request"))
+//        parents.push("PlayFabHTTP.PlayFabRequestCommon");
+//    if (datatype.className.toLowerCase().endsWith("response") || datatype.className.toLowerCase().endsWith("result"))
+//        parents.push("PlayFabHTTP.PlayFabResultCommon");
+//    else {
+//        parents.push("PlayFabHTTP.PlayFabBaseObject");
+//    }
+
+//    //parents.push("PlayFabHTTP.Serializable")
+
+//    if (parents.length > 0) {
+//        var output = "(";
+//        for (var i = 0; i < parents.length; i++) {
+//            if (i !== 0)
+//                output += ", ";
+//            output += parents[i];
+//        }
+//        output += ")"
+//    }
+//    return output;
+//}
+
+function getPropertyAttribs(tabbing, property, datatype, api) {
+    var attribs = "";
+
+    if (property.isUnordered) {
+        var listDatatype = api.datatypes[property.actualtype];
+        if (listDatatype && listDatatype.sortKey)
+            attribs += tabbing + "# [Unordered(SortProperty=\"" + listDatatype.sortKey + "\")]\n";
+        else
+            attribs += tabbing + "# [Unordered]\n";
+    }
+
+    return attribs;
+}
+
+//function getModelPropertyDef(property, datatype) {
+//    var basicType;
+//    if (property.collection) {
+//        basicType = getPropertyCsType(property, datatype, false);
+
+//        if (property.collection === "array")
+//            return "List<" + basicType + "> " + property.name;
+//        else if (property.collection === "map")
+//            return "Dictionary<string," + basicType + "> " + property.name;
+//        else
+//            throw "Unknown collection type: " + property.collection + " for " + property.name + " in " + datatype.name;
+//    }
+//    else {
+//        basicType = getPropertyCsType(property, datatype, true);
+//        return basicType + " " + property.name;
+//    }
+//    return property.name;
+//}
+
+function getAuthParams(apiCall) {
+    if (apiCall.url === "/Authentication/GetEntityToken")
+        return "authKey, authValue";
+    if (apiCall.auth === "EntityToken")
+        return "\"X-EntityToken\", PlayFabSettings._internalSettings.EntityToken";
+    if (apiCall.auth === "SecretKey")
+        return "\"X-SecretKey\", PlayFabSettings.DeveloperSecretKey";
+    else if (apiCall.auth === "SessionTicket")
+        return "\"X-Authorization\", PlayFabSettings._internalSettings.ClientSessionTicket";
+    return "None, None";
+}
+
+function getRequestActions(tabbing, apiCall) {
+    if (apiCall.result === "LoginResult" || apiCall.request === "RegisterPlayFabUserRequest")
+        return tabbing + "request[\"TitleId\"] = PlayFabSettings.TitleId or request.TitleId\n"
+            + tabbing + "if not request[\"TitleId\"]:\n"
+            + tabbing + "    raise PlayFabErrors.PlayFabException(\"Must be have TitleId set to call this method\")\n\n";
+    if (apiCall.auth === "EntityToken")
+        return tabbing + "if not PlayFabSettings._internalSettings.EntityToken:\n"
+            + tabbing + "    raise PlayFabErrors.PlayFabException(\"Must call GetEntityToken before calling this method\")\n\n";
+    if (apiCall.auth === "SessionTicket")
+        return tabbing + "if not PlayFabSettings._internalSettings.ClientSessionTicket:\n"
+            + tabbing + "    raise PlayFabErrors.PlayFabException(\"Must be logged in to call this method\")\n\n";
+    if (apiCall.auth === "SecretKey")
+        return tabbing + "if not PlayFabSettings.DeveloperSecretKey:\n"
+            + tabbing + "    raise PlayFabErrors.PlayFabException(\"Must have DeveloperSecretKey set to call this method\")\n\n";
+    if (apiCall.url === "/Authentication/GetEntityToken")
+        return tabbing + "authKey = None\n"
+            + tabbing + "authValue = None\n"
+            + tabbing + "if PlayFabSettings._internalSettings.EntityToken:\n"
+            + tabbing + "    authKey = \"X-EntityToken\"\n"
+            + tabbing + "    authValue = PlayFabSettings._internalSettings.EntityToken\n"
+            + tabbing + "elif PlayFabSettings._internalSettings.ClientSessionTicket:\n"
+            + tabbing + "    authKey = \"X-Authorization\"\n"
+            + tabbing + "    authValue = PlayFabSettings._internalSettings.ClientSessionTicket \n"
+            + tabbing + "elif PlayFabSettings.DeveloperSecretKey:\n"
+            + tabbing + "    authKey = \"X-SecretKey\"\n"
+            + tabbing + "    authValue = PlayFabSettings.DeveloperSecretKey \n\n";
+    return "";
+}
+
+function getResultActions(tabbing, apiCall, api) {
+    if (apiCall.result === "LoginResult")
+        return tabbing + "if playFabResult:\n" 
+            + tabbing + "    PlayFabSettings._internalSettings.ClientSessionTicket = playFabResult[\"SessionTicket\"] if \"SessionTicket\" in playFabResult else PlayFabSettings._internalSettings.ClientSessionTicket\n"
+            + tabbing + "    PlayFabSettings._internalSettings.EntityToken = playFabResult[\"EntityToken\"][\"EntityToken\"] if \"EntityToken\" in playFabResult else PlayFabSettings._internalSettings.EntityToken\n"
+            + tabbing + "    MultiStepClientLogin(playFabResult.get(\"SettingsForUser\"))\n";
+    else if (apiCall.result === "RegisterPlayFabUserResult")
+        return tabbing + "if playFabResult:\n" 
+            + tabbing + "    PlayFabSettings._internalSettings.ClientSessionTicket = playFabResult[\"SessionTicket\"] if \"SessionTicket\" in playFabResult else PlayFabSettings._internalSettings.ClientSessionTicket\n"
+            + tabbing + "    MultiStepClientLogin(playFabResult.get(\"SettingsForUser\"))\n";
+    else if (apiCall.result === "AttributeInstallResult")
+        return tabbing + "# Modify AdvertisingIdType:  Prevents us from sending the id multiple times, and allows automated tests to determine id was sent successfully\n"
+            + tabbing + "PlayFabSettings.AdvertisingIdType += \"_Successful\"\n";
+    else if (apiCall.result === "GetEntityTokenResponse")
+        return tabbing + "if playFabResult:\n"
+            + tabbing + "    PlayFabSettings._internalSettings.EntityToken = playFabResult[\"EntityToken\"] if \"EntityToken\" in playFabResult else PlayFabSettings._internalSettings.EntityToken\n";
+    return "";
+}
+
+function getDeprecationAttribute(tabbing, apiObj) {
+    var isDeprecated = apiObj.hasOwnProperty("deprecation");
+    var deprecationTime = null;
+    if (isDeprecated)
+        deprecationTime = new Date(apiObj.deprecation.DeprecatedAfter);
+    var isError = isDeprecated && (new Date() > deprecationTime) ? "true" : "false";
+
+    if (isDeprecated && apiObj.deprecation.ReplacedBy != null)
+        return tabbing + "# [Obsolete(\"Use '" + apiObj.deprecation.ReplacedBy + "' instead\", " + isError + ")]\n";
+    else if (isDeprecated)
+        return tabbing + "# [Obsolete(\"No longer available\", " + isError + ")]\n";
+    return "";
+}
+
+function generateApiSummary(tabbing, apiElement, summaryParam, extraLines) {
+    var lines = generateApiSummaryLines(apiElement, summaryParam, extraLines);
+    var tabbedLineComment = tabbing + cPythonNewLineComment;
+
+    var output;
+    if (lines.length === 1) {
+        output = tabbing + cPythonLineComment + " "+ lines.join("\n") + " " + tabbedLineComment + "\n";
+    } else if (lines.length > 0) {
+        output = tabbedLineComment + tabbing + lines.join("\n" + tabbing) + "\n" + tabbedLineComment;
+    } else {
+        output = "";
+    }
+    return output;
+}
+
+// TODO: This will be needed for Model generation in the future
+//function getComparator(tabbing, dataTypeName, dataTypeSortKey)
+//{
+//    //var output = multiTab(tabbing, 3) + "def __eq__(self, " + dataTypeName + " other):\n" +
+//    var output = multiTab(tabbing, 2) + "def __eq__(self, other):\n" +
+//        multiTab(tabbing, 3) + "if other == None or other." + dataTypeSortKey + " == None:\n" +
+//        multiTab(tabbing, 4) + "return 1\n" +
+//        multiTab(tabbing, 3) + "if " + dataTypeSortKey + " == None:\n" +
+//        multiTab(tabbing, 4) + "return -1\n"+
+//        multiTab(tabbing, 3) + "return "+dataTypeSortKey+".__eq__(self."+dataTypeSortKey+", other."+dataTypeSortKey+")\n";
+
+//    return output;
+//}
+
+//function multiTab(tabbing, numTabs)
+//{
+//    var finalTabbing = "";
+//    while (numTabs != 0)
+//    {
+//        finalTabbing += tabbing;
+//        numTabs--;
+//    }
+//    return finalTabbing;
+//}
+
+// TODO: This will be needed for Model Generation
+//function getDefaultValueForType(property, datatype) {
+
+//    if (property.jsontype === "Number")
+//        return "0";
+//    if (datatype.jsontype === "String")
+//        return "\"\"";
+//    if(datatype.JsonType === "Object" && datatype.isOptional)
+//        return "None";
+//    //if(datatype.JsonType === "Object")
+//    //    return "new " + ?namespace ? + datatype.actualtype + "()";
+//    if(datatype.JsonType === "Object")
+//        return "new " + datatype.actualtype + "()";
+
+//    if (property.actualtype === "String")
+//        return "\"\"";
+//    else if (property.actualtype === "Boolean")
+//        return "False";
+//    else if (property.actualtype === "int16")
+//        return "0";
+//    else if (property.actualtype === "uint16")
+//        return "0";
+//    else if (property.actualtype === "int32")
+//        return "0";
+//    else if (property.actualtype === "uint32")
+//        return "0";
+//    else if (property.actualtype === "int64")
+//        return "0";
+//    else if (property.actualtype === "uint64")
+//        return "0";
+//    else if (property.actualtype === "float")
+//        return "0.0";
+//    else if (property.actualtype === "double")
+//        return "0.0";
+//    else if (property.actualtype === "DateTime")
+//        return "datetime.min";
+//    else if (property.isclass)
+//        return property.actualtype + "()";
+//    else if (property.isenum)
+//        return property.actualtype;
+//    else if (property.actualtype === "object")
+//        return "None";
+//    else
+//        throw "Unknown property type: " + property.actualtype + " for " + property.name + " in " + datatype.name;
+//}
+//
+//function addInitializeFunction(tabbing, propertySize)
+//{
+//    return tabbing + (propertySize > 0 ? "def __init__(self):" : "def __init__(self):\n"+tabbing+"    pass");
+//}

--- a/targets/Panda3DSdk/source/panda3d_playfab/PlayFabErrors.py.ejs
+++ b/targets/Panda3DSdk/source/panda3d_playfab/PlayFabErrors.py.ejs
@@ -1,0 +1,54 @@
+from enum import Enum
+
+class PlayFabErrorCode(Enum):
+    """
+    Error codes returned by PlayFabAPIs
+    """
+    Success = 0,
+    Unknown = 1,
+    ConnectionError = 2,
+    JsonParseError = 3,
+    <% for(var i=1; i<errorList.length-1; i++) { var errorProps = errors[errorList[i]] %><%- errorProps.name %> = <%- errorProps.id %>,
+    <% } %><% var errorProps = errors[errorList[errorList.length-1]] %><%- errorProps.name %> = <%- errorProps.id %>
+
+class PlayFabError:
+    def __init__(self, *args):
+        """
+        The first args item is expected to be a valid dictionary
+        """
+        if len(args) == 1:
+            self.fromJson(args[0])
+        else:
+            self.HttpCode = 408
+            self.HttpStatus = "Request Timeout"
+            self.Error = "ServiceUnavailable"
+            self.ErrorCode = PlayFabErrorCode.ServiceUnavailable
+            self.ErrorMessage = "Unable to contact PlayFab server"
+            self.ErrorDetails = None # dictionary of string keys and list of strings for values
+
+    def fromJson(self, other):
+        self.HttpCode = other["code"]
+        self.HttpStatus = other["status"]
+        self.Error = other["error"]
+        self.ErrorCode = other["errorCode"]
+        self.ErrorMessage = other["errorMessage"]
+        self.ErrorDetails = other.get("errorDetails", None)
+
+    def GenerateErrorReport(self):
+        str = ""
+        if self.ErrorMessage != None:
+            str = self.ErrorMessage
+        if self.ErrorDetails == None:
+            return str
+
+        for i in self.ErrorDetails.items():
+            str += "{}".format(i)
+
+        return str
+
+    def __str__(self):
+        return self.GenerateErrorReport()
+
+class PlayFabException(Exception):
+    pass
+

--- a/targets/Panda3DSdk/source/panda3d_playfab/PlayFabHTTP.py
+++ b/targets/Panda3DSdk/source/panda3d_playfab/PlayFabHTTP.py
@@ -1,0 +1,245 @@
+from direct.directnotify.DirectNotifyGlobal import directNotify  
+
+import traceback
+import json
+
+import panda3d_playfab.PlayFabSettings as PlayFabSettings
+import panda3d_playfab.PlayFabErrors as PlayFabErrors
+
+from panda3d.core import HTTPClient, HTTPChannel, DocumentSpec
+from panda3d.core import Ramfile, UniqueIdAllocator, ConfigVariableInt
+
+PlayFabNotify = directNotify.newCategory('playfab')
+
+class PlayFabRequest(object):
+    """
+    Represents a Playfab HTTP request currently in queue
+    """
+
+    def __init__(self, rest, requestId, channel, ram_file, callback=None):
+        self._rest = rest
+        self._requestId = requestId
+        self._channel = channel
+        self._callback = callback
+        self._ramFile = ram_file
+    
+    @property
+    def requestId(self):
+        return self._requestId
+
+    @property
+    def channel(self):
+        return self._channel
+
+    @property
+    def ram_file(self):
+        return self._ram_file
+
+    def update(self):
+        """
+        Performs the run operations and finishing callbacks
+        for the request's channel instance
+        """
+
+        if self._channel == None:
+            return
+
+        done = not self._channel.run()
+        if done:
+            PlayFabNotify.debug('Completed request: %s' % self._requestId)
+            
+            if self._callback != None:
+                try:
+                    self._callback(self._ramFile.get_data())
+                except Exception as e:
+                    PlayFabSettings.GlobalExceptionLogger(e) 
+
+            self._rest.RemoveRequest(self._requestId)
+
+class PlayFabHTTPQueue(object):
+    """
+    Static class for handling Playfab API requests with Panda's HTTPClient object 
+    """
+
+    def __init__(self):
+        self.__httpClient = HTTPClient()
+
+        MaxHTTPRequests = ConfigVariableInt('playfab-max-requests', 900).value
+        self.__requestAllocator = UniqueIdAllocator(0, MaxHTTPRequests)
+        self.__pollTask = None
+        self.__requests = {}
+
+    def Initialize(self):
+        """
+        Performs setup operations on the PlayFabHTTP singleton
+        """
+
+        self.__pollTask = taskMgr.add(
+            self.__UpdateRequests, 
+            '%s-update-task' % self.__class__.__name__)
+
+    def __UpdateRequests(self, task):
+        """
+        Performs update operations on the PlayFabHTTP singleton
+        """
+
+        for requestId in list(self.__requests):
+
+            # Check that this id is still valid
+            if requestId not in self.__requests:
+                continue
+
+            request = self.__requests[requestId]
+            request.update()
+
+        return task.cont
+
+    def Destroy(self):
+        """
+        Performs destruction operations on the PandaHTTP instance
+        """
+    
+        if self.__pollTask:
+            taskMgr.remove(self.__pollTask)
+
+        for requestId in list(self.__requests):
+            self.RemoveRequest(requestId)
+
+    def RemoveRequest(self, requestId):
+        """
+        Removes the request id form the PandaHTTP request list
+        """
+        
+        if requestId not in self.__requests:
+            return
+
+        self.__requestAllocator.free(requestId)
+        del self.__requests[requestId]
+
+    def GetRequestStatus(self, requestId):
+        """
+        Returns the requests current status
+        """
+
+        return not requestId in self.__requests
+
+    def GetRequest(self, requestId):
+        """
+        Returns the requested request if its present
+        """
+
+        return self.__requests.get(requestId, None) 
+
+    def PerformPostRequest(self, url, headers={}, contentType=None, postBody={}, callback=None):
+        """
+        """
+
+        PlayFabNotify.debug('Sending POST request: %s' % url)
+
+        requestChannel = self.__httpClient.make_channel(True)
+        if contentType != None:
+            requestChannel.set_content_type(contentType)
+
+        for headerKey in headers:
+            headerValue = headers[headerKey]
+            requestChannel.send_extra_header(headerKey, headerValue)
+
+        requestChannel.begin_post_form(DocumentSpec(url), postBody)
+
+        ramFile = Ramfile()
+        requestChannel.download_to_ram(ramFile, False)
+
+        requestId = self.__requestAllocator.allocate()
+        httpRequest = PlayFabRequest(self, requestId, requestChannel, ramFile, callback)
+        self.__requests[requestId] = httpRequest
+
+        return requestId
+
+HTTPQueue = PlayFabHTTPQueue()
+
+def DoPost(urlPath, request, authKey, authVal, callback, customData = None, extraHeaders = None):
+    """
+    Note this is a blocking call and will always run synchronously
+    the return type is a dictionary that should contain a valid dictionary that
+    should reflect the expected JSON response
+    if the call fails, there will be a returned PlayFabError
+    """
+
+    url = PlayFabSettings.GetURL(urlPath, PlayFabSettings._internalSettings.RequestGetParams)
+
+    try:
+        j = json.dumps(request)
+    except Exception as e:
+        raise PlayFabErrors.PlayFabException("The given request is not json serializable. {}".format(e))
+
+    requestHeaders = {}
+
+    if extraHeaders:
+        requestHeaders.update(extraHeaders)
+
+    requestHeaders["Content-Type"] = "application/json"
+    requestHeaders["X-PlayFabSDK"] = PlayFabSettings._internalSettings.SdkVersionString
+    requestHeaders["X-ReportErrorAsSuccess"] = "true" # Makes processing PlayFab errors a little easier
+
+    if authKey and authVal:
+        requestHeaders[authKey] = authVal
+
+    def PlayFabWrapper(data):
+        """
+        """
+
+        error = response = None
+        data = json.loads(data.decode('utf-8'))
+        if data["code"] != 200:
+            # Contacted PlayFab, but response indicated failure
+            error = data 
+        else:
+            # Successful call to PlayFab
+            response = data["data"]
+
+        if error and callback:
+            callGlobalErrorHandler(error)
+
+            try:
+                # Notify the caller about an API Call failure
+                callback(None, error) 
+            except Exception as e:
+                # Global notification about exception in caller's callback
+                PlayFabSettings.GlobalExceptionLogger(e) 
+        elif (response or response == {}) and callback:
+            try:
+                # Notify the caller about an API Call success
+                # User should also check for {} on the response as it can still be a valid call
+                callback(response, None) 
+            except Exception as e:
+                # Global notification about exception in caller's callback
+                PlayFabSettings.GlobalExceptionLogger(e) 
+        elif callback:
+            try:
+                # Notify the caller about an API issue, response was none
+                emptyResponseError = PlayFabErrors.PlayFabError()
+                emptyResponseError.Error = "Empty Response Recieved"
+                emptyResponseError.ErrorMessage = "PlayFabHTTP Recieved an empty response"
+                emptyResponseError.ErrorCode = PlayFabErrors.PlayFabErrorCode.Unknown
+                callback(None, emptyResponseError)
+            except Exception as e:
+                # Global notification about exception in caller's callback
+                PlayFabSettings.GlobalExceptionLogger(e) 
+
+    requestId = HTTPQueue.PerformPostRequest(
+        url=url, 
+        headers=requestHeaders, 
+        contentType="application/json",
+        postBody=j,
+        callback=PlayFabWrapper)
+
+    return requestId
+
+def callGlobalErrorHandler(error):
+    if PlayFabSettings.GlobalErrorHandler:
+        try: 
+            # Global notification about an API Call failure
+            PlayFabSettings.GlobalErrorHandler(error)
+        except Exception as e:
+            # Global notification about exception in caller's callback
+            PlayFabSettings.GlobalExceptionLogger(e) 

--- a/targets/Panda3DSdk/source/panda3d_playfab/PlayFabManualTest.py
+++ b/targets/Panda3DSdk/source/panda3d_playfab/PlayFabManualTest.py
@@ -1,0 +1,69 @@
+"""
+These test API calls are synchronous and will block the current running python process.
+"""
+
+from panda3d_playfab import *
+import PlayFabManualTestSettings
+
+# This needs to be set for the application to work properly.
+# This can be found in the GameManger for your Title of the PlayFab website
+PlayFabSettings.TitleId = PlayFabManualTestSettings.TitleId
+customId = PlayFabManualTestSettings.customId
+
+request = {}
+
+request["CreateAccount"] = True
+request["CustomId"] = customId
+request["TitleId"] = PlayFabSettings.TitleId
+
+def loginCallback(success, fail):
+    if fail:
+        print(fail)
+    else:
+        print(success)
+
+PlayFabClientAPI.LoginWithCustomID(request, loginCallback)
+
+def entityTokenCallback(success, fail):
+    global EntityKey
+    if fail:
+        print(fail)
+    else:
+        EntityKey = success["Entity"]
+        print(success)
+
+etRequest = {}
+PlayFabAuthenticationAPI.GetEntityToken(etRequest, entityTokenCallback)
+
+def entityObjectCallback(success, fail):
+    if fail:
+        print(fail)
+    else:
+        print(success)
+
+# need to add entity id to this request
+eoRequest = {}
+PlayFabDataAPI.GetObjects(etRequest, entityObjectCallback)
+
+eoRequest2 = {
+    "Entity" : EntityKey
+}
+PlayFabDataAPI.GetObjects(eoRequest2, entityObjectCallback)
+
+def titleDataReqCallback(success, fail):
+    if fail:
+        print(fail)
+    else:
+        print(success)
+
+try:
+    titleDataRequest = {}
+    PlayFabServerAPI.GetTitleData(titleDataRequest, titleDataReqCallback)
+except PlayFabErrors.PlayFabException as e:
+    print("Caught expected error")
+    PlayFabSettings.GlobalExceptionLogger(e)
+
+PlayFabSettings.DeveloperSecretKey = PlayFabManualTestSettings.DeveloperSeceretKey
+
+titleDataRequest2 = {}
+PlayFabServerAPI.GetTitleData(titleDataRequest, titleDataReqCallback)

--- a/targets/Panda3DSdk/source/panda3d_playfab/PlayFabSettings.py.ejs
+++ b/targets/Panda3DSdk/source/panda3d_playfab/PlayFabSettings.py.ejs
@@ -1,0 +1,104 @@
+import panda3d_playfab.PlayFabErrors as PlayFabErrors
+
+import sys
+import traceback
+
+ProductionEnvironmentURL = ".playfabapi.com"
+
+"""
+The name of a customer vertical. This is only for customers running a private cluster. Generally you shouldn't touch this
+"""
+VerticalName = <%- getVerticalNameDefault() %>
+
+"""
+You must set this value for PlayFabSdk to work properly (Found in the Game
+Manager for your title, at the PlayFab Website)
+"""
+
+TitleId = ""
+
+"""
+You must set this value for Admin/Server/Matchmaker to work properly (Found in the Game
+Manager for your title, at the PlayFab Website)
+"""
+
+DeveloperSecretKey = None
+
+"""
+Client specifics
+"""
+
+"""
+Set this to the appropriate AD_TYPE_X constant below
+"""
+AdvertisingIdType = ""
+
+"""
+Set this to corresponding device value
+"""
+AdvertisingIdValue = None
+
+"""
+DisableAdvertising is provided for completeness, but changing it is not
+suggested
+Disabling this may prevent your advertising-related PlayFab marketplace
+partners from working correctly
+"""
+
+DisableAdvertising = False
+AD_TYPE_IDFA = "Idfa"
+AD_TYPE_ANDROID_ID = "Adid"
+
+class InternalSettings:
+    pass
+
+_internalSettings = InternalSettings()
+
+"""
+This is automatically populated by the PlayFabAuthenticationApi.GetEntityToken method.
+"""
+_internalSettings.EntityToken = None
+
+"""
+This is automatically populated by any PlayFabClientApi.Login method.
+"""
+_internalSettings.ClientSessionTicket = None
+_internalSettings.SdkVersionString = "PythonSdk-<%- sdkVersion %>"
+_internalSettings.RequestGetParams = {
+    "sdk": _internalSettings.SdkVersionString
+}
+
+def GetURL(methodUrl, getParams):
+    if not TitleId:
+        raise PlayFabErrors.PlayFabException("You must set PlayFabSettings.TitleId before making an API call")
+
+    url = []
+    if not ProductionEnvironmentURL.startswith("http"):
+        if VerticalName:
+            url.append("https://")
+            url.append(VerticalName)
+        else:
+            url.append("https://")
+            url.append(TitleId)
+
+    url.append(ProductionEnvironmentURL)
+    url.append(methodUrl)
+
+    if getParams:
+        for idx, (k, v) in enumerate(getParams.items()):
+            if idx == 0:
+                url.append("?")
+            else:
+                url.append("&")
+            url.append(k)
+            url.append("=")
+            url.append(v)
+
+    return "".join(url)
+
+def DefaultExceptionLogger(exceptionObj):
+    print("Unexpected error:", sys.exc_info()[0])
+    traceback.print_exc()
+
+GlobalErrorHandler = None
+GlobalExceptionLogger = DefaultExceptionLogger

--- a/targets/Panda3DSdk/source/panda3d_playfab/__init__.py.ejs
+++ b/targets/Panda3DSdk/source/panda3d_playfab/__init__.py.ejs
@@ -1,0 +1,12 @@
+<% for (var a = 0; a < apis.length; a++) { var api = apis[a];
+%>import panda3d_playfab.PlayFab<%- api.name %>API as PlayFab<%- api.name %>API
+<% } %>
+import panda3d_playfab.PlayFabErrors as PlayFabErrors
+import panda3d_playfab.PlayFabHTTP as PlayFabHTTP
+import panda3d_playfab.PlayFabSettings as PlayFabSettings
+
+__all__ = ["PlayFabErrors", "PlayFabHTTP", "PlayFabSettings"]
+
+<% for (var a = 0; a < apis.length; a++) { var api = apis[a];
+%>__all__.append("PlayFab<%- api.name %>API")
+<% } %>

--- a/targets/Panda3DSdk/source/panda3d_playfab/testCompile.py.ejs
+++ b/targets/Panda3DSdk/source/panda3d_playfab/testCompile.py.ejs
@@ -1,0 +1,15 @@
+import py_compile
+
+files = [
+<% for (var a = 0; a < apis.length; a++) { var api = apis[a];
+%>"PlayFab<%- api.name %>API.py",
+<% } %>
+"__init__.py",
+"PlayFabErrors.py",
+"PlayFabHTTP.py",
+"PlayFabSettings.py",
+"PlayFabManualTest.py"
+]
+
+for eachFile in files:
+    py_compile.compile(eachFile)

--- a/targets/Panda3DSdk/source/setup.py.ejs
+++ b/targets/Panda3DSdk/source/setup.py.ejs
@@ -1,0 +1,23 @@
+import setuptools
+with open("README.md", "r") as fh:
+        long_description = fh.read()
+        
+setuptools.setup(
+    name="panda3d_playfab",
+    version="<%- sdkVersion %>",
+    author="PlayFab Dev Tools team",
+    author_email="helloplayfab@microsoft.com",
+    description="PlayFab Panda3D SDK current API version: <%- sdkVersion %>",
+    long_description=long_description,
+    url="https://github.com/PlayFab/Panda3DSdk",
+    packages=setuptools.find_packages(),
+    install_requires=[
+        'panda3d',
+    ],
+    classifiers=[
+        "Programming Language :: Python :: 3",
+        "License :: OSI Approved :: Apache Software License",
+        "Operating System :: OS Independent",
+        "Topic :: Games/Entertainment",
+    ],
+)

--- a/targets/Panda3DSdk/templates/API.py.ejs
+++ b/targets/Panda3DSdk/templates/API.py.ejs
@@ -1,0 +1,37 @@
+import panda3d_playfab.PlayFabErrors as PlayFabErrors
+import panda3d_playfab.PlayFabHTTP as PlayFabHTTP
+import panda3d_playfab.PlayFabSettings as PlayFabSettings
+
+<%- generateApiSummary("", api, "description")
+%><% if (hasClientOptions) {
+%>
+def IsClientLoggedIn():
+    """Determine if the client session ticket is set, without actually making it public"""
+    return bool(PlayFabSettings._internalSettings.ClientSessionTicket)
+
+def MultiStepClientLogin(settingsForUser):
+    disabledAds = PlayFabSettings.DisableAdvertising
+    adIdType = PlayFabSettings.AdvertisingIdType
+    adIdVal = PlayFabSettings.AdvertisingIdValue
+
+    if settingsForUser and settingsForUser["NeedsAttribution"] and not disabledAds and adIdType and adIdVal:
+        request = {}
+        if adIdType == PlayFabSettings.AD_TYPE_IDFA:
+            request["Idfa"] = adIdVal
+        elif adIdType == PlayFabSettings.AD_TYPE_ANDROID_ID:
+            request["Adid"] = adIdVal
+        AttributeInstall(request, None)
+<% } %>
+<% for(var i in api.calls) { var apiCall = api.calls[i];
+%><%- getDeprecationAttribute("", apiCall)
+%>def <%- apiCall.name %>(request, callback, customData = None, extraHeaders = None):
+<%- generateApiSummary("    ", apiCall, "summary", "https://docs.microsoft.com/rest/api/playfab/" + api.name.toLowerCase() + "/" + apiCall.subgroup.toLowerCase().replaceAll(" ","-") + "/" + apiCall.name.toLowerCase())
+%><%- getRequestActions("    ", apiCall) 
+%>    def wrappedCallback(playFabResult, error):
+<%- getResultActions("        ", apiCall, api) 
+%>        if callback:
+            callback(playFabResult, error)
+
+    return PlayFabHTTP.DoPost("<%- apiCall.url %>", request, <%- getAuthParams(apiCall) %>, wrappedCallback, customData, extraHeaders)
+
+<% } %>


### PR DESCRIPTION
This build target functions similarly to the already existing PythonSdk. However it replaces requests with the engine's built in HTTPClient to allow for async http calls that can nicely coexist with the rest of the engine. In a normal scenario using Panda3D having blocking calls in critical points in the application can cause unwanted application lag due to Python's single threaded nature. 

This was created using what knowledge I have of PlayFab's requirements. I am open to adjusting things as required if there is interest in adding Panda3D support to PlayFab's SDK list.