### PR TITLE
[CSharpSDK-Draft] Adding Polly as a transport type

### DIFF
--- a/targets/csharp/source/PlayFabSDK/source/PlayFabHttp/PlayFabPollyHttp.cs
+++ b/targets/csharp/source/PlayFabSDK/source/PlayFabHttp/PlayFabPollyHttp.cs
@@ -1,0 +1,107 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Net;
+using System.Threading.Tasks;
+using Microsoft.Xbox.Publishing.PlayFabCSharpSDK.Polly.Interfaces;
+using PlayFab;
+using PlayFab.Internal;
+using Polly;
+using Polly.Wrap;
+
+namespace PlayFab.Internal
+{
+    /// <summary>
+    /// A Polly wrapped version of PlayFab Transport plug in which used
+    /// when making http requests to PlayFab Main Server.
+    /// </summary>
+    public class PlayFabPollyHttp : PlayFabHttp, ITransportPlugin
+    {
+        /// <summary>
+        /// Http requests worth retrying
+        /// </summary>
+        HttpStatusCode[] httpStatusCodesWorthRetrying = {
+           HttpStatusCode.RequestTimeout,       // 408
+           HttpStatusCode.InternalServerError,  // 500
+           HttpStatusCode.BadGateway,           // 502
+           HttpStatusCode.ServiceUnavailable,   // 503
+           HttpStatusCode.GatewayTimeout        // 504
+        };
+
+        /// <summary>
+        /// Gets or set the name of the plug in. Used by the PluginManager when looking up
+        /// plugins upon request.
+        /// </summary>
+        public string Name;
+
+        /// <summary>
+        /// Gets the resilience policies defined.
+        /// </summary>
+        public AsyncPolicyWrap CommonResilience { get; private set; }
+
+        /// <summary>
+        /// Constructor for objects of type PollyTransportPlug.
+        /// <remarks>
+        /// Sets a default resilience policy with the fololwing common settings
+        /// 1) Sets the retry to 3 times and has an embedded backoff.
+        /// 2) > Sets a circuit breaker that will trigger is 25% of collapsed calls within 
+        ///      a 5 second window are failing.
+        ///    > Period for evaluation requires a burst of >=2RPS before evaluating breaker rule,
+        ///      requires a minimum of 10 requests in 5 seconds, and the circuit breaker will
+        ///      will be open for 20 second.
+        /// More information on the client can be found here: https://github.com/App-vNext/Polly
+        ///</remarks>
+        /// </summary>
+        public PlayFabPollyHttp()
+        {
+            var retryPolicy = Policy
+               .Handle<Exception>()
+                .Or<HttpRequestException>()
+                    .OrResult<HttpResponseMessage>(r => httpStatusCodesWorthRetrying.Contains(r.StatusCode))
+                .Or<TaskCanceledException>()
+                .Or<TimeoutRejectedException>()
+                .WaitAndRetry(3,
+                  retryAttempt => TimeSpan.FromSeconds(Math.Pow(2, retryAttempt))  // exponential back-off: 2, 4, 8 etc
+                                + TimeSpan.FromMilliseconds(jitterer.Next(0, 1000)) // plus some jitter: up to 1 second
+
+            var breakerPolicy = Policy.Handle<Exception>()
+                .AdvancedCircuitBreakerAsync(
+                    failureThreshold: 0.25,
+                    samplingDuration: TimeSpan.FromSeconds(5),
+                    minimumThroughput: 10,
+                    durationOfBreak: TimeSpan.FromSeconds(20));
+
+            CommonResilience = Policy.WrapAsync(
+                retryPolicy,
+                breakerPolicy);
+        }
+
+        /// <inheritdoc/>
+        public async Task<object> DoPost(string fullPath, object request, Dictionary<string, string> headers)
+        {
+            object doPostResult = null;
+            await Policy.Handle<PlayFabException>()
+                .WrapAsync(CommonResilience)
+                .ExecuteAsync(async () =>
+                {
+                    result = await base.DoPost(fullUrl, request, extraHeaders);
+
+                    return result;
+                });
+
+            return doPostResult;
+        }
+
+        /// <summary>
+        /// Overrides the Polly Policies to enforce.
+        /// </summary>
+        /// <param name="retryPolicy">The retry policy to use.</param>
+        /// <param name="breakerPolicy">The circuit breaker policy to use.</param>
+        /// <exception cref="ArgumentNullException"> Thrown when retryPolicy and/or breakerPolicy is null.</exception>
+        public void OverridePolicies(AsyncPolicy retryPolicy, AsyncPolicy breakerPolicy)
+        {
+            CommonResilience = Policy.WrapAsync(
+                retryPolicy ?? throw new ArgumentNullException(nameof(retryPolicy)),
+                breakerPolicy ?? throw new ArgumentNullException(nameof(breakerPolicy)));
+        }
+    }
+}

--- a/targets/csharp/source/PlayFabSDK/source/PlayFabSDK.csproj.ejs
+++ b/targets/csharp/source/PlayFabSDK/source/PlayFabSDK.csproj.ejs
@@ -45,6 +45,10 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Polly" Version="7.2.3" />
+  </ItemGroup>
+
+  <ItemGroup>
     <None Include="LICENSE" Pack="true" PackagePath="" />
     <None Include="../images/icon.png" Pack="true" PackagePath=""/>
   </ItemGroup>

--- a/targets/csharp/source/PlayFabSDK/source/Uunit/PluginManagerTest.cs
+++ b/targets/csharp/source/PlayFabSDK/source/Uunit/PluginManagerTest.cs
@@ -54,9 +54,11 @@ namespace PlayFab.UUnit
         {
             var playFabSerializer = PluginManager.GetPlugin<ISerializerPlugin>(PluginContract.PlayFab_Serializer);
             var playFabTransport = PluginManager.GetPlugin<ITransportPlugin>(PluginContract.PlayFab_Transport);
+            var playFabTransportWithPolly = PluginManager.GetPlugin<ITransportPlugin>(PluginContract.PlayFab_Transport);
 
             testContext.NotNull(playFabSerializer);
             testContext.NotNull(playFabTransport);
+            testContext.NotNull(playFabTransportWithPolly)
             testContext.EndTest(UUnitFinishState.PASSED, null);
         }
 
@@ -112,6 +114,34 @@ namespace PlayFab.UUnit
             var actualTransport2 = PluginManager.GetPlugin<ITransportPlugin>(PluginContract.PlayFab_Transport, customTransportName2);
             testContext.True(object.ReferenceEquals(actualTransport2, expectedTransport2));
             testContext.EndTest(UUnitFinishState.PASSED, null);
+        }
+
+        /// <summary>
+        /// Test that plugin manager can set and return the polly plugin.
+        /// </summary>
+        [UUnitTest]
+        public void PluginManager_PollyPlugin_Succesful(UUnitTestContext testContext)
+        {
+            var realHttpPlugin = PluginManager.GetPlugin<ITransportPlugin>(PluginContract.PlayFab_Transport);
+            var expectedHttpPollyPlugin = new PollyTransportPlugin();
+            PluginManager.SetPlugin(testHttpPollyPlugin, PluginContract.PlayFab_Transport);
+            try
+            {
+                // Set the polly plugin
+                PluginManager.SetPlugin(testHttpPollyPlugin, PluginContract.PlayFab_Transport);
+
+                // Get polly plugin from manager
+                var actualHttpPollyPlugin = PluginManager.GetPlugin<ITransportPollyPol>(PluginContract.PlayFab_Transport);
+
+                // Verify
+                testContext.True(object.ReferenceEquals(actualHttpPollyPlugin, expectedHttpPollyPlugin));
+                testContext.EndTest(UUnitFinishState.PASSED, null);
+            }
+            finally
+            {
+                // Restore the original plugin
+                PluginManager.SetPlugin(realHttpPlugin, PluginContract.PlayFab_Transport);
+            }
         }
     }
 }

