### PR TITLE
Adding platform information

### DIFF
--- a/targets/unity-v2/source/ExampleTestProject/Assets/PlayFabSDK/Shared/Public/PlayFabSettings.cs.ejs
+++ b/targets/unity-v2/source/ExampleTestProject/Assets/PlayFabSDK/Shared/Public/PlayFabSettings.cs.ejs
@@ -259,7 +259,7 @@ namespace PlayFab
             }
 
             sb.Append(firstParam ? "?" : "&");
-            sb.Append("engineVersion=").Append(EngineVersion);
+            sb.Append("engine=").Append(EngineVersion);
             sb.Append("&platform=").Append(PlatformString);
 
             return sb.ToString();

--- a/targets/unity-v2/source/ExampleTestProject/Assets/PlayFabSDK/Shared/Public/PlayFabSettings.cs.ejs
+++ b/targets/unity-v2/source/ExampleTestProject/Assets/PlayFabSDK/Shared/Public/PlayFabSettings.cs.ejs
@@ -47,6 +47,7 @@ namespace PlayFab
         public const string BuildIdentifier = "<%- buildIdentifier %>";
         public const string VersionString = "UnitySDK-<%- sdkVersion %>";
         public static string EngineVersion = UnityEngine.Application.unityVersion;
+        public static string PlatformString;
 
         public const string DefaultPlayFabApiUrl = "playfabapi.com";
 
@@ -148,10 +149,51 @@ namespace PlayFab
             _cachedStringBuilder.Clear();
             return _cachedStringBuilder;
         }
-        
+
+        public static void DeterminePlatform()
+        {
+
+            switch (Application.platform)
+            {
+                case RuntimePlatform.WindowsEditor:
+                case RuntimePlatform.WindowsPlayer:
+                    PlatformString = "Windows";
+                    break;
+
+                case RuntimePlatform.XboxOne:
+                    PlatformString = "GDK";
+                    break;
+
+                case RuntimePlatform.PS4:
+                    PlatformString = "PS4";
+                    break;
+
+                case RuntimePlatform.PS5:
+                    PlatformString = "PS5";
+                    break;
+
+                case RuntimePlatform.Switch:
+                    PlatformString = "Switch";
+                    break;
+
+                case RuntimePlatform.IPhonePlayer:
+                    PlatformString = "iOS";
+                    break;
+
+                case RuntimePlatform.Android:
+                    PlatformString = "Android";
+                    break;
+
+                default:
+                    PlatformString = Application.platform.ToString();
+                    break;
+            }
+        }
+     
         public static string GetFullUrl(string apiCall, Dictionary<string, string> getParams, PlayFabApiSettings apiSettings = null)
         {
             StringBuilder sb = AcquireStringBuilder();
+            DeterminePlatform();
 
             string productionEnvironmentUrl = null, verticalName = null, titleId = null;
 
@@ -238,6 +280,7 @@ namespace PlayFab
 
             sb.Append(firstParam ? "?" : "&");
             sb.Append("engineVersion=").Append(EngineVersion);
+            sb.Append("&platform=").Append(PlatformString);
 
             return sb.ToString();
         }

--- a/targets/unity-v2/source/ExampleTestProject/Assets/PlayFabSDK/Shared/Public/PlayFabSettings.cs.ejs
+++ b/targets/unity-v2/source/ExampleTestProject/Assets/PlayFabSDK/Shared/Public/PlayFabSettings.cs.ejs
@@ -29,7 +29,28 @@ namespace PlayFab
 
     public static class PlayFabSettings
     {
-        static PlayFabSettings() { }
+        static PlayFabSettings() {
+#if UNITY_GAMECORE || UNITY_GAMECORE_XBOXONE || UNITY_GAMECORE_SCARLETT || MICROSOFT_GAME_CORE
+            PlatformString = "GDK";
+#else
+        switch (Application.platform)
+        {
+            case RuntimePlatform.WindowsEditor:
+            case RuntimePlatform.WindowsPlayer:
+            case RuntimePlatform.WindowsServer:
+                PlatformString = RuntimePlatform.iOS.ToString();
+                break;
+
+            case RuntimePlatform.IPhonePlayer:
+                PlatformString = "---";
+                break;
+
+            default:
+                PlatformString = Application.platform.ToString();
+                break;
+        }
+#endif
+        }
 
         private static PlayFabSharedSettings _playFabShared = null;
         private static PlayFabSharedSettings PlayFabSharedPrivate { get { if (_playFabShared == null) _playFabShared = GetSharedSettingsObjectPrivate(); return _playFabShared; } }
@@ -150,50 +171,9 @@ namespace PlayFab
             return _cachedStringBuilder;
         }
 
-        public static void DeterminePlatform()
-        {
-
-            switch (Application.platform)
-            {
-                case RuntimePlatform.WindowsEditor:
-                case RuntimePlatform.WindowsPlayer:
-                    PlatformString = "Windows";
-                    break;
-
-                case RuntimePlatform.XboxOne:
-                    PlatformString = "GDK";
-                    break;
-
-                case RuntimePlatform.PS4:
-                    PlatformString = "PS4";
-                    break;
-
-                case RuntimePlatform.PS5:
-                    PlatformString = "PS5";
-                    break;
-
-                case RuntimePlatform.Switch:
-                    PlatformString = "Switch";
-                    break;
-
-                case RuntimePlatform.IPhonePlayer:
-                    PlatformString = "iOS";
-                    break;
-
-                case RuntimePlatform.Android:
-                    PlatformString = "Android";
-                    break;
-
-                default:
-                    PlatformString = Application.platform.ToString();
-                    break;
-            }
-        }
-     
         public static string GetFullUrl(string apiCall, Dictionary<string, string> getParams, PlayFabApiSettings apiSettings = null)
         {
             StringBuilder sb = AcquireStringBuilder();
-            DeterminePlatform();
 
             string productionEnvironmentUrl = null, verticalName = null, titleId = null;
 

--- a/targets/unity-v2/source/ExampleTestProject/Assets/PlayFabSDK/Shared/Public/PlayFabSettings.cs.ejs
+++ b/targets/unity-v2/source/ExampleTestProject/Assets/PlayFabSDK/Shared/Public/PlayFabSettings.cs.ejs
@@ -38,11 +38,11 @@ namespace PlayFab
             case RuntimePlatform.WindowsEditor:
             case RuntimePlatform.WindowsPlayer:
             case RuntimePlatform.WindowsServer:
-                PlatformString = RuntimePlatform.iOS.ToString();
+                PlatformString = "Windows";
                 break;
 
             case RuntimePlatform.IPhonePlayer:
-                PlatformString = "---";
+                PlatformString = "iOS";
                 break;
 
             default:

--- a/targets/unity-v2/source/ExampleTestProject/Assets/PlayFabSDK/Shared/Public/PlayFabSettings.cs.ejs
+++ b/targets/unity-v2/source/ExampleTestProject/Assets/PlayFabSDK/Shared/Public/PlayFabSettings.cs.ejs
@@ -29,7 +29,8 @@ namespace PlayFab
 
     public static class PlayFabSettings
     {
-        static PlayFabSettings() {
+        static PlayFabSettings() 
+        {
 #if UNITY_GAMECORE || UNITY_GAMECORE_XBOXONE || UNITY_GAMECORE_SCARLETT || MICROSOFT_GAME_CORE
             PlatformString = "GDK";
 #else


### PR DESCRIPTION
Adding platform information to query string using Unity's Application.platform() enum values and GDK platform directives. 