### PR TITLE
Phase 7B: Migrate SDKGenerator to shared instructions

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,29 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+indent_style = space
+indent_size = 2
+
+[*.{js,ts,mjs,cjs,jsx,tsx,json,ejs,yml,yaml}]
+indent_size = 2
+
+[*.{md,markdown}]
+trim_trailing_whitespace = false
+
+[*.{ps1,psm1,psd1,bat,cmd}]
+end_of_line = crlf
+indent_size = 2
+
+[*.{sh,bash}]
+end_of_line = lf
+indent_size = 2
+
+# Generator output: leave to target's own conventions.
+# Don't enforce indent on generated files — but here we don't store generated output anyway.
+
+[*.{c,cc,cpp,cxx,h,hh,hpp,hxx,cs,java}]
+indent_size = 4

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,41 @@
+## Description
+
+<!-- What does this PR change? -->
+
+## Scope
+
+- [ ] New target (`targets/<name>/`)
+- [ ] Existing target update (specify which)
+- [ ] Shared tooling (`SDKBuildScripts/`, `SetupScripts/`, `JenkinsConsoleUtility/`)
+- [ ] Generator core (`generate.js`)
+- [ ] Documentation
+
+## Targets touched
+
+<!-- Which target(s)? e.g. csharp, unity-v2, java, PlayStation -->
+
+## Verification
+
+- [ ] Regenerated affected SDK(s) cleanly with `node generate.js <target>=<output>`
+- [ ] Snapshot diff against previous output is intentional / reviewed
+- [ ] Affected sibling SDK repo(s) (`sdks/*`) still build
+- [ ] No unintended changes to unrelated targets
+- [ ] No NDA / PlayStation source pasted in PR description (see `partycore-nda-boundary.md`)
+
+## Documentation
+
+- [ ] README updated (if user-facing)
+- [ ] Target-level README/notes updated (if applicable)
+
+## Compatibility
+
+- [ ] Public API of generated SDKs is backward-compatible (or major bump justified)
+- [ ] `package.json` deps unchanged (or new dep justified)
+- [ ] Sibling-folder convention preserved
+
+## References
+
+- [`AGENTS.md`](../AGENTS.md)
+- [`.github/copilot-instructions.md`](../.github/copilot-instructions.md)
+- [`.github/instructions/targets.instructions.md`](../.github/instructions/targets.instructions.md)
+- [`.github/instructions/templates.instructions.md`](../.github/instructions/templates.instructions.md)

