### PR TITLE
[Unity] fix: potential memory leak in PlayFabUnityHttp

### DIFF
--- a/targets/unity-v2/source/ExampleTestProject/Assets/PlayFabSDK/Shared/Internal/PlayFabHttp/PlayFabUnityHttp.cs
+++ b/targets/unity-v2/source/ExampleTestProject/Assets/PlayFabSDK/Shared/Internal/PlayFabHttp/PlayFabUnityHttp.cs
@@ -93,6 +93,8 @@ namespace PlayFab.Internal
                 {
                     successCallback(request.downloadHandler.data);
                 }
+
+                request.Dispose();
             }
         }
 


### PR DESCRIPTION
Hi,

I've written more about the issue https://community.playfab.com/questions/56356/possible-bugmemory-leak-in-playfab-unity-sdk-when.html below is a TL;DR

Within the `PlayFabUnityHttp.cs` file, at the end of the method `Post` the UnityWebRequest `www` will be disposed. 
If you then take a look at `SimpleCallCoroutine` you can see, that the request will not be disposed.

As far as I've noticed (please see the linked community post) it can lead to a memory leak that will crash the app, if you use APIs that will use `SimpleCallCoroutine` (like `SimplePutCall` to upload files to PlayFab).

This PR adds a `request.Dispose()` at the end of `SimpleCallCoroutine` to prevent a potential memory issue.