### PR TITLE
fix(targets/javascript): fix type definition imports on case-sensitive filesystems

### DIFF
--- a/targets/javascript/templates/PlayFab_Api.js.ejs
+++ b/targets/javascript/templates/PlayFab_Api.js.ejs
@@ -1,4 +1,4 @@
-/// <reference path="../typings/PlayFab/PlayFab<%- api.name %>Api.d.ts" />
+/// <reference path="../Typings/PlayFab/PlayFab<%- api.name %>Api.d.ts" />
 
 var PlayFab = typeof PlayFab != "undefined" ? PlayFab : {};
 


### PR DESCRIPTION
fix(targets/javascript): fix type definition imports on case-sensitive filesystems

The type definitions are located in a "Typings" folder, but are referenced via "typings". This will work on case-insensitive filesystems like NTFS, but does not work properly on macOS or Linux environments, including WSL.