### PR TITLE
[Unity] fix: check SdkPath for null or empty before deleting the SDK

### DIFF
--- a/targets/unity-v2/source/ExampleTestProject/Assets/PlayFabEditorExtensions/Editor/Scripts/Panels/PlayFabEditorSDKTools.cs
+++ b/targets/unity-v2/source/ExampleTestProject/Assets/PlayFabEditorExtensions/Editor/Scripts/Panels/PlayFabEditorSDKTools.cs
@@ -373,7 +373,7 @@ namespace PlayFab.PfEditor
                     FileUtil.DeleteFileOrDirectory(file);
             }
 
-            if (FileUtil.DeleteFileOrDirectory(PlayFabEditorPrefsSO.Instance.SdkPath))
+            if (!string.IsNullOrEmpty(PlayFabEditorPrefsSO.Instance.SdkPath) && FileUtil.DeleteFileOrDirectory(PlayFabEditorPrefsSO.Instance.SdkPath))
             {
                 PlayFabEditor.RaiseStateUpdate(PlayFabEditor.EdExStates.OnSuccess, "PlayFab SDK Removed!");
 


### PR DESCRIPTION
Hi,

I've posted this to the forum: https://community.playfab.com/questions/57907/unity-potential-issue-in-playfab-editor-extension.html

Some days ago I've had an issue that, for whatever reason, the sdkPath provided by `PlayFabEditorPrefsSO.Instance.SdkPath` was null or empty. If that's the case, Unity's `FileUtil.DeleteFileOrDirectory` will use the current working directory of the editor. By that, the whole project simply gets deleted, also other folders like `.git` etc. will be removed. 

While I can not reproduce the issue why `PlayFabEditorPrefsSO.Instance.SdkPath` was null or whitespace (that would be the better fix), we can still check when deleting the sdk if a path is set. 

This PR will simply use `string.IsNullOrEmpty` to prevent deleting the whole project.

Meanwhile, Unity also accepted this as a bug: https://issuetracker.unity3d.com/issues/fileutil-dot-deletefileordirectory-deletes-the-entire-project-folder-when-it-is-passed-a-null-value

Since there is no statement, when this will be used, it may be nice if PlayFab simply checks the path before deleting.