### PR TITLE
Update XML output logic

### DIFF
--- a/JenkinsConsoleUtility/jcuSrc/Commands/CloudScriptListener.cs
+++ b/JenkinsConsoleUtility/jcuSrc/Commands/CloudScriptListener.cs
@@ -136,7 +136,7 @@ namespace JenkinsConsoleUtility.Commands
             if (!callResult || testResults == null)
                 return 1;
             JcuUtil.FancyWriteToConsole(ConsoleColor.Gray, "Writing test results: " + outputFileFullPath);
-            return JUnitXml.WriteXmlFile(outputFileFullPath, testResults, false);
+            return JUnitXml.WriteXmlFile(outputFileFullPath, testResults, true);
         }
 
         public bool ExecuteCloudScript<TIn, TOut>(string functionName, TIn functionParameter, Dictionary<string, string> extraHeaders, out TOut result, out string errorReport)

--- a/JenkinsConsoleUtility/jcuSrc/Commands/CloudScriptListener.cs
+++ b/JenkinsConsoleUtility/jcuSrc/Commands/CloudScriptListener.cs
@@ -128,20 +128,15 @@ namespace JenkinsConsoleUtility.Commands
             var callResult = ExecuteCloudScript(CsFuncGetTestData, _getRequest, testTitleData.extraHeaders, out testResults, out errorReport);
 
             string outputFileFullPath = null;
-            for (int i = 0; i < 100; i++)
-            {
-                string eachOutputFile = Path.Combine(workspacePath, "ListenCsResult" + i + ".xml");
-                if (!File.Exists(eachOutputFile))
-                {
-                    outputFileFullPath = eachOutputFile;
-                    break; // Find the first file that doesn't exist
-                }
-            }
+
+            string outputFileName = "ListenCsResult.xml";
+            
+            outputFileFullPath = Path.Combine(workspacePath, outputFileName);
 
             if (!callResult || testResults == null)
                 return 1;
             JcuUtil.FancyWriteToConsole(ConsoleColor.Gray, "Writing test results: " + outputFileFullPath);
-            return JUnitXml.WriteXmlFile(outputFileFullPath, testResults, true);
+            return JUnitXml.WriteXmlFile(outputFileFullPath, testResults, false);
         }
 
         public bool ExecuteCloudScript<TIn, TOut>(string functionName, TIn functionParameter, Dictionary<string, string> extraHeaders, out TOut result, out string errorReport)

--- a/JenkinsConsoleUtility/jcuSrc/JUnitXml.cs
+++ b/JenkinsConsoleUtility/jcuSrc/JUnitXml.cs
@@ -181,7 +181,7 @@ namespace JenkinsConsoleUtility
                 sb.Append(tabbing).Append("</testsuites>\n");
 
                 JcuUtil.FancyWriteToConsole(ConsoleColor.Gray, "Write test results: " + destinationFile);
-                using (var output = File.Open(destinationFile, FileMode.Create))
+                using (var output = File.Open(destinationFile, FileMode.OpenOrCreate))
                 {
                     byte[] buffer = Encoding.UTF8.GetBytes(sb.ToString());
                     output.Write(buffer, 0, buffer.Length);


### PR DESCRIPTION
attempt to write output to the same xml file every time we run a test. Since ADO uploads this file to a particular location and we have this hardcoded limit in place, there have been pipelines that failed due to infrastructure issues rather than failing because of what we are testing. 