### PR TITLE
Adding aadAuth header to postman make file

### DIFF
--- a/targets/postman/make.js
+++ b/targets/postman/make.js
@@ -159,6 +159,10 @@ function getPostmanHeaderV2(apiCall) {
             {
                 "key": "Content-Type",
                 "value": "application/json"
+            },
+            {
+                "key": "X-AadToken",
+                "value": "{{AadToken}}"
             }
         ])
     else if (apiCall.auth === "None")

--- a/targets/postman/make.js
+++ b/targets/postman/make.js
@@ -150,6 +150,17 @@ function getPostmanHeaderV2(apiCall) {
                 "value": "{{EntityToken}}"
             }
         ])
+    else if (apiCall.auth === "AadToken")
+        return JSON.stringify([
+            {
+                "key": "X-PlayFabSDK",
+                "value": "PostmanCollection-" + sdkGlobals.sdkVersion
+            },
+            {
+                "key": "Content-Type",
+                "value": "application/json"
+            }
+        ])
     else if (apiCall.auth === "None")
         return JSON.stringify([
             {
@@ -162,7 +173,9 @@ function getPostmanHeaderV2(apiCall) {
             }
         ])
 
-    return "";
+    throw "Postman header was not found, this can be due to newer apiCall.auth's being made. Add any new call to the above conditionals \n";
+
+    return Json.stringify([{ "key": "X-PlayFabSDK", "value": "PostmanCollection-Headerless-Issue-Fix-This-Before-Loading"}]);
 }
 
 function jsonEscape(input) {


### PR DESCRIPTION
We didn't have a valid json output when we return a simple empty string. 

I added a case for aad if we need to do anything specific. 

Otherwise, this new throw is here to ensure we get a quicker fix in the future.