### PR TITLE
Update PlayFabWebRequest.cs

### DIFF
--- a/targets/unity-v2/source/ExampleTestProject/Assets/PlayFabSDK/Shared/Internal/PlayFabHttp/PlayFabWebRequest.cs
+++ b/targets/unity-v2/source/ExampleTestProject/Assets/PlayFabSDK/Shared/Internal/PlayFabHttp/PlayFabWebRequest.cs
@@ -420,7 +420,10 @@ namespace PlayFab.Internal
                 reqContainer.ApiResult.Request = reqContainer.ApiRequest;
                 reqContainer.ApiResult.CustomData = reqContainer.CustomData;
 
-                PlayFabHttp.instance.OnPlayFabApiResult(reqContainer);
+                if(_isApplicationPlaying)
+                {
+                    PlayFabHttp.instance.OnPlayFabApiResult(reqContainer);
+                }
 
 #if !DISABLE_PLAYFABCLIENT_API
                 lock (ResultQueueTransferThread)


### PR DESCRIPTION
only calls OnPlayFabApiResult if the application is playing (bug is, when it is not playing, that function may break due to an instance no longer being valid because the game was supposed to be closed).