### PR TITLE
Controls are accessible through keyboard

### DIFF
--- a/targets/unity-v2/source/ExampleTestProject/Assets/PlayFabEditorExtensions/Editor/PlayFabEditor.cs
+++ b/targets/unity-v2/source/ExampleTestProject/Assets/PlayFabEditorExtensions/Editor/PlayFabEditor.cs
@@ -191,7 +191,7 @@ namespace PlayFab.PfEditor
                     using (new UnityHorizontal())
                     {
                         GUILayout.FlexibleSpace();
-                        GUI.SetNextControlName("upgardEdex");
+                        GUI.SetNextControlName("upgradeEdex");
                         if (GUILayout.Button("UPGRADE EDEX", PlayFabEditorHelper.uiStyle.GetStyle("textButtonOr")))
                         {
                             UpgradeEdEx();

--- a/targets/unity-v2/source/ExampleTestProject/Assets/PlayFabEditorExtensions/Editor/PlayFabEditor.cs
+++ b/targets/unity-v2/source/ExampleTestProject/Assets/PlayFabEditorExtensions/Editor/PlayFabEditor.cs
@@ -191,6 +191,7 @@ namespace PlayFab.PfEditor
                     using (new UnityHorizontal())
                     {
                         GUILayout.FlexibleSpace();
+                        GUI.SetNextControlName("upgardEdex");
                         if (GUILayout.Button("UPGRADE EDEX", PlayFabEditorHelper.uiStyle.GetStyle("textButtonOr")))
                         {
                             UpgradeEdEx();
@@ -202,6 +203,7 @@ namespace PlayFab.PfEditor
                 using (new UnityHorizontal())
                 {
                     GUILayout.FlexibleSpace();
+                    GUI.SetNextControlName("view_documentation");
                     if (GUILayout.Button("VIEW DOCUMENTATION ->", PlayFabEditorHelper.uiStyle.GetStyle("textButton")))
                     {
                         Application.OpenURL("https://github.com/PlayFab/UnityEditorExtensions");
@@ -212,6 +214,7 @@ namespace PlayFab.PfEditor
                 using (new UnityHorizontal())
                 {
                     GUILayout.FlexibleSpace();
+                    GUI.SetNextControlName("report_issues");
                     if (GUILayout.Button("REPORT ISSUES ->", PlayFabEditorHelper.uiStyle.GetStyle("textButton")))
                     {
                         Application.OpenURL("https://github.com/PlayFab/UnityEditorExtensions/issues");
@@ -224,6 +227,7 @@ namespace PlayFab.PfEditor
                     using (new UnityHorizontal())
                     {
                         GUILayout.FlexibleSpace();
+                        GUI.SetNextControlName("unInstall");
                         if (GUILayout.Button("UNINSTALL ", PlayFabEditorHelper.uiStyle.GetStyle("button")))
                         {
                             RemoveEdEx();

--- a/targets/unity-v2/source/ExampleTestProject/Assets/PlayFabEditorExtensions/Editor/Scripts/Panels/PlayFabEditorHelpMenu.cs
+++ b/targets/unity-v2/source/ExampleTestProject/Assets/PlayFabEditorExtensions/Editor/Scripts/Panels/PlayFabEditorHelpMenu.cs
@@ -75,16 +75,20 @@ namespace PlayFab.PfEditor
                             focusIndex = 6;
                             break;
                         case 6:
-                            EditorGUI.FocusTextInControl("view_documentation");
+                            EditorGUI.FocusTextInControl("upgradeEdex");
                             focusIndex = 7;
                             break;
                         case 7:
-                            EditorGUI.FocusTextInControl("report_issues");
+                            EditorGUI.FocusTextInControl("view_documentation");
                             focusIndex = 8;
                             break;
                         case 8:
-                            EditorGUI.FocusTextInControl("unInstall");
+                            EditorGUI.FocusTextInControl("report_issues");
                             focusIndex = 9;
+                            break;
+                        case 9:
+                            EditorGUI.FocusTextInControl("unInstall");
+                            focusIndex = 0;
                             break;
                     }
                 }
@@ -121,15 +125,15 @@ namespace PlayFab.PfEditor
                             focusIndex = 5;
                             break;
                         case 7:
-                            EditorGUI.FocusTextInControl("view_documentation");
+                            EditorGUI.FocusTextInControl("upgradeEdex");
                             focusIndex = 6;
                             break;
                         case 8:
-                            EditorGUI.FocusTextInControl("report_issues");
+                            EditorGUI.FocusTextInControl("view_documentation");
                             focusIndex = 7;
                             break;
                         case 9:
-                            EditorGUI.FocusTextInControl("unInstall");
+                            EditorGUI.FocusTextInControl("report_issues");
                             focusIndex = 8;
                             break;
                     }

--- a/targets/unity-v2/source/ExampleTestProject/Assets/PlayFabEditorExtensions/Editor/Scripts/Panels/PlayFabEditorHelpMenu.cs
+++ b/targets/unity-v2/source/ExampleTestProject/Assets/PlayFabEditorExtensions/Editor/Scripts/Panels/PlayFabEditorHelpMenu.cs
@@ -72,7 +72,19 @@ namespace PlayFab.PfEditor
                             break;
                         case 5:
                             EditorGUI.FocusTextInControl("view_service_availability");
-                            focusIndex = 0;
+                            focusIndex = 6;
+                            break;
+                        case 6:
+                            EditorGUI.FocusTextInControl("view_documentation");
+                            focusIndex = 7;
+                            break;
+                        case 7:
+                            EditorGUI.FocusTextInControl("report_issues");
+                            focusIndex = 8;
+                            break;
+                        case 8:
+                            EditorGUI.FocusTextInControl("unInstall");
+                            focusIndex = 9;
                             break;
                     }
                 }
@@ -81,8 +93,8 @@ namespace PlayFab.PfEditor
                     switch (focusIndex)
                     {
                         case 0:
-                            EditorGUI.FocusTextInControl("view_service_availability");
-                            focusIndex = 5;
+                            EditorGUI.FocusTextInControl("unInstall");
+                            focusIndex = 9;
                             break;
                         case 1:
                             EditorGUI.FocusTextInControl("beginners_guide");
@@ -103,6 +115,22 @@ namespace PlayFab.PfEditor
                         case 5:
                             EditorGUI.FocusTextInControl("ask_questions");
                             focusIndex = 4;
+                            break;
+                        case 6:
+                            EditorGUI.FocusTextInControl("view_service_availability");
+                            focusIndex = 5;
+                            break;
+                        case 7:
+                            EditorGUI.FocusTextInControl("view_documentation");
+                            focusIndex = 6;
+                            break;
+                        case 8:
+                            EditorGUI.FocusTextInControl("report_issues");
+                            focusIndex = 7;
+                            break;
+                        case 9:
+                            EditorGUI.FocusTextInControl("unInstall");
+                            focusIndex = 8;
                             break;
                     }
                 }


### PR DESCRIPTION
[Bug 53805356](https://nam06.safelinks.protection.outlook.com/?url=https%3A%2F%2Fmicrosoft.visualstudio.com%2FXbox%2F_workitems%2Fedit%2F53805356&data=05%7C02%7Cv-ashishsing%40microsoft.com%7C884ab2f325fd466133b308dd7602a684%7C72f988bf86f141af91ab2d7cd011db47%7C1%7C0%7C638796475954456850%7CUnknown%7CTWFpbGZsb3d8eyJFbXB0eU1hcGkiOnRydWUsIlYiOiIwLjAuMDAwMCIsIlAiOiJXaW4zMiIsIkFOIjoiTWFpbCIsIldUIjoyfQ%3D%3D%7C0%7C%7C%7C&sdata=1%2BR9UKj0SisnzLZoEN5VMeYlLCMNBD0OcW96QLU%2FTj8%3D&reserved=0): [PlayFab Unity plugin-App] [PC] [Accessibility]: 'View Documentation', 'Report Issues' and 'Uninstall' controls present in 'Help' Tab control are not accessible through keyboard.