### PR TITLE
Use FirstOrDefault to read X-RequestId

### DIFF
--- a/targets/csharp/source/PlayFabSDK/source/PlayFabHttp/PlayFabSysHttp.cs
+++ b/targets/csharp/source/PlayFabSDK/source/PlayFabHttp/PlayFabSysHttp.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Net.Http;
 using System.Net.Http.Headers;
 using System.Text;
@@ -138,18 +139,26 @@ namespace PlayFab.Internal
         private string GetRequestId(bool hasReqId, IEnumerable<string> reqIdContainer)
         {
             const string defaultReqId = "NoRequestIdFound";
-            string reqId = "";
+
+            if (!hasReqId)
+            {
+                return defaultReqId;
+            }
 
             try
             {
-                reqId = hasReqId ? reqIdContainer.GetEnumerator().Current.ToString() : defaultReqId;
+                string reqId = reqIdContainer.FirstOrDefault();
+                if (string.IsNullOrEmpty(reqId))
+                {
+                    reqId = defaultReqId;
+                }
+
+                return reqId;
             }
             catch (Exception e)
             {
                 return "Failed to Enumerate RequestId. Exception message: " + e.Message;
             }
-
-            return reqId;
         }
     }
 }


### PR DESCRIPTION
I have been seeing request id values like "Failed to Enumerate
RequestId. Exception message: Enumeration has not started. Call
MoveNext."

Use `.FirstOrDefault()` to get the first item in reqIdContainer.

Minor refactoring to handle `hasReqId` on its own branch instead of
inside the try/catch.

I've been told that this change needs to land here, not just in the
PlayFab/CSharpSDK repo. I opened [a pull request there][0] with this
fix as well. Please close whichever is duplicative.

[0]: https://github.com/PlayFab/CSharpSDK/pull/121