--- a/.github/agents/build-config.md
+++ b/.github/agents/build-config.md
@@ -1,0 +1,79 @@
+---
+name: build-config
+description: Specialist for SDKGenerator — Node.js + EJS code generator that emits PlayFab client SDKs across 14+ targets. Owns `generate.js` invocation, target wiring (`targets/<name>/make.js`), EJS template patterns, sibling-folder layout, and `genConfig.json` semantics.
+tools: ['*']
+---
+
+# build-config — SDKGenerator
+
+You are the build/generation specialist for **SDKGenerator** — a Node.js + EJS code generator that emits PlayFab client SDKs from JSON API specs across 14+ language targets.
+
+## Mental model
+
+```
+<parent-folder>/
+├── SdkGenerator/                # this repo
+├── API_Specs/                   # input JSON specs (separate repo)
+└── sdks/                        # output destinations (each its own repo)
+    ├── PlayFabClientSdkCSharp/
+    ├── PlayFabSDK/
+    └── ...
+```
+
+The sibling-folder layout is **not optional** — many scripts and `genConfig.json` references assume it. Don't clone deep into a nested path.
+
+## Generation invocation
+
+```bash
+node generate.js <target>=<output-relative-path>
+# e.g. node generate.js csharp=../sdks/PlayFabClientSdkCSharp/
+# Multiple in one go: node generate.js csharp=../sdks/X/ unity-v2=../sdks/Y/
+```
+
+`generate.js` reads `genConfig.json` from each destination repo (in `sdks/<output>/`). The destination's `genConfig.json` selects the target template folder and version source — see `IGenConfig` interface in `generate.ts` for the schema (`templateFolder`, `versionKey`/`versionString`, `buildFlags`).
+
+## Editing rules — `targets/<name>/make.js`
+
+- **Entrypoint contract:** export functions that match what `generate.js` invokes (typically `makeClientApi(apis, sourceDir, apiOutputDir)` or sibling variants — match what existing same-language targets do).
+- **Re-entrant.** Same Node process may call `make.js` multiple times — no module-level mutable state.
+- **Logic in JS, presentation in EJS.** Compute view-model in `make.js`, render only in templates.
+- **Indent:** 2 spaces (Node convention).
+- **Output writes** only to the configured `apiOutputDir`. Never write anywhere else from `make.js`.
+- **No cross-target reaches** — `require('../<other-target>/make')` is forbidden.
+- **No absolute paths** — use `path.resolve(...)` from inputs.
+
+## Editing rules — `targets/<name>/templates/`
+
+- **EJS only** (`ejs ^3.1.10` is the sole runtime dep).
+- Keep `<% %>` blocks shallow — pre-compute on the JS side.
+- Emit code that already follows the **target language's conventions** (indent, brace style). The generator is the only place these conventions live.
+- Be deliberate about newlines / trailing whitespace — output goes straight to public SDK repos.
+
+## Adding a new target
+
+1. Copy `targets/newTarget/` → `targets/<your-target-name>/`.
+2. Implement `make.js` (match the existing entrypoint shape).
+3. Author EJS templates under `templates/`.
+4. Wire build scripts under `SDKBuildScripts/<your-target-name>/` if compilation is needed.
+5. Test via `node ../../generate.js <your-target-name>=<test-output>` and snapshot-diff vs prior runs.
+6. Document in README.
+
+## Sensitive scope
+
+- **PlayStation target = NDA-scoped.** See `partycore-nda-boundary.md` (referenced from the L1 footer) for the team-wide partial-NDA carve-out policy; never paste PS templates into external prompts or LLM context.
+- API_Specs are versioned in a separate repo — don't fork them inline.
+
+## Out of scope
+
+- API spec authoring → `API_Specs` repo.
+- Output SDK repos → `sdks/<target>/` (each is its own repo).
+- The aggregator monorepo → `PlayFab.SDKs.All`.
+- The publish flow → `PlayFab.Publish` / `PlayFab.Publish.Step2`.
+
+## Key references
+
+- L1 `### Stack`, `### Sibling-folder convention`, `### Adding a new target` — `.github/copilot-instructions.md`.
+- L2 `targets.instructions.md` (applyTo `targets/**`).
+- L2 `templates.instructions.md` (applyTo `**/templates/**`).
+- `generate.ts` — interface contracts (`IBuildTarget`, `IGenConfig`, `ISdkDoc`).
+- `AGENTS.md`, `CONTRIBUTING.md`.

