### PR TITLE
Fix CS0619: remove obsolete GetEntityTokenRequest.Entity from UUnit tests

### DIFF
--- a/targets/csharp/source/PlayFabSDK/source/Uunit/tests/PlayFabServerApiTest.cs
+++ b/targets/csharp/source/PlayFabSDK/source/Uunit/tests/PlayFabServerApiTest.cs
@@ -250,9 +250,6 @@ namespace PlayFab.UUnit
         public async void TestForNotFoundWithImportantInfo(UUnitTestContext testContext)
         {
             var eReq = new AuthenticationModels.GetEntityTokenRequest();
-            eReq.Entity = new AuthenticationModels.EntityKey();
-            eReq.Entity.Type = "title";
-            eReq.Entity.Id = testTitleData.titleId;
 
             var multiApiSettings = new PlayFabApiSettings();
 


### PR DESCRIPTION
 ## Problem
 `generate.js` copies this template into `CSharpSDK` and `CSharpBetaSDK` on
 every regeneration, overwriting any fix made directly in those repos.
 The latest API spec marks `GetEntityTokenRequest.Entity` as
 `[Obsolete("No longer available", true)]`, so the assignments here cause
 3× **CS0619** build breaks in `PlayFab.Publish`'s `BuildCSharp` and
 `BuildCSharpBeta` jobs after regeneration (build 278862).
 
 PRs #130 (CSharpSDK) and the matching one in CSharpBetaSDK already merged
 the same edit into the destination repos, but the pipeline kept failing
 because this template overwrote them.
 
 ## Fix
 Remove the three `eReq.Entity*` assignments. `GetEntityTokenRequest` now
 derives the entity from the authenticated context (`TitleId` +
 `DeveloperSecretKey` already set on `PlayFabApiSettings`).