### PR TITLE
Changes required to generate an Azure flavor of the Unity SDK

### DIFF
--- a/JenkinsConsoleUtility/jcuSrc/Commands/VersionVarWriter.cs
+++ b/JenkinsConsoleUtility/jcuSrc/Commands/VersionVarWriter.cs
@@ -129,7 +129,7 @@ namespace JenkinsConsoleUtility.Commands
                 case "javascriptsdk": case "javascriptbetasdk": return "javascript";
                 case "objective_c_sdk": return "objc";
                 // Multiple repos map to the same folder
-                case "csharpazuresdk": return "azure";
+                case "csharpazuresdk": case "unityazuresdk": return "azure";
                 case "csharpsdk": case "csharpbetasdk": case "csharppsnsdk": return "csharp";
                 case "nodesdk": case "nodebetasdk": return "js-node";
                 case "postmancollection": case "postmanbeta": return "postman";

--- a/SDKGenerator.njsproj
+++ b/SDKGenerator.njsproj
@@ -678,7 +678,7 @@
     <Content Include="targets\unity-v2\source\ExampleTestProject\Assets\PlayFabSDK\Shared\Internal\PlayFabHttp.meta" />
     <Content Include="targets\unity-v2\source\ExampleTestProject\Assets\PlayFabSDK\Shared\Internal\PlayFabHttp\IPlayFabHttp.cs" />
     <Content Include="targets\unity-v2\source\ExampleTestProject\Assets\PlayFabSDK\Shared\Internal\PlayFabHttp\IPlayFabHttp.cs.meta" />
-    <Content Include="targets\unity-v2\source\ExampleTestProject\Assets\PlayFabSDK\Shared\Internal\PlayFabHttp\PlayFabHTTP.cs" />
+    <Content Include="targets\unity-v2\source\ExampleTestProject\Assets\PlayFabSDK\Shared\Internal\PlayFabHttp\PlayFabHTTP.cs.ejs" />
     <Content Include="targets\unity-v2\source\ExampleTestProject\Assets\PlayFabSDK\Shared\Internal\PlayFabHttp\PlayFabHTTP.cs.meta" />
     <Content Include="targets\unity-v2\source\ExampleTestProject\Assets\PlayFabSDK\Shared\Internal\PlayFabHttp\PlayFabUnityHttp.cs" />
     <Content Include="targets\unity-v2\source\ExampleTestProject\Assets\PlayFabSDK\Shared\Internal\PlayFabHttp\PlayFabUnityHttp.cs.meta" />
@@ -1097,6 +1097,7 @@
     <Folder Include="targets\unity-v2\source\ExampleTestProject\Assets\PlayFabSDK\Localization\" />
     <Folder Include="targets\unity-v2\source\ExampleTestProject\Assets\PlayFabSDK\Matchmaker\" />
     <Folder Include="targets\unity-v2\source\ExampleTestProject\Assets\PlayFabSDK\Multiplayer\" />
+    <Folder Include="targets\unity-v2\source\ExampleTestProject\Assets\PlayFabSDK\Economy\" />
     <Folder Include="targets\unity-v2\source\ExampleTestProject\Assets\PlayFabSDK\Profiles\" />
     <Folder Include="targets\unity-v2\source\ExampleTestProject\Assets\PlayFabSDK\Server\" />
     <Folder Include="targets\unity-v2\source\ExampleTestProject\Assets\PlayFabSDK\Shared\" />

--- a/SDKGenerator.njsproj
+++ b/SDKGenerator.njsproj
@@ -1097,7 +1097,6 @@
     <Folder Include="targets\unity-v2\source\ExampleTestProject\Assets\PlayFabSDK\Localization\" />
     <Folder Include="targets\unity-v2\source\ExampleTestProject\Assets\PlayFabSDK\Matchmaker\" />
     <Folder Include="targets\unity-v2\source\ExampleTestProject\Assets\PlayFabSDK\Multiplayer\" />
-    <Folder Include="targets\unity-v2\source\ExampleTestProject\Assets\PlayFabSDK\Economy\" />
     <Folder Include="targets\unity-v2\source\ExampleTestProject\Assets\PlayFabSDK\Profiles\" />
     <Folder Include="targets\unity-v2\source\ExampleTestProject\Assets\PlayFabSDK\Server\" />
     <Folder Include="targets\unity-v2\source\ExampleTestProject\Assets\PlayFabSDK\Shared\" />

--- a/generate.js
+++ b/generate.js
@@ -594,7 +594,7 @@ if (!String.prototype.padStart) {
     };
 }
 // SDK generation utilities
