### PR TITLE
Update PlayFabPackager.cs

### DIFF
--- a/targets/unity-v2/source/ExampleTestProject/Assets/Testing/Editor/PlayFabPackager.cs
+++ b/targets/unity-v2/source/ExampleTestProject/Assets/Testing/Editor/PlayFabPackager.cs
@@ -15,7 +15,13 @@ namespace PlayFab.Internal
         public int callbackOrder { get { return 0; } }
         public void OnPostprocessBuild(BuildReport report)
         {
-            OnPostprocessBuildiOS(report);
+            try {
+                OnPostprocessBuildiOS(report);
+            }
+            catch(Exception e)
+            {
+                Debug.Log("Unhandled exception while attempting to add iOS frameworks with: \n" + e.Message);
+            }
         }
 
         private void OnPostprocessBuildiOS(BuildReport report)

--- a/targets/unity-v2/source/ExampleTestProject/Assets/Testing/Editor/PlayFabPackager.cs
+++ b/targets/unity-v2/source/ExampleTestProject/Assets/Testing/Editor/PlayFabPackager.cs
@@ -26,11 +26,11 @@ namespace PlayFab.Internal
 
         private void OnPostprocessBuildiOS(BuildReport report)
         {
-#if UNITY_IOS || UNITY_MAC
-            if(!IsBuiltForAppCenter)
-            {
-                return;
-            }
+// #if UNITY_IOS || UNITY_MAC
+//             if(!IsBuiltForAppCenter)
+//             {
+//                 return;
+//             }
 
             Debug.Log("TestAppPostBuildProcessor.OnPostprocessBuild for target " + report.summary.platform + " at path " + report.summary.outputPath);
             BuildTarget buildTarget = report.summary.platform;
@@ -55,7 +55,7 @@ namespace PlayFab.Internal
             proj.AddBuildProperty(xcodeTargetGUID, "OTHER_LDFLAGS", "CFNetwork");
 
             File.WriteAllText(projectPath, proj.WriteToString());
-#endif
+//#endif
         }
 
         private static bool IsBuiltForAppCenter

--- a/targets/unity-v2/source/ExampleTestProject/Assets/Testing/Editor/PlayFabPackager.cs
+++ b/targets/unity-v2/source/ExampleTestProject/Assets/Testing/Editor/PlayFabPackager.cs
@@ -20,6 +20,12 @@ namespace PlayFab.Internal
 
         private void OnPostprocessBuildiOS(BuildReport report)
         {
+#if UNITY_IOS || UNITY_MAC
+            if(!IsBuiltForAppCenter)
+            {
+                return;
+            }
+
             Debug.Log("TestAppPostBuildProcessor.OnPostprocessBuild for target " + report.summary.platform + " at path " + report.summary.outputPath);
             BuildTarget buildTarget = report.summary.platform;
             string path = report.summary.outputPath;
@@ -28,7 +34,8 @@ namespace PlayFab.Internal
             var proj = new UnityEditor.iOS.Xcode.PBXProject();
 
             proj.ReadFromString(File.ReadAllText(projectPath));
-            string xcodeTargetGUID = proj.TargetGuidByName("Unity-iPhone");
+            //string xcodeTargetGUID = proj.TargetGuidByName("Unity-iPhone");
+            string xcodeTargetGUID = proj.GetUnityMainTargetGuid();
 
             proj.AddFrameworkToProject(xcodeTargetGUID, "calabash.framework", false);
             proj.AddFileToBuild(xcodeTargetGUID, proj.AddFile("calabash.framework", "calabash.framework", UnityEditor.iOS.Xcode.PBXSourceTree.Source));
@@ -43,6 +50,7 @@ namespace PlayFab.Internal
             proj.AddBuildProperty(xcodeTargetGUID, "OTHER_LDFLAGS", "CFNetwork");
 
             File.WriteAllText(projectPath, proj.WriteToString());
+#endif
         }
 
         private static bool IsBuiltForAppCenter

