### PR TITLE
Adding ENABLE_PLAYFAB_SECRETKEY preprocessor symbol to enable Secret Key use

### DIFF
--- a/targets/csharp/make.js
+++ b/targets/csharp/make.js
@@ -257,7 +257,7 @@ function getRequestActions(tabbing, apiCall, isInstance) {
             + "#if !DISABLE_PLAYFABCLIENT_API\n"
             + tabbing + "if (requestContext.ClientSessionTicket != null) { authKey = \"X-Authorization\"; authValue = requestContext.ClientSessionTicket; }\n"
             + "#endif\n\n"
-            + "#if ENABLE_PLAYFABSERVER_API || ENABLE_PLAYFABADMIN_API\n"
+            + "#if ENABLE_PLAYFABSERVER_API || ENABLE_PLAYFABADMIN_API || ENABLE_PLAYFAB_SECRETKEY\n"
             + tabbing + "if (requestSettings.DeveloperSecretKey != null) { authKey = \"X-SecretKey\"; authValue = requestSettings.DeveloperSecretKey; }\n"
             + "#endif\n\n"
             + "#if !DISABLE_PLAYFABENTITY_API\n"

--- a/targets/csharp/source/PlayFabSDK/source/PlayFabApiSettings.cs.ejs
+++ b/targets/csharp/source/PlayFabSDK/source/PlayFabApiSettings.cs.ejs
@@ -13,7 +13,7 @@ namespace PlayFab
         /// <summary> The name of a customer vertical. This is only for customers running a private cluster.  Generally you shouldn't touch this </summary>
         public string VerticalName = <%- getVerticalNameDefault() %>;
 
-#if ENABLE_PLAYFABSERVER_API || ENABLE_PLAYFABADMIN_API
+#if ENABLE_PLAYFABSERVER_API || ENABLE_PLAYFABADMIN_API || ENABLE_PLAYFAB_SECRETKEY
         /// <summary> You must set this value for PlayFabSdk to work properly (Found in the Game Manager for your title, at the PlayFab Website) </summary>
         public string DeveloperSecretKey = null;
 #endif

--- a/targets/csharp/source/PlayFabSDK/source/PlayFabSettings.cs.ejs
+++ b/targets/csharp/source/PlayFabSDK/source/PlayFabSettings.cs.ejs
@@ -28,7 +28,7 @@ namespace PlayFab
         [Obsolete("Moved to PlayFabSettings.staticSettings.VerticalName")]
         public static string VerticalName { get { return staticSettings.VerticalName; } set { staticSettings.VerticalName = value; } }
 
-#if ENABLE_PLAYFABSERVER_API || ENABLE_PLAYFABADMIN_API
+#if ENABLE_PLAYFABSERVER_API || ENABLE_PLAYFABADMIN_API || ENABLE_PLAYFAB_SECRETKEY
         [Obsolete("Moved to PlayFabSettings.staticSettings.DeveloperSecretKey")]
         public static string DeveloperSecretKey { get { return staticSettings.DeveloperSecretKey; } set { staticSettings.DeveloperSecretKey = value; } }
 #endif


### PR DESCRIPTION
This addresses a gap that's existed since the introduction of the entity APIs. In order for GetEntityToken to be able to retrieve a Title Entity Token, you had to set ENABLE_PLAYFABSERVER_API. This is possibly enabling much more than desired. The new ENABLE_PLAYFAB_SECRETKEY allows for configurations where you only want to use entity APIs but still use GetEntityToken to auth as the title entity. This is also useful for the Azure configurations, where there is no Server API at all.