### PR TITLE
remove windows phone target

### DIFF
--- a/targets/unity-v2/source/ExampleTestProject/Assets/Testing/Editor/PlayFabPackager.cs
+++ b/targets/unity-v2/source/ExampleTestProject/Assets/Testing/Editor/PlayFabPackager.cs
@@ -310,8 +310,10 @@ namespace PlayFab.Internal
         {
             Setup();
 #if UNITY_2017_1_OR_NEWER
+#if !UNITY_2021_1_OR_NEWER
             EditorUserBuildSettings.wsaBuildAndRunDeployTarget = WSABuildAndRunDeployTarget.WindowsPhone;
             EditorUserBuildSettings.wsaSubtarget = WSASubtarget.AnyDevice;
+#endif
 #if !UNITY_2019_1_OR_NEWER
             EditorUserBuildSettings.wsaGenerateReferenceProjects = true;
 #endif


### PR DESCRIPTION
Unity 2021 errors out when we load the PlayFab Unity SDK, complaining about the two lines we are omitting in future Unity versions