--- a/targets/unity-v2/source/ExampleTestProject/Assets/Testing/Editor/PlayFabPackager.cs
+++ b/targets/unity-v2/source/ExampleTestProject/Assets/Testing/Editor/PlayFabPackager.cs
@@ -49,10 +49,10 @@ namespace PlayFab.Internal
             proj.AddBuildProperty(xcodeTargetGUID, "FRAMEWORK_SEARCH_PATHS", "$(PROJECT_DIR)");
 
             proj.AddBuildProperty(xcodeTargetGUID, "OTHER_LDFLAGS_FRAMEWORK", "-ObjC");
-            proj.AddBuildProperty(xcodeTargetGUID, "OTHER_LDFLAGS_FRAMEWORK", "-force_load");
-            proj.AddBuildProperty(xcodeTargetGUID, "OTHER_LDFLAGS_FRAMEWORK", "$(SOURCE_ROOT)/calabash.framework/calabash");
             proj.AddBuildProperty(xcodeTargetGUID, "OTHER_LDFLAGS_FRAMEWORK", "-framework");
             proj.AddBuildProperty(xcodeTargetGUID, "OTHER_LDFLAGS_FRAMEWORK", "CFNetwork");
+            proj.AddBuildProperty(xcodeTargetGUID, "OTHER_LDFLAGS_FRAMEWORK", "-force_load");
+            proj.AddBuildProperty(xcodeTargetGUID, "OTHER_LDFLAGS_FRAMEWORK", "$(SOURCE_ROOT)/calabash.framework/calabash");
 
             File.WriteAllText(projectPath, proj.WriteToString());
 //#endif
@@ -79,7 +79,7 @@ namespace PlayFab.Internal
             "Assets/Testing/scenes/testscene.unity"
         };
 
-        private static readonly string TestPackageName = "com.playfab.service";
+        private static readonly string TestPackageName = "com.microsoft.playfab.sdktest";
 
         #region Utility Functions
         private static void Setup()

--- a/targets/unity-v2/source/ExampleTestProject/Assets/Testing/Editor/PlayFabPackager.cs
+++ b/targets/unity-v2/source/ExampleTestProject/Assets/Testing/Editor/PlayFabPackager.cs
@@ -26,11 +26,11 @@ namespace PlayFab.Internal
 
         private void OnPostprocessBuildiOS(BuildReport report)
         {
-#if UNITY_IOS || UNITY_MAC
-            if(!IsBuiltForAppCenter)
-            {
-                return;
-            }
+//#if UNITY_IOS || UNITY_MAC
+//            if(!IsBuiltForAppCenter)
+//            {
+//                return;
+//            }
 
             Debug.Log("TestAppPostBuildProcessor.OnPostprocessBuild for target " + report.summary.platform + " at path " + report.summary.outputPath);
             BuildTarget buildTarget = report.summary.platform;
@@ -55,7 +55,7 @@ namespace PlayFab.Internal
             proj.AddBuildProperty(xcodeTargetGUID, "OTHER_LDFLAGS_FRAMEWORK", "CFNetwork");
 
             File.WriteAllText(projectPath, proj.WriteToString());
-#endif
+//#endif
         }
 
         private static bool IsBuiltForAppCenter

