### PR TITLE
Update playfabV2.json.ejs

### DIFF
--- a/targets/postman/templates/playfabV2.json.ejs
+++ b/targets/postman/templates/playfabV2.json.ejs
@@ -16,6 +16,7 @@
                 "header": <%- getPostmanHeaderV2(apiCall) %>,
                 "body": {
                     "mode": "raw",
+                    "Content-Type": "application/json",
                     "raw": <%- getRequestExample(api, apiCall) %>
                 },
                 "url": "<%- getUrl(apiCall) %>",


### PR DESCRIPTION
Explicitly label body as application/json, as Postman defaults to text now.