### PR TITLE
Phase 7B3: Promote codegen patterns to shared topic reference

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -94,11 +94,8 @@ Use `targets/newTarget/` as the template:
 ## Conventions
 
 - **Indent**: 2 spaces (Node convention).
-- **Target isolation**: each `targets/<name>/` is independent — don't share state across targets.
-- **EJS templates**: keep logic out; do data prep in `make.js`.
-- **No global state** in `make.js` — re-entry from tests should be safe.
-- **`targets/PlayStation/`** is NDA-scoped content inside this otherwise non-NDA repo. See `partycore-nda-boundary.md` (linked in the footer) for the team-wide NDA-boundary policy that governs it; do not paste PS templates into external AI prompts.
 - **API_Specs** are versioned in a separate repo; don't fork them inline.
+- Target isolation, re-entrant drivers, template responsibility split, output discipline, snapshot-diff validation, new-target scaffolds, and NDA carve-out rules are defined in the shared `partycore-codegen-conventions.md` (footer link). This repo is the canonical consumer of that topic.
 
 ## Test / validation
 
@@ -114,7 +111,7 @@ Use `targets/newTarget/` as the template:
 
 See also: [`AGENTS.md`](../AGENTS.md), [`CONTRIBUTING.md`](../CONTRIBUTING.md), `README.md`.
 
-Cross-cutting conventions (PlayFab C/C++ source patterns reflected in the C/C++ generator targets, and the NDA-boundary policy that scopes the `targets/PlayStation/` target) are documented in the shared instructions repos linked in the footer below.
+Cross-cutting conventions (code-generator authoring patterns, PlayFab C/C++ source conventions for the emitted SDKs, and NDA-boundary policy for the `targets/PlayStation/` carve-out) are documented in the shared instructions repos linked in the footer below.
 
 ---
 
@@ -127,6 +124,7 @@ This repo loads cross-cutting team instructions from one or both of:
 
 Topics most relevant to this repo:
 
+- `partycore-codegen-conventions.md` — target isolation, re-entrant drivers, template responsibility split, output discipline, snapshot-diff validation, new-target scaffolds, and NDA carve-out rules. This repo is the canonical consumer; the L2 instruction files (`targets.instructions.md`, `templates.instructions.md`) layer repo-specific details on top.
 - `partycore-cpp-source-conventions.md` — SDKGenerator emits PlayFab C/C++ client SDK code (e.g. `cpp-cocos2dx`, console targets). The generator templates encode the PF prefix, XAsync pattern, handle lifecycle, and generated-code discipline defined in this shared topic; template authors and generator changes must stay aligned with it so emitted SDKs remain consistent with hand-authored PlayFab C/C++ code.
 - `partycore-nda-boundary.md` — `targets/PlayStation/` is NDA-scoped content inside an otherwise non-NDA public GitHub repo. This shared topic defines what may live in this repo, what must be excluded from external AI prompts, and where NDA-tented sibling repos sit.
 

--- a/.github/instructions/targets.instructions.md
+++ b/.github/instructions/targets.instructions.md
@@ -17,12 +17,10 @@ targets/<name>/
 
 ## Rules
 
-- **One target = one folder.** Don't share mutable state across targets.
 - **`make.js`** must export a function `makeClientApi(apis, sourceDir, apiOutputDir)` (or sibling variants — see existing targets).
-- Logic in `make.js`, presentation in `templates/<x>.ejs`.
 - **Indent**: 2 spaces.
-- Re-entrant: a target's `make.js` may be invoked multiple times in one process — no module-level mutation that would corrupt subsequent calls.
 - **`targets/PlayStation/`**: NDA-scoped content; see `partycore-nda-boundary.md` (referenced from the L1 footer) for the team-wide NDA-boundary policy. Do not paste source into external AI prompts.
+- Target isolation, re-entrancy, template responsibility split, output discipline, and other cross-target rules are defined in the shared `partycore-codegen-conventions.md` (L1 footer link).
 
 ## Adding a new target
 
@@ -36,8 +34,5 @@ targets/<name>/
 
 ## Don't
 
-- Don't reach across targets (`require('../<other-target>/make')`).
-- Don't write anywhere except the configured `apiOutputDir`.
-- Don't hardcode absolute paths — use `path.resolve(...)` from inputs.
-- Don't commit generated SDK output back into `targets/` — it goes to the sibling `sdks/<output>/` repos.
 - Don't commit real credentials or Title IDs in `testTitleData.json` and `unityTestTitleData.json` — use placeholder values only. The file template should be safe to push to the public repo.
+- Additional "don't" rules (no cross-target imports, no writes outside `apiOutputDir`, no hardcoded absolute paths, no generated output committed back) are in the shared `partycore-codegen-conventions.md`.

--- a/.github/instructions/templates.instructions.md
+++ b/.github/instructions/templates.instructions.md
@@ -9,11 +9,10 @@ Each target has its own `templates/` directory consumed by that target's `make.j
 ## Rules
 
 - **EJS only.** No other templating engine.
-- **Logic stays in `make.js`.** Templates should focus on rendering. Avoid heavy `<% if %>` chains.
 - **Output formatting**: emit code that already follows the target language's conventions (indent, brace style). The generator is the only place these conventions live for that target.
-- **No cross-target template imports.** Each target owns its own template tree.
 - **Newlines / trailing whitespace**: be deliberate — generated files often go straight to a public SDK repo.
 - **Localization / translations**: kept under the target's templates if the SDK has them.
+- Logic-vs-template split, no cross-target template imports, and other shared rules are in `partycore-codegen-conventions.md` (L1 footer link).
 
 ## Authoring tips
 
@@ -24,5 +23,4 @@ Each target has its own `templates/` directory consumed by that target's `make.j
 ## Don't
 
 - Don't put complex logic in templates (`<% if (...) { for (...) { switch (...) { ... } } } %>`).
-- Don't reach into other targets' templates.
 - Don't bypass EJS by string-concatenating in `make.js` for the bulk of output (defeats the point).


### PR DESCRIPTION
## Description

Phase 7B3 follow-up for SDKGenerator: now that the shared topic `partycore-codegen-conventions.md` has been merged into `copilot-instructions-partycore`, this PR trims duplicated codegen patterns from SDKGenerator's local instructions and replaces them with references to the shared topic.

## What changed

**`.github/copilot-instructions.md`:**
- Trimmed conventions section: replaced duplicated target isolation, re-entrancy, EJS logic split, and output discipline rules with a one-line reference to `partycore-codegen-conventions.md`.
- Updated cross-cutting conventions description.
- Added `partycore-codegen-conventions.md` to the Shared Instructions footer.

**`.github/instructions/targets.instructions.md`:**
- Replaced duplicated Rules and Don't items with shared topic references.
- Kept repo-specific details: `make.js` entrypoint shape, `testTitleData.json` credential rule.

**`.github/instructions/templates.instructions.md`:**
- Replaced duplicated logic-split and cross-target rules with shared topic reference.
- Kept EJS-specific authoring tips.

## Verification

- [x] No content lost — all trimmed rules exist verbatim in `partycore-codegen-conventions.md`.
- [x] Repo-specific details preserved.
- [x] Footer references point to merged shared topics only.

## Linked work

Tracks ADO task **#62331661** (Phase 7 — consumer migration).