### PR TITLE
Fix the GetLatestEdExVersion method not working issue

### DIFF
--- a/targets/unity-v2/source/ExampleTestProject/Assets/PlayFabEditorExtensions/Editor/PlayFabEditor.cs
+++ b/targets/unity-v2/source/ExampleTestProject/Assets/PlayFabEditorExtensions/Editor/PlayFabEditor.cs
@@ -362,7 +362,7 @@ namespace PlayFab.PfEditor
 
             if (DateTime.Today > threshold)
             {
-                PlayFabEditorHttp.MakeGitHubApiCall("https://api.github.com/repos/PlayFab/UnityEditorExtensions/git/refs/tags", (version) =>
+                PlayFabEditorHttp.MakeGitHubApiCall("https://api.github.com/repos/PlayFab/UnitySDK/git/refs/tags", (version) =>
                 {
                     latestEdExVersion = version ?? "Unknown";
                     PlayFabEditorPrefsSO.Instance.EdSet_latestEdExVersion = latestEdExVersion;


### PR DESCRIPTION
As [UnityEditorExtensions](https://github.com/PlayFab/UnityEditorExtensions) is deprecated, GetLatestEdExVersion method cannot work anymore, which blocks the built-in upgrade of PlayFab EdEx.

Changing the URL so that it can get the correct latest version.