--- a/.github/agents/code-reviewer.md
+++ b/.github/agents/code-reviewer.md
@@ -1,0 +1,64 @@
+---
+name: code-reviewer
+description: Reviews SDKGenerator changes with focus on target isolation, re-entrancy, EJS-vs-JS responsibility split, output-path discipline, and NDA-leak prevention (PlayStation).
+tools: ['*']
+---
+
+# code-reviewer — SDKGenerator
+
+This generator emits public SDK source code. A bad `make.js` change ships broken/insecure code to every PlayFab customer using that SDK. Review accordingly.
+
+## What to flag
+
+### Target isolation
+- `require('../<other-target>/...')` from within a target — cross-target reaches break the "one folder = one target" rule.
+- Shared mutable state across targets (e.g., `targets/utils.js` import that holds module-level mutable data).
+- A target reading from another target's `templates/`.
+
+### Re-entrancy / state
+- Module-level `let`/`var` in `make.js` that accumulates across calls — same process re-invokes will corrupt subsequent generations.
+- Caching of `apiOutputDir` or other inputs at module load time instead of per-invocation.
+
+### Output discipline
+- `make.js` writing outside the configured `apiOutputDir` (e.g., back into `targets/`, into siblings, into temp paths not derived from `apiOutputDir`).
+- Generated SDK content committed back into `targets/` — output goes to sibling `sdks/<output>/` repos, not into this repo.
+- Hardcoded absolute paths instead of `path.resolve(...)` from inputs.
+
+### EJS / templates
+- Heavy logic in templates (`<% if (...) { for (...) { switch (...) { ... } } } %>`) — push it to `make.js` as a pre-computed view-model.
+- Bulk output emitted via JS string concatenation in `make.js` while EJS sits unused — defeats the templating model.
+- Generated output that ignores target-language formatting conventions (the generator is the only place these conventions live for that target).
+
+### NDA / sensitive
+See `partycore-nda-boundary.md` (referenced from the L1 footer) for the team-wide partial-NDA carve-out policy. In this repo, flag:
+- PlayStation source/template content pasted into PR descriptions, issue comments, or external systems.
+- PlayStation templates moved out of their NDA-scoped target area into a public location.
+- Console-target build secrets inlined.
+
+### Generation surface
+- Changes to `generate.js` / `generate.ts` interface (`IBuildTarget`, `IGenConfig`, `ISdkDoc`) without ripple updates to all targets that depend on the modified shape.
+- New required field added to `IGenConfig` without backward-compat handling — every destination repo's `genConfig.json` would need updating.
+- `npm install` introducing a new runtime dep beyond `ejs` — this repo intentionally has only one.
+
+### Build / Jenkins
+- Build script changes under `SDKBuildScripts/<target>/` that diverge between Linux and Windows variants without justification.
+
+## What NOT to flag
+
+- Style (`.editorconfig` enforces 2-space).
+- README-only edits.
+- Test-app / fixture-only changes.
+
+## Validation expectation
+
+For non-trivial changes, expect the PR description to reference:
+- A `node generate.js <target>=<output>` regeneration of at least one affected target.
+- A snapshot diff vs the prior generated SDK output.
+- For console targets: `JenkinsConsoleUtility/` end-to-end run.
+
+## Key references
+
+- L1 `### Conventions`, `### Test / validation`, `### Out of scope` — `.github/copilot-instructions.md`.
+- L2 `targets.instructions.md`, `templates.instructions.md`.
+- `generate.ts` — interface contracts.
+- `AGENTS.md`, `CONTRIBUTING.md`, `.github/PULL_REQUEST_TEMPLATE.md`.

