### PR TITLE
Code fixes for GACC lime bugs

### DIFF
--- a/targets/unity-v2/source/ExampleTestProject/Assets/PlayFabEditorExtensions/Editor/PlayFabEditor.cs
+++ b/targets/unity-v2/source/ExampleTestProject/Assets/PlayFabEditorExtensions/Editor/PlayFabEditor.cs
@@ -219,7 +219,7 @@ namespace PlayFab.PfEditor
                 using (new UnityHorizontal())
                 {
                     GUILayout.FlexibleSpace();
-                    if (GUILayout.Button("VIEW DOCUMENTATION", PlayFabEditorHelper.uiStyle.GetStyle("textButton")))
+                    if (GUILayout.Button("VIEW DOCUMENTATION ->", PlayFabEditorHelper.uiStyle.GetStyle("textButton")))
                     {
                         Application.OpenURL("https://github.com/PlayFab/UnityEditorExtensions");
                     }
@@ -229,7 +229,7 @@ namespace PlayFab.PfEditor
                 using (new UnityHorizontal())
                 {
                     GUILayout.FlexibleSpace();
-                    if (GUILayout.Button("REPORT ISSUES", PlayFabEditorHelper.uiStyle.GetStyle("textButton")))
+                    if (GUILayout.Button("REPORT ISSUES ->", PlayFabEditorHelper.uiStyle.GetStyle("textButton")))
                     {
                         Application.OpenURL("https://github.com/PlayFab/UnityEditorExtensions/issues");
                     }
@@ -241,7 +241,7 @@ namespace PlayFab.PfEditor
                     using (new UnityHorizontal())
                     {
                         GUILayout.FlexibleSpace();
-                        if (GUILayout.Button("UNINSTALL ", PlayFabEditorHelper.uiStyle.GetStyle("textButton")))
+                        if (GUILayout.Button("UNINSTALL ", PlayFabEditorHelper.uiStyle.GetStyle("button")))
                         {
                             RemoveEdEx();
                         }

--- a/targets/unity-v2/source/ExampleTestProject/Assets/PlayFabEditorExtensions/Editor/Scripts/Panels/PlayFabEditorAuthenticate.cs
+++ b/targets/unity-v2/source/ExampleTestProject/Assets/PlayFabEditorExtensions/Editor/Scripts/Panels/PlayFabEditorAuthenticate.cs
@@ -274,7 +274,7 @@ private static void shiftKeyHandler()
                 using (new UnityHorizontal(PlayFabEditorHelper.uiStyle.GetStyle("gpStyleClear")))
                 {
                     GUILayout.FlexibleSpace();
-                    if (GUILayout.Button("VIEW README", PlayFabEditorHelper.uiStyle.GetStyle("textButton")))
+                    if (GUILayout.Button("VIEW README ->", PlayFabEditorHelper.uiStyle.GetStyle("textButton")))
                     {
                         Application.OpenURL("https://github.com/PlayFab/UnityEditorExtensions#setup");
                     }

--- a/targets/unity-v2/source/ExampleTestProject/Assets/PlayFabEditorExtensions/Editor/Scripts/Panels/PlayFabEditorHeader.cs
+++ b/targets/unity-v2/source/ExampleTestProject/Assets/PlayFabEditorExtensions/Editor/Scripts/Panels/PlayFabEditorHeader.cs
@@ -41,10 +41,10 @@ namespace PlayFab.PfEditor
                     GUILayout.BeginArea(new Rect(gmAnchor, 10, EditorGUIUtility.currentViewWidth * .25f, 42));
                     GUILayout.BeginHorizontal();
                 }
+                    if (GUILayout.Button(new GUIContent("", "Dashboard"), PlayFabEditorHelper.uiStyle.GetStyle("gmIcon")))
 
-                if (GUILayout.Button("", PlayFabEditorHelper.uiStyle.GetStyle("gmIcon")))
-                {
-                    OnDashbaordClicked();
+                    {
+                        OnDashbaordClicked();
                 }
                 GUILayout.EndHorizontal();
                 GUILayout.EndArea();

--- a/targets/unity-v2/source/ExampleTestProject/Assets/PlayFabEditorExtensions/Editor/Scripts/Panels/PlayFabEditorHelpMenu.cs
+++ b/targets/unity-v2/source/ExampleTestProject/Assets/PlayFabEditorExtensions/Editor/Scripts/Panels/PlayFabEditorHelpMenu.cs
@@ -10,6 +10,21 @@ namespace PlayFab.PfEditor
         // chnages in local
         private static int focusIndex;
         private static bool isShiftKeyPressed = false;
+        private static float scrollFactor = 20f;
+
+        public static void KeyboardEventHandler()
+        {
+            var e = Event.current;
+            if (e.type == EventType.KeyUp && e.keyCode == KeyCode.UpArrow)
+            {
+                scrollPos = new Vector2(0, scrollPos.y - scrollFactor);
+
+            }
+            if (e.type == EventType.KeyUp && e.keyCode == KeyCode.DownArrow)
+            {
+                scrollPos = new Vector2(0, scrollPos.y + scrollFactor);
+            }
+        }
         private static void shiftKeyHandler()
         {
             var e = Event.current;
@@ -94,6 +109,7 @@ namespace PlayFab.PfEditor
         public static void DrawHelpPanel()
         {
             HelpInputHandler();
+            KeyboardEventHandler();
             scrollPos = GUILayout.BeginScrollView(scrollPos, PlayFabEditorHelper.uiStyle.GetStyle("gpStyleGray1"));
             buttonWidth = EditorGUIUtility.currentViewWidth > 400 ? EditorGUIUtility.currentViewWidth / 2 : 200;
 

--- a/targets/unity-v2/source/ExampleTestProject/Assets/PlayFabEditorExtensions/Editor/Scripts/Panels/PlayFabEditorMenu.cs
+++ b/targets/unity-v2/source/ExampleTestProject/Assets/PlayFabEditorExtensions/Editor/Scripts/Panels/PlayFabEditorMenu.cs
@@ -1,9 +1,14 @@
 using UnityEngine;
+using System;
+using System.Collections.Generic;
+using UnityEditor;
 
 namespace PlayFab.PfEditor
 {
     public class PlayFabEditorMenu : UnityEditor.Editor
     {
+        private static int focusIndex;
+
         #region panel variables
         internal enum MenuStates
         {
@@ -18,9 +23,10 @@ namespace PlayFab.PfEditor
 
         internal static MenuStates _menuState = MenuStates.Sdks;
         #endregion
-
         public static void DrawMenu()
         {
+            mainMenuHandler();
+
             if (PlayFabEditorSDKTools.IsInstalled && PlayFabEditorSDKTools.isSdkSupported)
                 _menuState = (MenuStates)PlayFabEditorPrefsSO.Instance.curMainMenuIdx;
 
@@ -31,49 +37,63 @@ namespace PlayFab.PfEditor
             var logoutButtonStyle = PlayFabEditorHelper.uiStyle.GetStyle("Button");
             var toolsButtonStyle = PlayFabEditorHelper.uiStyle.GetStyle("textButton");
             var packagesButtonStyle = PlayFabEditorHelper.uiStyle.GetStyle("textButton");
-
             if (_menuState == MenuStates.Sdks)
-                sdksButtonStyle = PlayFabEditorHelper.uiStyle.GetStyle("textButton_selected");
+            sdksButtonStyle = PlayFabEditorHelper.uiStyle.GetStyle("textButton_selected");
             if (_menuState == MenuStates.Settings)
-                settingsButtonStyle = PlayFabEditorHelper.uiStyle.GetStyle("textButton_selected");
+            settingsButtonStyle = PlayFabEditorHelper.uiStyle.GetStyle("textButton_selected");
             if (_menuState == MenuStates.Logout)
-                logoutButtonStyle = PlayFabEditorHelper.uiStyle.GetStyle("textButton_selected");
+            logoutButtonStyle = PlayFabEditorHelper.uiStyle.GetStyle("textButton_selected");
             if (_menuState == MenuStates.Data)
-                dataButtonStyle = PlayFabEditorHelper.uiStyle.GetStyle("textButton_selected");
+            dataButtonStyle = PlayFabEditorHelper.uiStyle.GetStyle("textButton_selected");
             if (_menuState == MenuStates.Help)
-                helpButtonStyle = PlayFabEditorHelper.uiStyle.GetStyle("textButton_selected");
+            helpButtonStyle = PlayFabEditorHelper.uiStyle.GetStyle("textButton_selected");
             if (_menuState == MenuStates.Packages)
-                packagesButtonStyle = PlayFabEditorHelper.uiStyle.GetStyle("textButton_selected");
+            packagesButtonStyle = PlayFabEditorHelper.uiStyle.GetStyle("textButton_selected");
             if (_menuState == MenuStates.Tools)
-                toolsButtonStyle = PlayFabEditorHelper.uiStyle.GetStyle("textButton_selected");
+            toolsButtonStyle = PlayFabEditorHelper.uiStyle.GetStyle("textButton_selected");
 
             using (new UnityHorizontal(PlayFabEditorHelper.uiStyle.GetStyle("gpStyleGray1"), GUILayout.Height(25), GUILayout.ExpandWidth(true)))
             {
                 GUILayout.Space(5);
-
+                GUI.SetNextControlName("sdk");
                 if (GUILayout.Button("SDK", sdksButtonStyle, GUILayout.MaxWidth(35)))
                 {
                     OnSdKsClicked();
                 }
-
                 if (PlayFabEditorSDKTools.IsInstalled && PlayFabEditorSDKTools.isSdkSupported)
                 {
+                    GUI.SetNextControlName("settings");
                     if (GUILayout.Button("SETTINGS", settingsButtonStyle, GUILayout.MaxWidth(65)))
+                    {
                         OnSettingsClicked();
+                    }
+                    GUI.SetNextControlName("data");
                     if (GUILayout.Button("DATA", dataButtonStyle, GUILayout.MaxWidth(45)))
+                    {
                         OnDataClicked();
+                    }
+                    GUI.SetNextControlName("tools");
                     if (GUILayout.Button("TOOLS", toolsButtonStyle, GUILayout.MaxWidth(45)))
+                    {
                         OnToolsClicked();
-                    if(GUILayout.Button("PACKAGES", packagesButtonStyle, GUILayout.MaxWidth(72)))
+                    }
+                    GUI.SetNextControlName("packages");
+                    if (GUILayout.Button("PACKAGES", packagesButtonStyle, GUILayout.MaxWidth(72)))
+                    {
                         OnPackagesClicked();
+                    }
                 }
-
+                GUI.SetNextControlName("help");
                 if (GUILayout.Button("HELP", helpButtonStyle, GUILayout.MaxWidth(45)))
+                {
                     OnHelpClicked();
+                }
                 GUILayout.FlexibleSpace();
-                GUI.SetNextControlName("logout");
+                GUI.SetNextControlName("logOut");
                 if (GUILayout.Button("LOGOUT", logoutButtonStyle, GUILayout.MaxWidth(85)))
+                {
                     OnLogoutClicked();
+                }
             }
         }
 
@@ -83,7 +103,79 @@ namespace PlayFab.PfEditor
             PlayFabEditor.RaiseStateUpdate(PlayFabEditor.EdExStates.OnMenuItemClicked, MenuStates.Tools.ToString());
             PlayFabEditorPrefsSO.Instance.curMainMenuIdx = (int)_menuState;
         }
+        public static void mainMenuHandler()
+        {
+            var e = Event.current;
+            if (e.type == EventType.KeyUp && e.keyCode == KeyCode.RightArrow)
+            {
+                switch (focusIndex)
+                {
+                    case 0:
+                        EditorGUI.FocusTextInControl("sdk");
+                        focusIndex = 1;
+                        break;
+                    case 1:
+                        EditorGUI.FocusTextInControl("settings");
+                        focusIndex = 2;
+                        break;
+                    case 2:
+                        EditorGUI.FocusTextInControl("data");
+                        focusIndex = 3;
+                        break;
+                    case 3:
+                        EditorGUI.FocusTextInControl("tools");
+                        focusIndex = 4;
+                        break;
+                    case 4:
+                        EditorGUI.FocusTextInControl("packages");
+                        focusIndex = 5;
+                        break;
+                    case 5:
+                        EditorGUI.FocusTextInControl("help");
+                        focusIndex = 6;
+                        break;
+                    case 6:
+                        EditorGUI.FocusTextInControl("logOut");
+                        focusIndex = 0;
+                        break;
+                }
 
+            }
+            if (e.type == EventType.KeyUp && e.keyCode == KeyCode.LeftArrow)
+            {
+                switch (focusIndex)
+                {
+                    case 0:
+                        EditorGUI.FocusTextInControl("logOut");
+                        focusIndex = 1;
+                        break;
+                    case 1:
+                        EditorGUI.FocusTextInControl("help");
+                        focusIndex = 2;
+                        break;
+                    case 2:
+                        EditorGUI.FocusTextInControl("packages");
+                        focusIndex = 3;
+                        break;
+                    case 3:
+                        EditorGUI.FocusTextInControl("tools");
+                        focusIndex = 4;
+                        break;
+                    case 4:
+                        EditorGUI.FocusTextInControl("data");
+                        focusIndex = 5;
+                        break;
+                    case 5:
+                        EditorGUI.FocusTextInControl("settings");
+                        focusIndex = 6;
+                        break;
+                    case 6:
+                        EditorGUI.FocusTextInControl("sdk");
+                        focusIndex = 0;
+                        break;
+                }
+            }
+        }
         public static void OnDataClicked()
         {
             _menuState = MenuStates.Data;

--- a/targets/unity-v2/source/ExampleTestProject/Assets/PlayFabEditorExtensions/Editor/Scripts/Panels/PlayFabEditorSDKTools.cs
+++ b/targets/unity-v2/source/ExampleTestProject/Assets/PlayFabEditorExtensions/Editor/Scripts/Panels/PlayFabEditorSDKTools.cs
@@ -314,7 +314,7 @@ namespace PlayFab.PfEditor
                     {
                         GUILayout.FlexibleSpace();
                         GUI.SetNextControlName("set_my_title");
-                        if (GUILayout.Button("SET MY TITLE", PlayFabEditorHelper.uiStyle.GetStyle("textButton")))
+                        if (GUILayout.Button("SET MY TITLE ->", PlayFabEditorHelper.uiStyle.GetStyle("textButton")))
                         {
                             PlayFabEditorMenu.OnSettingsClicked();
                         }
@@ -327,7 +327,7 @@ namespace PlayFab.PfEditor
             {
                 GUILayout.FlexibleSpace();
                 GUI.SetNextControlName("view_release_note");
-                if (GUILayout.Button("VIEW RELEASE NOTES", PlayFabEditorHelper.uiStyle.GetStyle("textButton"), GUILayout.MinHeight(32), GUILayout.MinWidth(200)))
+                if (GUILayout.Button("VIEW RELEASE NOTES ->", PlayFabEditorHelper.uiStyle.GetStyle("textButton"), GUILayout.MinHeight(32), GUILayout.MinWidth(200)))
                 {
                     Application.OpenURL("https://docs.microsoft.com/en-us/gaming/playfab/release-notes/");
                 }

--- a/targets/unity-v2/source/ExampleTestProject/Assets/PlayFabEditorExtensions/Editor/UI/PlayFabStyles.guiskin
+++ b/targets/unity-v2/source/ExampleTestProject/Assets/PlayFabEditorExtensions/Editor/UI/PlayFabStyles.guiskin
@@ -1554,7 +1554,7 @@ MonoBehaviour:
     m_StretchHeight: 0
   - m_Name: textButton_selected
     m_Normal:
-      m_Background: {fileID: 2800000, guid: d03222342209e43daaf2ca8d1364e47a, type: 3}
+      m_Background: {fileID: 2800000, guid: ce06979c901076a4681b4a77fcf036e7, type: 3}
       m_ScaledBackgrounds: []
       m_TextColor: {r: 0.09411765, g: 0.7058824, b: 0.7607843, a: 1}
     m_Hover:


### PR DESCRIPTION
**Code Fixes for**
**48210554:**	Only color is used to highlight the selected 'SDK' tab control present in the application.	
**48211699:**	Underline or chevron is not provided for the 'VIEW README' link present in the application.	
**48223758:**	LOG IN' control present on the application under the 'Welcome to PlayFab!' section is not appearing as button.	
**48293639:**	Tooltip is not defined for the 'Game Manager' icon control present above 'Welcome to PlayFab!' text.	
**48302565:**	Scrollable control present on the 'Help' tab is not accessible through keyboard.	
**48304143:**	LOGOUT' button presents in the 'No SDK is installed' screen is visually not appearing as button.
**48304316:**	Only color is used to highlight the selected 'SETTINGS' tab control present in the application.
**48304352:**	UNINSTALL' button control present in the 'Help' tab is visually not appearing as button.	
**48304382:**	CREATE AN ACCOUNT' button control is visually not appearing as button.	
**48305052:**	Underline or chevron is not provided for the 'VIEW DOCUMENTATION' & 'REPORT ISSUES' links present in       the 'Help' tab.	
**48305066:**	Underline or chevron is not provided for the 'SET MY TITLE' and 'VIEW RELEASE NOTES' links present in the 'SDK' tab.

