### PR TITLE
Add Multiplayer API TypeScript typings to CloudScript declarations

### DIFF
--- a/targets/SdkTestingCloudScript/make.js
+++ b/targets/SdkTestingCloudScript/make.js
@@ -12,18 +12,24 @@ exports.makeServerAPI = function (apis, sourceDir, apiOutputDir) {
     // Get only the server api because this is for CloudScript (only has access to serverAPI)
     var serverApiNames = ["Server"];
     var entityApiNames = ["Authentication", "Data", "Events", "Groups", "Profiles"];
+    var multiplayerApiNames = ["Multiplayer"];
     var serverApiList = [];
     var entityApiList = [];
+    var multiplayerApiList = [];
     for (var i = 0; i < apis.length; i++) {
         if (serverApiNames.includes(apis[i].name))
             serverApiList.push(apis[i]);
         if (entityApiNames.includes(apis[i].name))
             entityApiList.push(apis[i]);
+        if (multiplayerApiNames.includes(apis[i].name))
+            multiplayerApiList.push(apis[i]);
     }
     if (serverApiList.length === 0)
         throw "Could not find Server API";
     if (entityApiList.length === 0)
         throw "Could not find Entity API";
+    if (multiplayerApiList.length === 0)
+        throw "Could not find Multiplayer API";
 
     // Load PlayStream APIs
     var playStreamEventModels = getApiJson("PlayStreamEventModels");
@@ -32,6 +38,7 @@ exports.makeServerAPI = function (apis, sourceDir, apiOutputDir) {
     var locals = {
         serverApiList: serverApiList,
         entityApiList: entityApiList,
+        multiplayerApiList: multiplayerApiList,
         childTypes: playStreamEventModels.ChildTypes,
         parentTypes: playStreamEventModels.ParentTypes,
         sdkVersion: sdkGlobals.sdkVersion,

--- a/targets/SdkTestingCloudScript/source/Scripts/typings/PlayFab/CloudScript.d.ts.ejs
+++ b/targets/SdkTestingCloudScript/source/Scripts/typings/PlayFab/CloudScript.d.ts.ejs
@@ -77,6 +77,8 @@ interface IApiError {
 declare var server: IPlayFabServerAPI;
 /** Static object which allows access to PlayFab Entity API calls */
 declare var entity: IPlayFabEntityAPI;
+/** Static object which allows access to PlayFab Multiplayer API calls (includes Matchmaking, MultiplayerServer, Party, and Lobby) */
+declare var multiplayer: IPlayFabMultiplayerAPI;
 <% for(var sa in serverApiList) { var api = serverApiList[sa]; %>
 /** <%- api.name %>API.Models as interfaces */
 declare namespace PlayFab<%- api.name %>Models {
@@ -108,6 +110,24 @@ interface IPlayFabEntityAPI {
 <% for(var ea in entityApiList) { var api = entityApiList[ea];
 %>
 <% for(var i in api.calls) { var apiCall = api.calls[i];
+%><%- generateApiSummary("    ", apiCall, "summary", "https://docs.microsoft.com/rest/api/playfab/" + api.name.toLowerCase() + "/" + apiCall.subgroup.toLowerCase().replaceAll(" ","-") + "/" + apiCall.name.toLowerCase()) -%>
+    <%- apiCall.name %>(request: PlayFab<%- api.name %>Models.<%- apiCall.request %>): PlayFab<%- api.name %>Models.<%- apiCall.result %>;
+
+<% } } %>
+}
+
+<% for(var ma in multiplayerApiList) { var api = multiplayerApiList[ma]; %>
+/** <%- api.name %>API.Models as interfaces */
+declare namespace PlayFab<%- api.name %>Models {
+<% for(var i in api.datatypes) { var datatype = api.datatypes[i];
+%><%- generateApiSummary("    ", datatype, "description")
+%><%- makeDatatype("    ", datatype, sourceDir, "") %><% }
+%>}<% } %>
+
+/** Multiplayer interface methods (includes Matchmaking, MultiplayerServer, Party, and Lobby) */
+interface IPlayFabMultiplayerAPI {
+<% for(var ma in multiplayerApiList) { var api = multiplayerApiList[ma];
+for(var i in api.calls) { var apiCall = api.calls[i];
 %><%- generateApiSummary("    ", apiCall, "summary", "https://docs.microsoft.com/rest/api/playfab/" + api.name.toLowerCase() + "/" + apiCall.subgroup.toLowerCase().replaceAll(" ","-") + "/" + apiCall.name.toLowerCase()) -%>
     <%- apiCall.name %>(request: PlayFab<%- api.name %>Models.<%- apiCall.request %>): PlayFab<%- api.name %>Models.<%- apiCall.result %>;
 


### PR DESCRIPTION
This PR adds TypeScript type declarations for the multiplayer global object in CloudScript, enabling IntelliSense and type checking for Matchmaking, MultiplayerServer, Party, and Lobby APIs.

---
**Why do we need this PR?:**

The CloudScript runtime (ServerApi.cs + scriptEngineInitialization.js in pf-main) already exposes a multiplayer global with methods like CreateMatchmakingTicket, GetMatch, GetMatchmakingTicket, etc. However, the generated CloudScript.d.ts only declares server and entity, so TypeScript users of these APIs get no autocomplete or type safety for multiplayer/matchmaking calls.