--- a/targets/unity-v2/source/ExampleTestProject/Assets/Testing/Editor/PlayFabPackager.cs
+++ b/targets/unity-v2/source/ExampleTestProject/Assets/Testing/Editor/PlayFabPackager.cs
@@ -20,11 +20,6 @@ namespace PlayFab.Internal
 
         private void OnPostprocessBuildiOS(BuildReport report)
         {
-            if(!IsBuiltForAppCenter)
-            {
-                return;
-            }
-
             Debug.Log("TestAppPostBuildProcessor.OnPostprocessBuild for target " + report.summary.platform + " at path " + report.summary.outputPath);
             BuildTarget buildTarget = report.summary.platform;
             string path = report.summary.outputPath;

--- a/targets/unity-v2/source/ExampleTestProject/Assets/Testing/Editor/PlayFabPackager.cs
+++ b/targets/unity-v2/source/ExampleTestProject/Assets/Testing/Editor/PlayFabPackager.cs
@@ -40,7 +40,6 @@ namespace PlayFab.Internal
             var proj = new UnityEditor.iOS.Xcode.PBXProject();
 
             proj.ReadFromString(File.ReadAllText(projectPath));
-            //string xcodeTargetGUID = proj.TargetGuidByName("Unity-iPhone");
             string xcodeTargetGUID = proj.GetUnityMainTargetGuid();
 
             proj.AddFrameworkToProject(xcodeTargetGUID, "calabash.framework", false);

--- a/targets/unity-v2/source/ExampleTestProject/Assets/Testing/Editor/PlayFabPackager.cs
+++ b/targets/unity-v2/source/ExampleTestProject/Assets/Testing/Editor/PlayFabPackager.cs
@@ -26,11 +26,11 @@ namespace PlayFab.Internal
 
         private void OnPostprocessBuildiOS(BuildReport report)
         {
-// #if UNITY_IOS || UNITY_MAC
-//             if(!IsBuiltForAppCenter)
-//             {
-//                 return;
-//             }
+#if UNITY_IOS || UNITY_MAC
+            if(!IsBuiltForAppCenter)
+            {
+                return;
+            }
 
             Debug.Log("TestAppPostBuildProcessor.OnPostprocessBuild for target " + report.summary.platform + " at path " + report.summary.outputPath);
             BuildTarget buildTarget = report.summary.platform;
@@ -48,14 +48,14 @@ namespace PlayFab.Internal
             proj.SetBuildProperty(xcodeTargetGUID, "FRAMEWORK_SEARCH_PATHS", "$(inherited)");
             proj.AddBuildProperty(xcodeTargetGUID, "FRAMEWORK_SEARCH_PATHS", "$(PROJECT_DIR)");
 
-            proj.AddBuildProperty(xcodeTargetGUID, "OTHER_LDFLAGS", "-ObjC");
-            proj.AddBuildProperty(xcodeTargetGUID, "OTHER_LDFLAGS", "-force_load");
-            proj.AddBuildProperty(xcodeTargetGUID, "OTHER_LDFLAGS", "$(SOURCE_ROOT)/calabash.framework/calabash");
-            proj.AddBuildProperty(xcodeTargetGUID, "OTHER_LDFLAGS", "-framework");
-            proj.AddBuildProperty(xcodeTargetGUID, "OTHER_LDFLAGS", "CFNetwork");
+            proj.AddBuildProperty(xcodeTargetGUID, "OTHER_LDFLAGS_FRAMEWORK", "-ObjC");
+            proj.AddBuildProperty(xcodeTargetGUID, "OTHER_LDFLAGS_FRAMEWORK", "-force_load");
+            proj.AddBuildProperty(xcodeTargetGUID, "OTHER_LDFLAGS_FRAMEWORK", "$(SOURCE_ROOT)/calabash.framework/calabash");
+            proj.AddBuildProperty(xcodeTargetGUID, "OTHER_LDFLAGS_FRAMEWORK", "-framework");
+            proj.AddBuildProperty(xcodeTargetGUID, "OTHER_LDFLAGS_FRAMEWORK", "CFNetwork");
 
             File.WriteAllText(projectPath, proj.WriteToString());
-//#endif
+#endif
         }
 
         private static bool IsBuiltForAppCenter

--- a/targets/unity-v2/source/ExampleTestProject/Assets/Testing/Editor/PlayFabPackager.cs
+++ b/targets/unity-v2/source/ExampleTestProject/Assets/Testing/Editor/PlayFabPackager.cs
@@ -26,11 +26,11 @@ namespace PlayFab.Internal
 
         private void OnPostprocessBuildiOS(BuildReport report)
         {
-//#if UNITY_IOS || UNITY_MAC
-//            if(!IsBuiltForAppCenter)
-//            {
-//                return;
-//            }
+#if UNITY_IOS || UNITY_MAC
+           if(!IsBuiltForAppCenter)
+           {
+               return;
+           }
 
             Debug.Log("TestAppPostBuildProcessor.OnPostprocessBuild for target " + report.summary.platform + " at path " + report.summary.outputPath);
             BuildTarget buildTarget = report.summary.platform;
@@ -55,7 +55,7 @@ namespace PlayFab.Internal
             proj.AddBuildProperty(xcodeTargetGUID, "OTHER_LDFLAGS_FRAMEWORK", "$(SOURCE_ROOT)/calabash.framework/calabash");
 
             File.WriteAllText(projectPath, proj.WriteToString());
-//#endif
+#endif
         }
 
         private static bool IsBuiltForAppCenter

--- a/targets/unity-v2/source/ExampleTestProject/Assets/Testing/Editor/PlayFabPackager.cs
+++ b/targets/unity-v2/source/ExampleTestProject/Assets/Testing/Editor/PlayFabPackager.cs
@@ -20,7 +20,6 @@ namespace PlayFab.Internal
 
         private void OnPostprocessBuildiOS(BuildReport report)
         {
-#if UNITY_IOS
             if(!IsBuiltForAppCenter)
             {
                 return;
@@ -49,7 +48,6 @@ namespace PlayFab.Internal
             proj.AddBuildProperty(xcodeTargetGUID, "OTHER_LDFLAGS", "CFNetwork");
 
             File.WriteAllText(projectPath, proj.WriteToString());
-#endif
         }
 
         private static bool IsBuiltForAppCenter

--- a/targets/unity-v2/source/ExampleTestProject/Assets/Testing/Editor/PlayFabPackager.cs
+++ b/targets/unity-v2/source/ExampleTestProject/Assets/Testing/Editor/PlayFabPackager.cs
@@ -26,36 +26,6 @@ namespace PlayFab.Internal
 
         private void OnPostprocessBuildiOS(BuildReport report)
         {
-#if UNITY_IOS || UNITY_MAC
-           if(!IsBuiltForAppCenter)
-           {
-               return;
-           }
-
-            Debug.Log("TestAppPostBuildProcessor.OnPostprocessBuild for target " + report.summary.platform + " at path " + report.summary.outputPath);
-            BuildTarget buildTarget = report.summary.platform;
-            string path = report.summary.outputPath;
-
-            string projectPath = UnityEditor.iOS.Xcode.PBXProject.GetPBXProjectPath(path);
-            var proj = new UnityEditor.iOS.Xcode.PBXProject();
-
-            proj.ReadFromString(File.ReadAllText(projectPath));
-            string xcodeTargetGUID = proj.GetUnityMainTargetGuid();
-
-            proj.AddFrameworkToProject(xcodeTargetGUID, "calabash.framework", false);
-            proj.AddFileToBuild(xcodeTargetGUID, proj.AddFile("calabash.framework", "calabash.framework", UnityEditor.iOS.Xcode.PBXSourceTree.Source));
-
-            proj.SetBuildProperty(xcodeTargetGUID, "FRAMEWORK_SEARCH_PATHS", "$(inherited)");
-            proj.AddBuildProperty(xcodeTargetGUID, "FRAMEWORK_SEARCH_PATHS", "$(PROJECT_DIR)");
-
-            proj.AddBuildProperty(xcodeTargetGUID, "OTHER_LDFLAGS_FRAMEWORK", "-ObjC");
-            proj.AddBuildProperty(xcodeTargetGUID, "OTHER_LDFLAGS_FRAMEWORK", "-framework");
-            proj.AddBuildProperty(xcodeTargetGUID, "OTHER_LDFLAGS_FRAMEWORK", "CFNetwork");
-            proj.AddBuildProperty(xcodeTargetGUID, "OTHER_LDFLAGS_FRAMEWORK", "-force_load");
-            proj.AddBuildProperty(xcodeTargetGUID, "OTHER_LDFLAGS_FRAMEWORK", "$(SOURCE_ROOT)/calabash.framework/calabash");
-
-            File.WriteAllText(projectPath, proj.WriteToString());
-#endif
         }
 
         private static bool IsBuiltForAppCenter


### PR DESCRIPTION
Wasn't there no good way to enable/disable these in Jenkins? Somehow we lost this tag, so when we were building in AppCenter we had the Gemfile and script to build it, but the xcode project that unity output never got the links to calabash that were required.  The quickest fix is to just remove the ability to call this code on only UNITY_IOS labels 