### PR TITLE
Update ValidateEntityTokenAsync to use the instance authenticationContext values

### DIFF
--- a/targets/csharp/make.js
+++ b/targets/csharp/make.js
@@ -263,7 +263,7 @@ function getRequestActions(tabbing, apiCall, isInstance) {
             + tabbing + "if (request.PlayerAccountPoolId == null) throw new PlayFabException(PlayFabExceptionCode.PlayerAccountPoolNotSet, \"PlayerAccountPoolId must be set in your local or global settings to call this method\");\n";
     if (apiCall.auth === "EntityToken" && apiCall.name === "ValidateEntityToken")
     {
-        return "\n"+tabbing+"var entityToken = request?.AuthenticationContext?.EntityToken ?? PlayFabSettings.staticPlayer.EntityToken;\n"
+        return "\n"+tabbing+"var entityToken = requestContext?.EntityToken ?? PlayFabSettings.staticPlayer.EntityToken;\n"
                     +tabbing + "if ((entityToken) == null) throw new PlayFabException(PlayFabExceptionCode.EntityTokenNotSet, \"Must call Client Login or GetEntityToken before calling this method\");\n";
     }
     else if (apiCall.auth === "EntityToken")

--- a/targets/csharp/make.js
+++ b/targets/csharp/make.js
@@ -262,9 +262,14 @@ function getRequestActions(tabbing, apiCall, isInstance) {
             + tabbing + "if (request != null) request.PlayerAccountPoolId = request?.PlayerAccountPoolId ?? requestSettings.PlayerAccountPoolId;\n"
             + tabbing + "if (request.PlayerAccountPoolId == null) throw new PlayFabException(PlayFabExceptionCode.PlayerAccountPoolNotSet, \"PlayerAccountPoolId must be set in your local or global settings to call this method\");\n";
     if (apiCall.auth === "EntityToken" && apiCall.name === "ValidateEntityToken")
-    {
-        return "\n"+tabbing+"var entityToken = requestContext?.EntityToken ?? PlayFabSettings.staticPlayer.EntityToken;\n"
-                    +tabbing + "if ((entityToken) == null) throw new PlayFabException(PlayFabExceptionCode.EntityTokenNotSet, \"Must call Client Login or GetEntityToken before calling this method\");\n";
+    {   
+        if(isInstance)
+            return "\n" + tabbing + "var entityToken = requestContext?.EntityToken ?? PlayFabSettings.staticPlayer.EntityToken;\n"
+                + tabbing + "if ((entityToken) == null) throw new PlayFabException(PlayFabExceptionCode.EntityTokenNotSet, \"Must call Client Login or GetEntityToken before calling this method\");\n";
+        else
+            return "\n" + tabbing + "var entityToken = request?.AuthenticationContext?.EntityToken ?? PlayFabSettings.staticPlayer.EntityToken;\n"
+                + tabbing + "if ((entityToken) == null) throw new PlayFabException(PlayFabExceptionCode.EntityTokenNotSet, \"Must call Client Login or GetEntityToken before calling this method\");\n";
+
     }
     else if (apiCall.auth === "EntityToken")
     {


### PR DESCRIPTION
Added the use of the requestContext local variable that contains the PlayFabAuthenticationContext object.
The PlayFabAuthenticationContext instance object isn't used to get the auth context. If we do not pass the auth context in the method request parameters, it does not fall back to use the auth context from the class instance.
Thanks @fernandezafb for the work: https://github.com/PlayFab/CSharpSDK/pull/125