### PR TITLE
Support AF debugging in Unity with C# SDK

### DIFF
--- a/targets/csharp/source/PlayFabSDK/source/PlayFabSettings.cs.ejs
+++ b/targets/csharp/source/PlayFabSDK/source/PlayFabSettings.cs.ejs
@@ -50,7 +50,7 @@ namespace PlayFab
 #endif
 <% } %>        #endregion Deprecated staticSettingsredirect properties
 
-#if !NET45 && !NETSTANDARD2_0
+#if !NET45 && !NETSTANDARD2_0 && !UNITY_EDITOR && !UNITY_STANDALONE
         private static string _localApiServer;
 #endif
 
@@ -58,13 +58,13 @@ namespace PlayFab
         {
             get
             {
-#if NET45 || NETSTANDARD2_0
+#if NET45 || NETSTANDARD2_0 || UNITY_EDITOR || UNITY_STANDALONE
                 return PlayFabUtil.GetLocalSettingsFile().LocalApiServer;
 #else
                 return _localApiServer;
 #endif
             }
-#if !NET45 && !NETSTANDARD2_0
+#if !NET45 && !NETSTANDARD2_0 && !UNITY_EDITOR && !UNITY_STANDALONE
             set
             {
                 _localApiServer = value;


### PR DESCRIPTION
Some game developers are using the PlayFab C# SDK in their Unity games.
This PR adds the UNITY_EDITOR and UNITY_STANDALONE constants to the #if
controls for the LocalServerApi setting. This will allow this setting
to work correctly via the settings file when using the PlayFab C# SDK
in a Unity game.