### PR TITLE
enable relative ejs include paths

### DIFF
--- a/generate.js
+++ b/generate.js
@@ -753,11 +753,14 @@ global.writeFile = writeFile;
  * Wrapper function for boilerplate of compiling templates
  * Also Caches the Templates to avoid reloading and recompiling
  * */
-function getCompiledTemplate(templatePath) {
+function getCompiledTemplate(templatePath, includes = false) {
     if (!this.compiledTemplates)
         this.compiledTemplates = {};
     if (!this.compiledTemplates.hasOwnProperty(templatePath))
-        this.compiledTemplates[templatePath] = ejs.compile(readFile(templatePath));
+        if (includes)
+            this.compiledTemplates[templatePath] = ejs.compile(readFile(templatePath), { filename: templatePath });
+        else
+            this.compiledTemplates[templatePath] = ejs.compile(readFile(templatePath), { filename: templatePath });
     return this.compiledTemplates[templatePath];
 }
 global.getCompiledTemplate = getCompiledTemplate;

--- a/generate.ts
+++ b/generate.ts
@@ -877,11 +877,14 @@ global.writeFile = writeFile;
  * Wrapper function for boilerplate of compiling templates
  * Also Caches the Templates to avoid reloading and recompiling
  * */
-function getCompiledTemplate(templatePath: string): any {
+function getCompiledTemplate(templatePath: string, includes: boolean = false): any {
     if (!this.compiledTemplates)
         this.compiledTemplates = {};
     if (!this.compiledTemplates.hasOwnProperty(templatePath))
-        this.compiledTemplates[templatePath] = ejs.compile(readFile(templatePath));
+        if (includes) 
+            this.compiledTemplates[templatePath] = ejs.compile(readFile(templatePath), { filename: templatePath });
+        else
+            this.compiledTemplates[templatePath] = ejs.compile(readFile(templatePath), { filename: templatePath });
     return this.compiledTemplates[templatePath];
 }
 global.getCompiledTemplate = getCompiledTemplate;


### PR DESCRIPTION
This enables <%- include('filename') %> usage (without absolute paths) which can prevent bloat in template files and hopefully make them a little more readable by pulling out reused or bespoke chunks of code.

In theory, just adding the filename arg here probably shouldn't mess any current usage up, but I added the switch to ensure other projects are unchanged by this unless they opt in.