### PR TITLE
Changing CSharp SDK target to .Net Standard 2.0

### DIFF
--- a/targets/csharp/source/PlayFabSDK/source/PlayFabSDK.csproj.ejs
+++ b/targets/csharp/source/PlayFabSDK/source/PlayFabSDK.csproj.ejs
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>netstandard2.0</TargetFramework>
     <RootNamespace>PlayFab<%- libname %>SDK</RootNamespace>
     <AssemblyName>PlayFab<%- libname %>SDK</AssemblyName>
     <DefaultLanguage>en-US</DefaultLanguage>


### PR DESCRIPTION
This should restore Xamarin and Unity support for the CSharp SDK. As far as I can tell, there are no side effects of this change.