### PR TITLE
Fix the header and url issue in Postman V2

### DIFF
--- a/targets/postman/make.js
+++ b/targets/postman/make.js
@@ -24,6 +24,7 @@ exports.makeCombinedAPI = function (apis, sourceDir, apiOutputDir) {
         apis: apis,
         getPostmanDescription: getPostmanDescription,
         getPostmanHeader: getPostmanHeader,
+        getPostmanHeaderV2: getPostmanHeaderV2,
         getRequestExample: getRequestExample,
         getUrl: getUrl,
         getVerticalTag: getVerticalTag
@@ -84,6 +85,86 @@ function getPostmanHeader(apiCall) {
     return "";
 }
 
+function getPostmanHeaderV2(apiCall) {
+    if (apiCall.url === "/Authentication/GetEntityToken")
+        return JSON.stringify([
+            {
+                "key": "X-PlayFabSDK",
+                "value": "PostmanCollection-" + sdkGlobals.sdkVersion
+            },
+            {
+                "key": "Content-Type",
+                "value": "application/json"
+            },
+            {
+                "key": "X-Authorization",
+                "value": "{{SessionTicket}}"
+            },
+            {
+                "key": "X-SecretKey",
+                "value": "{{SecretKey}}"
+            }
+        ])
+    if (apiCall.auth === "SessionTicket")
+        return JSON.stringify([
+            {
+                "key": "X-PlayFabSDK",
+                "value": "PostmanCollection-" + sdkGlobals.sdkVersion
+            },
+            {
+                "key": "Content-Type",
+                "value": "application/json"
+            },
+            {
+                "key": "X-Authorization",
+                "value": "{{SessionTicket}}"
+            }
+        ])
+    else if (apiCall.auth === "SecretKey")
+        return JSON.stringify([
+            {
+                "key": "X-PlayFabSDK",
+                "value": "PostmanCollection-" + sdkGlobals.sdkVersion
+            },
+            {
+                "key": "Content-Type",
+                "value": "application/json"
+            },
+            {
+                "key": "X-SecretKey",
+                "value": "{{SecretKey}}"
+            }
+        ])
+    else if (apiCall.auth === "EntityToken")
+        return JSON.stringify([
+            {
+                "key": "X-PlayFabSDK",
+                "value": "PostmanCollection-" + sdkGlobals.sdkVersion
+            },
+            {
+                "key": "Content-Type",
+                "value": "application/json"
+            },
+            {
+                "key": "X-EntityToken",
+                "value": "{{EntityToken}}"
+            }
+        ])
+    else if (apiCall.auth === "None")
+        return JSON.stringify([
+            {
+                "key": "X-PlayFabSDK",
+                "value": "PostmanCollection-" + sdkGlobals.sdkVersion
+            },
+            {
+                "key": "Content-Type",
+                "value": "application/json"
+            }
+        ])
+
+    return "";
+}
+
 function jsonEscape(input) {
     if (input != null)
         input = input.replace(/\r/g, "").replace(/\n/g, "\\n").replace(/"/g, "\\\"");
@@ -107,7 +188,7 @@ function getPostmanDescription(api, apiCall) {
 
     output += jsonEscape(apiCall.summary); // Make sure quote characters are properly escaped
     if (!isProposed)
-        output += "\\n\\nApi Documentation: https://docs.microsoft.com/rest/api/playfab/" + api.name.toLowerCase() + "/" + apiCall.subgroup.toLowerCase().replaceAll(" ","-") + "/" + apiCall.name.toLowerCase();
+        output += "\\n\\nApi Documentation: https://docs.microsoft.com/rest/api/playfab/" + api.name.toLowerCase() + "/" + apiCall.subgroup.toLowerCase().replaceAll(" ", "-") + "/" + apiCall.name.toLowerCase();
 
     output += "\\n\\n**The following case-sensitive environment variables are required for this call:**";
     output += "\\n\\n\\\"TitleId\\\" - The Title Id of your game, available in the Game Manager (https://developer.playfab.com)";

--- a/targets/postman/templates/playfabV2.json.ejs
+++ b/targets/postman/templates/playfabV2.json.ejs
@@ -13,32 +13,12 @@
             "name": "<%- apiCall.name %>",
             "request": {
                 "method": "POST",
-                "header": [
-                    "<%- getPostmanHeader(apiCall) %>"
-                ],
+                "header": <%- getPostmanHeaderV2(apiCall) %>,
                 "body": {
                     "mode": "raw",
                     "raw": <%- getRequestExample(api, apiCall) %>
                 },
-                "url" : {
-                    "raw": "<%- getUrl(apiCall) %>",
-                    "protocol": "https",
-                    "host": [
-                        "{{TitleId}}",
-                        "playfabapi",
-                        "com"
-                    ],
-                    "path": [
-                        "<%- apiName %>",
-                        "<%- apiCall.name %>"
-                    ],
-                    "query": [
-                        {
-                            "key": "sdk",
-                            "value": "PostmanCollection-<%- sdkVersion %>"
-                        }
-                    ]
-                },
+                "url": "<%- getUrl(apiCall) %>",
                 "description": "<%- getPostmanDescription(api, apiCall) %>"
             },
             "response": []


### PR DESCRIPTION
Although Postman Schema said the header can be string, but when we use string, the Postman app (I'm using Postman v9.7.1) cannot recognize the header correctly. So, I added a getPostmanHeaderV2 method to set the header to "Header List".

Currently, we are using "apiName" and "apiCall.name" to set up the path of the current url. However, for some APIs, the first segment of the path is not the "apiName". Using "GetDraftItem" for example, it's "apiName" is "economy", however, the correct segment should be "catalog". As the Url can be a string, I'm just using the literal request URL instead of the complete broken-down object.