-function templatizeTree(locals, sourcePath, destPath) {
+function templatizeTree(locals, sourcePath, destPath, excludeFolders, excludeFiles) {
     if (!fs.existsSync(sourcePath))
         throw Error("Copy tree source doesn't exist: " + sourcePath);
     if (!fs.lstatSync(sourcePath).isDirectory())
@@ -608,10 +608,16 @@ function templatizeTree(locals, sourcePath, destPath) {
     for (var i = 0; i < filesInDir.length; i++) {
         var filename = filesInDir[i];
         var file = sourcePath + "/" + filename;
-        if (fs.lstatSync(file).isDirectory())
-            templatizeTree(locals, file, destPath + "/" + filename);
-        else
+        if (fs.lstatSync(file).isDirectory()) {
+            if (excludeFolders != null && excludeFolders.includes(filename))
+                continue;
+            templatizeTree(locals, file, destPath + "/" + filename, excludeFolders, excludeFiles);
+        }
+        else {
+            if (excludeFiles != null && excludeFiles.includes(filename))
+                continue;
             copyOrTemplatizeFile(locals, file, destPath + "/" + filename);
+        }
     }
 }
 global.templatizeTree = templatizeTree;

--- a/generate.ts
+++ b/generate.ts
@@ -721,11 +721,13 @@ function templatizeTree(locals: { [key: string]: any }, sourcePath: string, dest
         throw Error("Copy tree source doesn't exist: " + sourcePath);
     if (!fs.lstatSync(sourcePath).isDirectory()) // File
         return copyOrTemplatizeFile(locals, sourcePath, destPath);
+
     // Directory
     if (!fs.existsSync(destPath))
         mkdirParentsSync(destPath);
     else if (!fs.lstatSync(destPath).isDirectory())
         throw Error("Can't copy a directory onto a file: " + sourcePath + " " + destPath);
+
     var filesInDir = fs.readdirSync(sourcePath);
     for (var i = 0; i < filesInDir.length; i++) {
         var filename = filesInDir[i];

--- a/generate.ts
+++ b/generate.ts
@@ -716,26 +716,30 @@ if (!String.prototype.padStart) {
 }
 
 // SDK generation utilities
-function templatizeTree(locals: { [key: string]: any }, sourcePath: string, destPath: string): void {
+function templatizeTree(locals, sourcePath, destPath, excludeFolders, excludeFiles) {
     if (!fs.existsSync(sourcePath))
         throw Error("Copy tree source doesn't exist: " + sourcePath);
-    if (!fs.lstatSync(sourcePath).isDirectory()) // File
+    if (!fs.lstatSync(sourcePath).isDirectory())
         return copyOrTemplatizeFile(locals, sourcePath, destPath);
-
     // Directory
     if (!fs.existsSync(destPath))
         mkdirParentsSync(destPath);
     else if (!fs.lstatSync(destPath).isDirectory())
         throw Error("Can't copy a directory onto a file: " + sourcePath + " " + destPath);
-
     var filesInDir = fs.readdirSync(sourcePath);
     for (var i = 0; i < filesInDir.length; i++) {
         var filename = filesInDir[i];
         var file = sourcePath + "/" + filename;
-        if (fs.lstatSync(file).isDirectory())
-            templatizeTree(locals, file, destPath + "/" + filename);
-        else
+        if (fs.lstatSync(file).isDirectory()) {
+            if (excludeFolders != null && excludeFolders.includes(filename))
+                continue;
+            templatizeTree(locals, file, destPath + "/" + filename, excludeFolders, excludeFiles);
+        }
+        else {
+            if (excludeFiles != null && excludeFiles.includes(filename))
+                continue;
             copyOrTemplatizeFile(locals, file, destPath + "/" + filename);
+        }
     }
 }
 global.templatizeTree = templatizeTree;

--- a/generate.ts
+++ b/generate.ts
@@ -716,10 +716,10 @@ if (!String.prototype.padStart) {
 }
 
 // SDK generation utilities
-function templatizeTree(locals, sourcePath, destPath, excludeFolders, excludeFiles) {
+function templatizeTree(locals: { [key: string]: any }, sourcePath: string, destPath: string, excludeFolders: string, excludeFiles: string): void {
     if (!fs.existsSync(sourcePath))
         throw Error("Copy tree source doesn't exist: " + sourcePath);
-    if (!fs.lstatSync(sourcePath).isDirectory())
+    if (!fs.lstatSync(sourcePath).isDirectory()) // File
         return copyOrTemplatizeFile(locals, sourcePath, destPath);
     // Directory
     if (!fs.existsSync(destPath))

--- a/targets/unity-v2/source/ExampleTestProject/Assets/PlayFabSDK/Shared/Internal/PlayFabHttp/PlayFabHTTP.cs.ejs
+++ b/targets/unity-v2/source/ExampleTestProject/Assets/PlayFabSDK/Shared/Internal/PlayFabHttp/PlayFabHTTP.cs.ejs
@@ -237,11 +237,20 @@ namespace PlayFab.Internal
             var result = reqContainer.ApiResult;
 
 #if !DISABLE_PLAYFABENTITY_API
+<% if (azureSdk) { %>
+            var authRes = result as AuthenticationModels.AuthenticateIdentityResult;
+            if (authRes != null)
+            {
+                authRes.AuthenticationContext = new PlayFabAuthenticationContext(null, authRes.TitlePlayerAccount.EntityToken, null, authRes.TitlePlayerAccount.Entity.Id, authRes.TitlePlayerAccount.Entity.Type);
+                reqContainer.context.CopyFrom(authRes.AuthenticationContext);
+            }
+<%} else { %>
             var entRes = result as AuthenticationModels.GetEntityTokenResponse;
             if (entRes != null)
             {
                 PlayFabSettings.staticPlayer.EntityToken = entRes.EntityToken;
             }
+<% } %>
 #endif
 #if !DISABLE_PLAYFABCLIENT_API
             var logRes = result as ClientModels.LoginResult;

--- a/targets/unity-v2/source/ExampleTestProject/Assets/PlayFabSDK/Shared/Models/PlayFabSharedSettings.cs.ejs
+++ b/targets/unity-v2/source/ExampleTestProject/Assets/PlayFabSDK/Shared/Models/PlayFabSharedSettings.cs.ejs
@@ -7,6 +7,9 @@ using PlayFab;
 public class PlayFabSharedSettings : ScriptableObject
 {
     public string TitleId;
+<% if (azureSdk) { %>
+    public string PlayerAccountPoolId;
+<% } %>
     internal string VerticalName = <%- getVerticalNameDefault() %>;
 #if ENABLE_PLAYFABSERVER_API || ENABLE_PLAYFABADMIN_API || UNITY_EDITOR
     public string DeveloperSecretKey;

--- a/targets/unity-v2/source/ExampleTestProject/Assets/PlayFabSDK/Shared/Public/PlayFabApiSettings.cs.ejs
+++ b/targets/unity-v2/source/ExampleTestProject/Assets/PlayFabSDK/Shared/Public/PlayFabApiSettings.cs.ejs
@@ -16,6 +16,10 @@ namespace PlayFab
         public virtual string ProductionEnvironmentUrl { get { return _ProductionEnvironmentUrl; } set { _ProductionEnvironmentUrl = value; } }
         /// <summary> You must set this value for PlayFabSdk to work properly (Found in the Game Manager for your title, at the PlayFab Website) </summary>
         public virtual string TitleId { get; set; }
+<% if (azureSdk) { %>
+        /// <summary> You must set this value in order to call Player Authentication APIs (Found in the Azure Portal as a property of the Player Account Pool resource) </summary>
+        public virtual string PlayerAccountPoolId { get; set; }
+<% } %>
         /// <summary> The name of a customer vertical. This is only for customers running a private cluster.  Generally you shouldn't touch this </summary>
         internal virtual string VerticalName { get; set; }
 #if ENABLE_PLAYFABSERVER_API || ENABLE_PLAYFABADMIN_API || UNITY_EDITOR
@@ -69,7 +73,13 @@ namespace PlayFab
             get { var so = GetSO(); return so == null ? base.TitleId : so.TitleId; }
             set { var so = GetSO(); if (so != null) so.TitleId = value; base.TitleId = value; }
         }
-
+<% if (azureSdk) { %>
+        public override string PlayerAccountPoolId
+        {
+            get { var so = GetSO(); return so == null ? base.PlayerAccountPoolId : so.PlayerAccountPoolId; }
+            set { var so = GetSO(); if (so != null) so.PlayerAccountPoolId = value; base.PlayerAccountPoolId = value; }
+        }
+<% } %>
         public override bool DisableDeviceInfo
         {
             get { var so = GetSO(); return so == null ? base.DisableDeviceInfo : so.DisableDeviceInfo; }

--- a/targets/unity-v2/source/ExampleTestProject/Assets/PlayFabSDK/Shared/Public/PlayFabSettings.cs.ejs
+++ b/targets/unity-v2/source/ExampleTestProject/Assets/PlayFabSDK/Shared/Public/PlayFabSettings.cs.ejs
@@ -84,6 +84,10 @@ namespace PlayFab
         #region staticSettings Redirects
         // You must set this value for PlayFabSdk to work properly (Found in the Game Manager for your title, at the PlayFab Website)
         public static string TitleId { get { return staticSettings.TitleId; } set { staticSettings.TitleId = value; } }
+<% if (azureSdk) { %>
+        // You must set this value in order to call Player Authentication APIs (Found in the Azure Portal as a property of the Player Account Pool resource)
+        public static string PlayerAccountPoolId { get { return staticSettings.PlayerAccountPoolId; } set { staticSettings.PlayerAccountPoolId = value; } }
+<% } %>
         // Set this value to override specific title connection point
         public static string ConnectionString { get {return staticSettings.ConnectionString; } set { staticSettings.ConnectionString = value; } }
         /// <summary> The name of a customer vertical. This is only for customers running a private cluster.  Generally you shouldn't touch this </summary>


### PR DESCRIPTION
This set of changes builds on the earlier work to support an Azure C# SDK, but adds a few more things:

- A general ability within the SDK Generator to exclude specific files and folder from the code gen. This keeps us from having to create new templates when there are a limited number of files that are not applicable to a specific SDK flavor.
- For Azure Unity, we don't want to generate the Editor Extensions, or the Client, Server, and Admin api groups.
- Adding the Account Pool Id to settings and automatically setting it on Auth requests
- Caching auth context for the new Azure auth API

Generated output in this branch: https://github.com/PlayFab/UnityAzureSdk/tree/andmcc/InitialSDKGen