### PR TITLE
Fix the mismatch between PlayFabEdEx and PlayFabShareSettings

### DIFF
--- a/targets/unity-v2/source/ExampleTestProject/Assets/PlayFabEditorExtensions/Editor/Scripts/Panels/PlayFabEditorSettings.cs
+++ b/targets/unity-v2/source/ExampleTestProject/Assets/PlayFabEditorExtensions/Editor/Scripts/Panels/PlayFabEditorSettings.cs
@@ -20,11 +20,12 @@ namespace PlayFab.PfEditor
 
         public enum WebRequestType
         {
+#if !UNITY_2018_2_OR_NEWER // Unity has deprecated Www
             UnityWww, // High compatability Unity api calls
-            HttpWebRequest, // High performance multi-threaded api calls
-#if UNITY_2017_2_OR_NEWER
-            UnityWebRequest, // Modern unity HTTP component
 #endif
+            UnityWebRequest, // Modern unity HTTP component
+            HttpWebRequest, // High performance multi-threaded api calls
+            CustomHttp //If this is used, you must set the Http to an IPlayFabHttp object.
         }
 
         private static float LABEL_WIDTH = 180;


### PR DESCRIPTION
As the WebRequestType used in PlayFabEditorSettings doesn't match the one used in PlayFab SDK, there is a mismatch between PlayFabEdEx and PlayFabShareSettings as the following:
![Mismatch between PlayFabEdEx and PlayFabShareSettings](https://user-images.githubusercontent.com/6903218/147462246-86af7fa1-cdae-4a95-932e-a03f789ec46d.png)

I'm changing the WebRequestType to the same one in PlayFab SDK to resolve this issue.