### PR TITLE
Bug 37699015: Null reference exception in Unity WebGL in Deserializer

### DIFF
--- a/targets/unity-v2/source/ExampleTestProject/Assets/PlayFabSDK/link.xml
+++ b/targets/unity-v2/source/ExampleTestProject/Assets/PlayFabSDK/link.xml
@@ -15,7 +15,5 @@
     <namespace fullname="Mono.Security.Protocol.Tls" preserve="all"/>
     <namespace fullname="Mono.Security.X509" preserve="all"/>
   </assembly>
-  <assembly fullname="Assembly-CSharp">
-    <namespace fullname="PlayFab.*" preserve="all"/>
-  </assembly>
+  <assembly fullname="PlayFab" preserve="all"/>
 </linker>


### PR DESCRIPTION
incorporating link.xml fix in unity to prevent json deserializer in PF to break in WebGL client

See: 
https://teams.microsoft.com/l/message/19:54099bfaf86949bb956a5af1de69c228@thread.skype/1639528962546?tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47&groupId=de7d3966-c0d8-41fe-abb4-498e2cac675a&parentMessageId=1639528962546&teamName=PlayFab%201PP%20Discussion&channelName=General&createdTime=1639528962546