### PR TITLE
Appending engine version information within GetFullUrl()

### DIFF
--- a/targets/unity-v2/source/ExampleTestProject/Assets/PlayFabSDK/Shared/Public/PlayFabSettings.cs.ejs
+++ b/targets/unity-v2/source/ExampleTestProject/Assets/PlayFabSDK/Shared/Public/PlayFabSettings.cs.ejs
@@ -46,6 +46,7 @@ namespace PlayFab
         public const string SdkVersion = "<%- sdkVersion %>";
         public const string BuildIdentifier = "<%- buildIdentifier %>";
         public const string VersionString = "UnitySDK-<%- sdkVersion %>";
+        public static string EngineVersion = UnityEngine.Application.unityVersion;
 
         public const string DefaultPlayFabApiUrl = "playfabapi.com";
 
@@ -217,9 +218,9 @@ namespace PlayFab
 
             sb.Append(baseUrl).Append(apiCall);
 
+            bool firstParam = true;
             if (getParams != null)
             {
-                bool firstParam = true;
                 foreach (var paramPair in getParams)
                 {
                     if (firstParam)
@@ -234,6 +235,9 @@ namespace PlayFab
                     sb.Append(paramPair.Key).Append("=").Append(paramPair.Value);
                 }
             }
+
+            sb.Append(firstParam ? "?" : "&");
+            sb.Append("engineVersion=").Append(EngineVersion);
 
             return sb.ToString();
         }


### PR DESCRIPTION
Adding Unity Engine Version to query string using UnityEngine.Application.unityVersion. I wasn't able to find an existing variable that stores the engine version (such as ueTargetVersion for the Unreal SDK) but I could switch the implementation if the variable exists or is preferred.