--- a/targets/unity-v2/source/ExampleTestProject/Assets/Testing/Tests/Client/ClientApiTests.cs
+++ b/targets/unity-v2/source/ExampleTestProject/Assets/Testing/Tests/Client/ClientApiTests.cs
@@ -83,7 +83,9 @@ namespace PlayFab.UUnit
         public void InvalidLogin(UUnitTestContext testContext)
         {
             if (string.IsNullOrEmpty(_userEmail))
+            {
                 testContext.Skip(); // We need additional information to attempt this test
+            }
 
             // If the setup failed to log in a user, we need to create one.
             var request = new LoginWithEmailAddressRequest
@@ -108,7 +110,6 @@ namespace PlayFab.UUnit
 
             testContext.EndTest(UUnitFinishState.PASSED, null);
         }
-
 
         /// <summary>
         /// CLIENT API
@@ -141,7 +142,6 @@ namespace PlayFab.UUnit
             testContext.True(errorReport.Contains(expectedPasswordMsg), errorReport);
             testContext.EndTest(UUnitFinishState.PASSED, null);
         }
-
 
         /// <summary>
         /// CLIENT API
@@ -333,7 +333,6 @@ namespace PlayFab.UUnit
             testContext.True(result.Leaderboard.Count > 0, "Client leaderboard should not be empty");
             testContext.EndTest(UUnitFinishState.PASSED, null);
         }
-
 
         /// <summary>
         /// CLIENT API


### PR DESCRIPTION
> This is an initial version of how to include Polly polices into the SDK. Without changing too much of the internals of the plugin manager, I've added a PluginContract type *(PlayFab_TransportWithPolly) for Polly that wraps around the existing PlayFabHttp and can have its policy overridden prior to the code being called that gets a plugin by name. I did this because the existing code requires the parameterless constructor (hence not wanting to change too much).

> Note: there are defaults defined for the common resiliency setting which would be good to go over with the SDK team to see is these values make sense, and or to tweak them. 

> My team has a service that can dogfood this in prod and would to generate a prerelease to test it out. Looking to see if that's possible or not a standard followed. Similar tests to the existing ones were added for the new plugin. 

Thanks in advance for the time taken to review this