--- a/.github/agents/test-runner.md
+++ b/.github/agents/test-runner.md
@@ -1,0 +1,79 @@
+---
+name: test-runner
+description: Routes "how do I test this?" for SDKGenerator. Local validation = regenerate a known-good target and snapshot-diff vs prior output. Console targets validated via `JenkinsConsoleUtility/`.
+tools: ['*']
+---
+
+# test-runner — SDKGenerator
+
+There is **no `npm test` unit-test layer here.** The generator's correctness is judged by the SDK source it emits. Validation is a regenerate-and-diff loop, plus per-target test apps for runtime checks.
+
+## Prerequisites (one-time)
+
+- The sibling-folder layout exists: `<parent>/SdkGenerator/`, `<parent>/API_Specs/`, `<parent>/sdks/<target-output>/...`.
+- `npm install` has run inside SDKGenerator (only `ejs` is pulled).
+- For each target you're going to regenerate, the destination repo (`sdks/<target>/`) is cloned and clean.
+
+## How to "run tests"
+
+### 1. Local snapshot-diff loop (the canonical loop)
+
+```bash
+# from SDKGenerator/
+node generate.js <target>=<output-relative-path>
+
+# Example: regenerate C# client SDK
+node generate.js csharp=../sdks/PlayFabClientSdkCSharp/
+```
+
+Then in the **destination** repo:
+
+```bash
+cd ../sdks/<output>
+git status         # shows everything generate.js wrote
+git diff           # the actual snapshot — read it carefully
+```
+
+The diff IS the test. Look for:
+- Unintended changes to files you didn't touch (cross-target leakage).
+- Whitespace/newline drift (templates often regress here).
+- Loss of language-specific formatting (indent, brace style, trailing commas).
+- Public API surface changes that don't match the API_Specs intent.
+
+### 2. Multi-target regeneration
+
+Regenerate **every target your change might affect**, not just the obvious one:
+
+```bash
+node generate.js csharp=../sdks/PlayFabClientSdkCSharp/ unity-v2=../sdks/PlayFabSDK/ java=../sdks/JavaSDK/
+```
+
+Generic edits to `generate.js` / `generate.ts` should regenerate a representative sample across language families.
+
+### 3. Per-target runtime tests
+
+Where they exist, run the test app under `sdks/<target>/PlayFab*TestApp/` against generated output. Confirms the emitted code actually compiles and the API surface works.
+
+### 4. Console targets
+
+`JenkinsConsoleUtility/` orchestrates end-to-end build + test for console SDKs (Switch / Sony / NDA platforms). For console-target changes, this is the gate — local snapshot-diff is necessary but not sufficient.
+
+## Before reporting "tests pass"
+
+- Snapshot diff inspected (not just "the script exited 0").
+- For interface or `generate.js` changes: regenerated **multiple** representative targets.
+- For new target: clean regeneration into a fresh destination repo + snapshot-diff vs `targets/newTarget/` baseline.
+- For console-target changes: `JenkinsConsoleUtility/` run is green.
+
+## Don't
+
+- Don't fabricate `npm test` — there's no unit-test runner here.
+- Don't approve a change that only regenerated one target if `generate.js` / shared interfaces moved.
+- Don't paste PlayStation snapshot diffs into external systems; see `partycore-nda-boundary.md` for the team-wide partial-NDA carve-out policy.
+- Don't commit generated SDK output back into `targets/` (it goes to the sibling `sdks/` repos).
+
+## Key references
+
+- L1 `### Generating an SDK`, `### Test / validation` — `.github/copilot-instructions.md`.
+- L2 `targets.instructions.md`, `templates.instructions.md`.
+- `generate.ts` — `IBuildTarget` / `IGenConfig` shape if you're tracing what gets passed to `make.js`.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,136 @@
+# Copilot Instructions — SDKGenerator
+
+> **Code generator** that emits PlayFab client SDKs for many platforms (C++, C#, Java, JS, Python, PHP, Unity, ObjC, ActionScript, Postman, etc.) from JSON API specs. Node.js + EJS templates.
+
+## Stack
+
+- **Node.js** (≥ 18 recommended)
+- **TypeScript** (lightweight — entrypoints are `.js`)
+- **EJS** templating (`ejs ^3.1.10`) — only runtime dep
+- **No bundler** — direct execution
+
+## Sibling-folder convention (critical)
+
+This generator **expects to live as a sibling** of the API specs and the SDK output dirs:
+
+```
+<your-parent-folder>/
+├── SdkGenerator/                # <— this repo (clone here)
+├── API_Specs/                   # JSON API specs (separate repo)
+├── sdks/                        # Output SDKs (separate repos, one per language typically)
+│   ├── PlayFabClientSdkCSharp/
+│   ├── PlayFabSDK/
+│   └── ...
+└── (other tooling, optional)
+```
+
+Many scripts assume this sibling layout. Don't clone this repo standalone into a deeply-nested path.
+
+## Repo layout
+
+```
+SDKGenerator/
+├── package.json                  # ejs dep only
+├── generate.js                   # Main entrypoint
+├── tsconfig.json
+├── targets/                      # One folder per generator target
+│   ├── PlayStation/              # NDA — gated
+│   ├── actionscript/
+│   ├── cpp-cocos2dx/
+│   ├── csharp/
+│   ├── java/
+│   ├── javascript/
+│   ├── js-node/
+│   ├── LuaSdk/
+│   ├── newTarget/                # Template for adding a new target
+│   ├── objc/
+│   ├── PhpSdk/
+│   ├── postman/
+│   ├── PythonSdk/
+│   ├── SdkTestingCloudScript/
+│   └── unity-v2/
+├── SDKBuildScripts/              # Per-language build helpers
+├── SetupScripts/                 # Environment setup
+├── JenkinsConsoleUtility/        # Console SDK build/test orchestration
+└── (other tooling, e.g. snapshot tests)
+```
+
+## Day-1 setup
+
+```bash
+# Clone alongside API_Specs and sdks/ (not standalone!)
+cd <your-parent-folder>
+git clone <SDKGenerator-url> SdkGenerator
+git clone <API_Specs-url> API_Specs
+# clone target SDK output repos as needed under sdks/
+
+cd SdkGenerator
+npm install   # only `ejs` is pulled
+```
+
+## Generating an SDK
+
+```bash
+node generate.js <target>=<output-relative-path>
+
+# Example: regenerate the C# client SDK
+node generate.js csharp=../sdks/PlayFabClientSdkCSharp/
+
+# Multiple targets in one invocation
+node generate.js csharp=../sdks/PlayFabClientSdkCSharp/ unity-v2=../sdks/PlayFabSDK/
+```
+
+## Adding a new target
+
+Use `targets/newTarget/` as the template:
+
+1. Copy `targets/newTarget/` → `targets/<your-target-name>/`.
+2. Implement `make.js` (entrypoint per target).
+3. Add EJS templates under `templates/`.
+4. Wire build scripts under `SDKBuildScripts/<your-target-name>/` if compilation is needed.
+5. Test against API_Specs.
+6. Document in README.
+
+## Conventions
+
+- **Indent**: 2 spaces (Node convention).
+- **Target isolation**: each `targets/<name>/` is independent — don't share state across targets.
+- **EJS templates**: keep logic out; do data prep in `make.js`.
+- **No global state** in `make.js` — re-entry from tests should be safe.
+- **`targets/PlayStation/`** is NDA-scoped content inside this otherwise non-NDA repo. See `partycore-nda-boundary.md` (linked in the footer) for the team-wide NDA-boundary policy that governs it; do not paste PS templates into external AI prompts.
+- **API_Specs** are versioned in a separate repo; don't fork them inline.
+
+## Test / validation
+
+- `JenkinsConsoleUtility/` runs end-to-end builds-and-tests for console targets.
+- Per-target test apps usually live under `sdks/<target-name>/PlayFab*TestApp/`.
+- Snapshot diffs against the previous SDK output are the standard sanity check.
+
+## Out of scope
+
+- API specs themselves → `API_Specs` (separate repo).
+- The output SDKs → `sdks/*` (each is its own repo).
+- The aggregator-monorepo → `PlayFab.SDKs.All` (different beast).
+
+See also: [`AGENTS.md`](../AGENTS.md), [`CONTRIBUTING.md`](../CONTRIBUTING.md), `README.md`.
+
+Cross-cutting conventions (PlayFab C/C++ source patterns reflected in the C/C++ generator targets, and the NDA-boundary policy that scopes the `targets/PlayStation/` target) are documented in the shared instructions repos linked in the footer below.
+
+---
+
+## Shared Instructions
+
+This repo loads cross-cutting team instructions from one or both of:
+
+- [copilot-instructions-partycore](https://dev.azure.com/PlayFabInternal/Main/_git/copilot-instructions-partycore) — non-NDA team conventions.
+- [copilot-instructions-partycore-nda](https://dev.azure.com/PlayFabInternal/Main/_git/copilot-instructions-partycore-nda) — NDA-only additions (NDA-tented engineers).
+
+Topics most relevant to this repo:
+
+- `partycore-cpp-source-conventions.md` — SDKGenerator emits PlayFab C/C++ client SDK code (e.g. `cpp-cocos2dx`, console targets). The generator templates encode the PF prefix, XAsync pattern, handle lifecycle, and generated-code discipline defined in this shared topic; template authors and generator changes must stay aligned with it so emitted SDKs remain consistent with hand-authored PlayFab C/C++ code.
+- `partycore-nda-boundary.md` — `targets/PlayStation/` is NDA-scoped content inside an otherwise non-NDA public GitHub repo. This shared topic defines what may live in this repo, what must be excluded from external AI prompts, and where NDA-tented sibling repos sit.
+
+To check what's currently loaded:
+`echo $env:COPILOT_CUSTOM_INSTRUCTIONS_DIRS` (PowerShell) or
+`echo $COPILOT_CUSTOM_INSTRUCTIONS_DIRS` (bash/zsh). For setup
+instructions, see the shared repos' READMEs.

--- a/.github/instructions/targets.instructions.md
+++ b/.github/instructions/targets.instructions.md
@@ -40,3 +40,4 @@ targets/<name>/
 - Don't write anywhere except the configured `apiOutputDir`.
 - Don't hardcode absolute paths — use `path.resolve(...)` from inputs.
 - Don't commit generated SDK output back into `targets/` — it goes to the sibling `sdks/<output>/` repos.
+- Don't commit real credentials or Title IDs in `testTitleData.json` and `unityTestTitleData.json` — use placeholder values only. The file template should be safe to push to the public repo.

--- a/.github/instructions/targets.instructions.md
+++ b/.github/instructions/targets.instructions.md
@@ -1,0 +1,42 @@
+---
+applyTo: "targets/**"
+---
+
+# `targets/` — SDKGenerator
+
+Each subfolder is one **generator target** (one output language/platform).
+
+## Layout per target
+
+```
+targets/<name>/
+├── make.js                # Entrypoint: invoked by ../../generate.js
+├── templates/             # EJS templates (consumed by make.js)
+└── (optional) testTitleData.json, etc.
+```
+
+## Rules
+
+- **One target = one folder.** Don't share mutable state across targets.
+- **`make.js`** must export a function `makeClientApi(apis, sourceDir, apiOutputDir)` (or sibling variants — see existing targets).
+- Logic in `make.js`, presentation in `templates/<x>.ejs`.
+- **Indent**: 2 spaces.
+- Re-entrant: a target's `make.js` may be invoked multiple times in one process — no module-level mutation that would corrupt subsequent calls.
+- **`targets/PlayStation/`**: NDA-scoped content; see `partycore-nda-boundary.md` (referenced from the L1 footer) for the team-wide NDA-boundary policy. Do not paste source into external AI prompts.
+
+## Adding a new target
+
+1. Copy `targets/newTarget/` → `targets/<your-name>/`.
+2. Implement `make.js`.
+3. Author EJS templates under `templates/`.
+4. Add a test invocation: `node ../../generate.js <your-name>=<test-output>`.
+5. Snapshot-diff vs prior runs to catch regressions.
+6. If the SDK needs compiling/testing, wire under `SDKBuildScripts/<your-name>/`.
+7. Update README + add to CI if applicable.
+
+## Don't
+
+- Don't reach across targets (`require('../<other-target>/make')`).
+- Don't write anywhere except the configured `apiOutputDir`.
+- Don't hardcode absolute paths — use `path.resolve(...)` from inputs.
+- Don't commit generated SDK output back into `targets/` — it goes to the sibling `sdks/<output>/` repos.

--- a/.github/instructions/templates.instructions.md
+++ b/.github/instructions/templates.instructions.md
@@ -1,0 +1,28 @@
+---
+applyTo: "**/templates/**"
+---
+
+# EJS templates — SDKGenerator
+
+Each target has its own `templates/` directory consumed by that target's `make.js`.
+
+## Rules
+
+- **EJS only.** No other templating engine.
+- **Logic stays in `make.js`.** Templates should focus on rendering. Avoid heavy `<% if %>` chains.
+- **Output formatting**: emit code that already follows the target language's conventions (indent, brace style). The generator is the only place these conventions live for that target.
+- **No cross-target template imports.** Each target owns its own template tree.
+- **Newlines / trailing whitespace**: be deliberate — generated files often go straight to a public SDK repo.
+- **Localization / translations**: kept under the target's templates if the SDK has them.
+
+## Authoring tips
+
+- Pre-compute everything you need on the JS side in `make.js` (e.g. sorted lists, sanitized names, language-keyword escaping). Pass a clean view-model into the EJS template.
+- Test by regenerating a known-good output SDK and snapshot-diffing.
+- Keep templates small and focused — one concern per template (e.g. one for the model class, one for the API surface).
+
+## Don't
+
+- Don't put complex logic in templates (`<% if (...) { for (...) { switch (...) { ... } } } %>`).
+- Don't reach into other targets' templates.
+- Don't bypass EJS by string-concatenating in `make.js` for the bulk of output (defeats the point).

--- a/.vscode/mcp.json
+++ b/.vscode/mcp.json
@@ -1,0 +1,11 @@
+{
+  "servers": {
+    "github": {
+      "type": "http",
+      "url": "https://api.githubcopilot.com/mcp/",
+      "headers": {
+        "X-MCP-Toolsets": "context,issues,pull_requests,repos"
+      }
+    }
+  }
+}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,32 @@
+# AGENTS.md — SDKGenerator
+
+> Primary agent context: [`.github/copilot-instructions.md`](.github/copilot-instructions.md).
+
+## TL;DR
+
+Node.js + EJS code generator that emits PlayFab client SDKs for many platforms. Lives as a **sibling** of `API_Specs/` and `sdks/`. Run via `node generate.js <target>=<output>`.
+
+## Quick rules
+
+- **Sibling-folder layout** is required — see copilot-instructions.md.
+- One target = one folder under `targets/<name>/`. Don't share code across targets.
+- EJS templates: logic out, data prep in `make.js`.
+- Indent = 2 spaces (Node).
+- `targets/PlayStation/` is NDA-scoped; see `partycore-nda-boundary.md` via the L1 footer and do not paste PS content into external AI prompts.
+- API specs live in `API_Specs` (separate repo) — don't fork inline.
+
+## Where to look
+
+| You need... | Read |
+|---|---|
+| What this is, layout, run flow, conventions | [`.github/copilot-instructions.md`](.github/copilot-instructions.md) |
+| Adding a new target | [`.github/instructions/targets.instructions.md`](.github/instructions/targets.instructions.md) |
+| Template authoring | [`.github/instructions/templates.instructions.md`](.github/instructions/templates.instructions.md) |
+| Branching, PR | [`CONTRIBUTING.md`](CONTRIBUTING.md) |
+
+## Useful refs
+
+- API specs: `API_Specs` (sibling repo)
+- Output SDK repos: `sdks/*` (sibling repos)
+- Console build tooling: `JenkinsConsoleUtility/`
+- [EJS docs](https://ejs.co/)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,64 @@
+# Contributing to SDKGenerator
+
+Code generator that emits PlayFab client SDKs from JSON API specs.
+
+> 🤖 **AI agents:** read [`.github/copilot-instructions.md`](.github/copilot-instructions.md), [`AGENTS.md`](AGENTS.md), and the README first.
+
+## Setup
+
+```bash
+# Sibling-folder layout (required):
+mkdir playfab-sdks && cd playfab-sdks
+git clone <SDKGenerator-url> SdkGenerator
+git clone <API_Specs-url> API_Specs
+# (clone target SDK repos under sdks/ as needed)
+
+cd SdkGenerator
+npm install
+```
+
+## Branching
+
+| Prefix | Use For |
+|---|---|
+| `feature/` | New target, new generator feature |
+| `fix/` | Bug fix |
+| `chore/` | Dependency / template updates |
+| `docs/` | Documentation only |
+
+## Generating SDKs (smoke test)
+
+```bash
+node generate.js csharp=../sdks/PlayFabClientSdkCSharp/
+node generate.js unity-v2=../sdks/PlayFabSDK/
+```
+
+Diff the output against the prior commit to spot regressions.
+
+## Adding a new target
+
+See [`.github/instructions/targets.instructions.md`](.github/instructions/targets.instructions.md).
+
+## Coding style
+
+- Node.js + JS + EJS templates.
+- 2-space indent everywhere (`.editorconfig` enforces).
+- Logic in `make.js`, rendering in `templates/`.
+- One target = one folder under `targets/`.
+- No cross-target imports.
+
+## NDA reminder
+
+`targets/PlayStation/` is NDA-scoped content inside this otherwise non-NDA repo. See `partycore-nda-boundary.md` from the L1 footer for the team-wide policy; do not paste its source into external AI prompts.
+
+## PR Process
+
+1. Branch.
+2. Implement; regenerate affected SDK(s); diff and verify.
+3. Update README / target docs as appropriate.
+4. Open PR ([template](.github/PULL_REQUEST_TEMPLATE.md)).
+5. CI passes; review; merge.
+
+## Code of Conduct
+
+[Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/).


### PR DESCRIPTION
## Description

Phase 7B migration of `SDKGenerator` to consume shared custom instructions from `copilot-instructions-partycore` (and reference `-nda` for NDA-tented contributors). This is the **first Batch 2** PR, the only `code-generator` archetype in the fleet, and the only Phase 7B repo hosted on GitHub (rest are ADO).

This PR commits the previously-untracked Copilot agentic-readiness bootstrap files in their post-migration shape (already consuming the shared instructions repos), rather than landing raw bootstrap first and migrating in a follow-up.

## What changed

**L1 (`.github/copilot-instructions.md`):**
- Trimmed the `Conventions` bullet `PlayStation target is NDA-gated` to a one-line cross-reference to the shared `partycore-nda-boundary.md` topic (kept the practical "don't paste into external AI prompts" reminder).
- Added a `Cross-cutting team conventions` closing paragraph and the `Shared Instructions` footer referencing:
  - `partycore-cpp-source-conventions.md` — the C/C++ generator targets (`cpp-cocos2dx`, console targets) emit code that must follow team-wide PF prefix / XAsync / handle / generated-code conventions.
  - `partycore-nda-boundary.md` — `targets/PlayStation/` is NDA-scoped content inside an otherwise non-NDA public GitHub repo; the shared policy governs what may live here and what must stay out of external prompts.

**L2 (`.github/instructions/`):**
- `targets.instructions.md` — light trim: the `PlayStation: NDA` bullet became a cross-reference to `partycore-nda-boundary.md`. All target-specific rules (target isolation, `make.js` contract, re-entrancy, output-path discipline) kept.
- `templates.instructions.md` — kept as-is. Content is EJS/template-specific and not duplicated by any shared topic.

**Bootstrap sidecars committed:**
- `AGENTS.md`, `CONTRIBUTING.md`, `.editorconfig`
- `.github/PULL_REQUEST_TEMPLATE.md`
- `.github/agents/{build-config,code-reviewer,test-runner}.md`
- `.vscode/mcp.json`

**Trim-and-delegate amend after shared baseline merge:**
- Delegated repeated partial-NDA / PlayStation reminder wording in sidecars and per-repo agents to the now-merged `partycore-nda-boundary.md` shared topic.
- Kept SDKGenerator-specific target isolation, EJS template, output-path, and regenerate/snapshot validation guidance local. The broader codegen-conventions promotion remains deferred to a future shared PR.

## Reference: pilot PRs

This migration follows the patterns established by the two pilot PRs:

- ADO PR #15678197 in `PlayFab.SDKs.All` (non-NDA super-repo archetype) — merged.
- ADO PR #3005 in `LibHttpClient.PS` (NDA library-overlay archetype) — merged.

For this PR the file content already reflects the post-migration target shape.

## Verification

- [x] All footer topic links resolve to existing files in the shared `copilot-instructions-partycore` repo.
- [x] L1 / L2 cross-references resolve.
- [x] No transitional wording (no "coming soon", "TODO", or "will be added") in any committed file.
- [x] `git diff --check master...HEAD` is clean.
- [x] Generator behavior unchanged (no code under `targets/`, `templates/`, `SDKBuildScripts/`, or `generate.js` touched).

## Linked work

Tracks ADO task #62331661 (Phase 7 — consumer migration). Cross-org link from a GitHub PR to an ADO work item is not directly supported, so this is recorded as a plain-text reference here.