### PR TITLE
Fix the typo in #if Unity_2021_1_OR_NEWER

### DIFF
--- a/targets/unity-v2/source/ExampleTestProject/Assets/PlayFabSDK/Shared/Internal/PlayFabHttp/PlayFabUnityHttp.cs
+++ b/targets/unity-v2/source/ExampleTestProject/Assets/PlayFabSDK/Shared/Internal/PlayFabHttp/PlayFabUnityHttp.cs
@@ -81,7 +81,7 @@ namespace PlayFab.Internal
                 yield return request.Send();
 #endif
 
-#if Unity_2021_1_OR_NEWER
+#if UNITY_2021_1_OR_NEWER
                 if (request.result == UnityWebRequest.Result.ConnectionError || request.result == UnityWebRequest.Result.ProtocolError)
 #else
                 if (request.isNetworkError || request.isHttpError)


### PR DESCRIPTION
Customer reported there is a typo in version define in Unity SDK. UNITY needs to be capitalized to work. Open this PR on behalf of the customer.
Refer https://community.playfab.com/questions/57660/typo-in-if-unity-2021-1-or-newer.html