### PR TITLE
Fixed scripting defines for dedicated server

### DIFF
--- a/targets/unity-v2/source/ExampleTestProject/Assets/PlayFabEditorExtensions/Editor/Scripts/Panels/PlayFabEditorSettings.cs
+++ b/targets/unity-v2/source/ExampleTestProject/Assets/PlayFabEditorExtensions/Editor/Scripts/Panels/PlayFabEditorSettings.cs
@@ -3,6 +3,7 @@ using System;
 using System.Collections.Generic;
 using System.Text;
 using UnityEditor;
+using UnityEditor.Build;
 using UnityEngine;
 
 namespace PlayFab.PfEditor
@@ -43,7 +44,23 @@ namespace PlayFab.PfEditor
         {
             using (new UnityVertical(PlayFabEditorHelper.uiStyle.GetStyle("gpStyleGray1")))
             {
-                var curDefines = PlayerSettings.GetScriptingDefineSymbolsForGroup(EditorUserBuildSettings.selectedBuildTargetGroup);
+#if UNITY_2021_2_OR_NEWER
+#if UNITY_SERVER
+                NamedBuildTarget buildTarget = NamedBuildTarget.Server;
+#else
+                BuildTarget buildTarget = EditorUserBuildSettings.activeBuildTarget;
+                BuildTargetGroup targetGroup = BuildPipeline.GetBuildTargetGroup(buildTarget);
+                NamedBuildTarget buildTarget = NamedBuildTarget.FromBuildTargetGroup(targetGroup);
+#endif
+#else
+                BuildTargetGroup buildTarget = EditorUserBuildSettings.selectedBuildTargetGroup;
+#endif
+                
+#if UNITY_2021_2_OR_NEWER
+                var curDefines = PlayerSettings.GetScriptingDefineSymbols(buildTarget);
+#else
+                var curDefines = PlayerSettings.GetScriptingDefineSymbolsForGroup(buildTarget);
+#endif
                 var changedFlags = false;
                 var allFlags = new Dictionary<string, PfDefineFlag>(PlayFabEditorHelper.FLAG_LABELS);
                 var extraDefines = new HashSet<string>(curDefines.Split(' ', ';'));
@@ -69,7 +86,12 @@ namespace PlayFab.PfEditor
 
                 if (changedFlags)
                 {
-                    PlayerSettings.SetScriptingDefineSymbolsForGroup(EditorUserBuildSettings.selectedBuildTargetGroup, curDefines);
+#if UNITY_2021_2_OR_NEWER
+                    PlayerSettings.SetScriptingDefineSymbols(buildTarget, curDefines);
+#else
+                    PlayerSettings.SetScriptingDefineSymbolsForGroup(buildTarget, curDefines);
+#endif
+                    
                     Debug.Log("Updating Defines: " + curDefines);
                     AssetDatabase.Refresh();
                 }


### PR DESCRIPTION
Unity has changed how build targets are defined and have set `GetScriptingDefineSymbolsForGroup` and `SetScriptingDefineSymbolsForGroup` for future deprecation. This introduces a bug in PlayFab, causing the editor settings not to update the scripting defines when a "Dedicated Server" build is selected, which was released in 2021.3.

This PR should fix the problem with dedicated servers for versions 2021.3+, and cover backwards compatibility for older Unity versions. Additionally, 2021.2+ should now use the non-deprecated methods for scripting define symbols.

The large use of conditional compilation is due to an oversight(?) from Unity, where this is no easy way to get your current build setting for dedicated servers, because dedicated servers are actually a sub target.