### PR TITLE
Removing Accept-Encoding from future web requests

### DIFF
--- a/targets/unity-v2/source/ExampleTestProject/Assets/PlayFabSDK/Shared/Internal/PlayFabHttp/PlayFabUnityHttp.cs
+++ b/targets/unity-v2/source/ExampleTestProject/Assets/PlayFabSDK/Shared/Internal/PlayFabHttp/PlayFabUnityHttp.cs
@@ -101,7 +101,9 @@ namespace PlayFab.Internal
             if (PlayFabSettings.CompressApiData)
             {
                 reqContainer.RequestHeaders["Content-Encoding"] = "GZIP";
+#if !UNITY_2020_1_OR_NEWER
                 reqContainer.RequestHeaders["Accept-Encoding"] = "GZIP";
+#endif
 
                 using (var stream = new MemoryStream())
                 {

--- a/targets/unity-v2/source/ExampleTestProject/Assets/PlayFabSDK/Shared/Internal/PlayFabHttp/PlayFabWWW.cs
+++ b/targets/unity-v2/source/ExampleTestProject/Assets/PlayFabSDK/Shared/Internal/PlayFabHttp/PlayFabWWW.cs
@@ -105,7 +105,9 @@ namespace PlayFab.Internal
             if (PlayFabSettings.CompressApiData)
             {
                 reqContainer.RequestHeaders["Content-Encoding"] = "GZIP";
+#if !UNITY_2020_1_OR_NEWER
                 reqContainer.RequestHeaders["Accept-Encoding"] = "GZIP";
+#endif
 
                 using (var stream = new MemoryStream())
                 {


### PR DESCRIPTION
Unity 2020 will throw a ton of warnings if you include PlayFab anywhere in your Asset folder.

Supposedly Unity has changed how their WebRequests are working under the hood.

We should only need to declare Content-Encoding, Accept-Encoding will either not be looked at by Unity, or certain platforms may experience undefined behavior.

It is recommended we don't fill in Accept-Encoding.