### PR TITLE
Fix Java SDK Throttling issue

### DIFF
--- a/targets/java/source_shared/src/test/java/com/playfab/test/PlayFabApiTest.java.ejs
+++ b/targets/java/source_shared/src/test/java/com/playfab/test/PlayFabApiTest.java.ejs
@@ -42,6 +42,7 @@ public class PlayFabApiTest
     // Cached values
     private static String playFabId = "1337D00D"; // This is not a valid player id, but Cloud Script doesn't care unless that id is used by the Cloud Script handler.
 <% } %>
+    private static Random rand = new Random(); 
     // Helpers
     private <RT> void VerifyResult(PlayFabResult<RT> result, boolean expectSuccess)
     {

--- a/targets/java/source_shared/src/test/java/com/playfab/test/PlayFabApiTest.java.ejs
+++ b/targets/java/source_shared/src/test/java/com/playfab/test/PlayFabApiTest.java.ejs
@@ -5,6 +5,7 @@ import org.junit.*;
 
 import java.util.*;
 import java.io.*;
+import java.lang.Thread;
 import java.util.Properties;
 
 import com.google.gson.*;
@@ -55,6 +56,16 @@ public class PlayFabApiTest
         {
             assertNull(errorMessage, result.Result);
             assertNotNull(errorMessage, result.Error);
+        }
+
+        // Add a rest to the tests so they don't throttle themselves. 
+        try
+        {
+            Thread.sleep(rand.nextInt(1000));
+        }
+        catch(Exception e)
+        {
+            System.out.println(e);
         }
     }
 


### PR DESCRIPTION
Java still seems to be emitting too many api calls at once. Adding a random wait time (less than 1 second) per test.